### PR TITLE
抽出フォームにおけるカスタムアクション管理機能の追加と改善

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
+++ b/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
@@ -51,18 +51,3 @@ jobs:
           production_branch: 'main'
           pull_request_id: ${{ github.event.pull_request.number }}
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_FIELD_00CC2DA00 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: 'close'
-          production_branch: 'main'
-          pull_request_id: ${{ github.event.pull_request.number }}

--- a/app/components/action-selector.tsx
+++ b/app/components/action-selector.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+// 親コンポーネントの CustomAction 型をインポートします。
+// 本来は共通の型定義ファイルに移動するのが望ましいです。
+import { type CustomAction } from '../config/default-actions';
+
+interface ActionSelectorProps {
+  actions: CustomAction[];
+  selectedAction: CustomAction | null;
+  onSelectedActionChange: (actionName: string | null) => void;
+  onActionCopy: () => void;
+  onOpenCustomActionModal: () => void;
+  onDeleteCustomAction: (actionName: string) => void;
+  isPromptCopied: boolean;
+}
+
+export default function ActionSelector({
+  actions,
+  selectedAction,
+  onSelectedActionChange,
+  onActionCopy,
+  onOpenCustomActionModal,
+  onDeleteCustomAction,
+  isPromptCopied,
+}: ActionSelectorProps) {
+  return (
+    <div className="mt-6 p-4 border border-gray-200 rounded-md bg-gray-50">
+      <h3 className="text-lg font-medium mb-3">テキストアクション</h3>
+      <p className="text-sm text-gray-600 mb-3">
+        選択したアクションを実行すると、整形されたテキストと指定したプロンプトが一緒にコピーされます。
+      </p>
+
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+        <div className="w-full sm:w-64">
+          <select
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={selectedAction?.name || ''}
+            onChange={(e) => onSelectedActionChange(e.target.value || null)}
+          >
+            <option value="">アクションを選択</option>
+            {actions.map((action) => (
+              <option key={action.name} value={action.name}>
+                {action.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          onClick={onActionCopy}
+          disabled={!selectedAction}
+          className={`px-4 py-2 rounded-md transition-colors ${
+            !selectedAction
+              ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+              : isPromptCopied
+              ? 'bg-green-600 text-white'
+              : 'bg-blue-600 hover:bg-blue-700 text-white'
+          }`}
+        >
+          {isPromptCopied ? 'コピーしました！' : 'コピー'}
+        </button>
+
+        <button
+          onClick={onOpenCustomActionModal}
+          className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-md ml-auto"
+        >
+          カスタムアクション
+        </button>
+      </div>
+
+      {selectedAction && (
+        <div className="mt-3 p-3 bg-gray-100 rounded-md">
+          <p className="text-sm font-medium">選択中: {selectedAction.name}</p>
+          <p className="text-sm text-gray-600 mt-1">{selectedAction.prompt}</p>
+          {!selectedAction.isBuiltIn && (
+            <button
+              onClick={() => onDeleteCustomAction(selectedAction.name)}
+              className="mt-2 text-xs text-red-600 hover:text-red-800"
+            >
+              このカスタムアクションを削除
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/article-display.tsx
+++ b/app/components/article-display.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { type ArticleOutput } from '../utils/extract-content';
+
+interface ArticleDisplayProps {
+  article: ArticleOutput;
+}
+
+export default function ArticleDisplay({ article }: ArticleDisplayProps) {
+  return (
+    <div className="mt-8 space-y-4">
+      {article.title && (
+        <h2 className="text-2xl font-semibold">{article.title}</h2>
+      )}
+
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
+        <h3 className="text-lg font-medium">抽出されたコンテンツ：</h3>
+      </div>
+
+      <div className="p-4 border border-gray-200 rounded-md bg-gray-50 whitespace-pre-wrap h-40 overflow-y-auto">
+        {article.textContent || 'テキストコンテンツがありません'}
+      </div>
+
+      {/* アクション選択セクションはこのコンポーネントの外にあります */}
+
+      {article.siteName && (
+        <div className="text-sm text-gray-600">
+          サイト名: {article.siteName}
+        </div>
+      )}
+
+      {article.byline && (
+        <div className="text-sm text-gray-600">著者: {article.byline}</div>
+      )}
+    </div>
+  );
+}

--- a/app/components/custom-action-modal.tsx
+++ b/app/components/custom-action-modal.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { type CustomAction } from '../config/default-actions';
+
+interface CustomActionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (name: string, prompt: string) => void;
+  onImport: (actions: CustomAction[]) => void;
+  onExportAll: () => CustomAction[];
+  initialName?: string;
+  initialPrompt?: string;
+}
+
+export default function CustomActionModal({
+  isOpen,
+  onClose,
+  onSave,
+  onImport,
+  onExportAll,
+  initialName = '',
+  initialPrompt = '',
+}: CustomActionModalProps) {
+  const [name, setName] = useState(initialName);
+  const [prompt, setPrompt] = useState(initialPrompt);
+
+  useEffect(() => {
+    setName(initialName);
+    setPrompt(initialPrompt);
+  }, [initialName, initialPrompt, isOpen]);
+
+  const handleSave = () => {
+    if (!name.trim() || !prompt.trim()) return;
+    onSave(name.trim(), prompt.trim());
+  };
+
+  const handleFileImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result;
+        if (typeof content !== 'string')
+          throw new Error('File content is not a string.');
+        let importedActions = JSON.parse(content) as any[];
+
+        if (
+          !Array.isArray(importedActions) ||
+          !importedActions.every(
+            (action) =>
+              typeof action.name === 'string' &&
+              typeof action.prompt === 'string'
+          )
+        ) {
+          throw new Error(
+            '無効なアクションフォーマットです。nameとpromptが必要です。'
+          );
+        }
+        const sanitizedActions: CustomAction[] = importedActions.map(
+          (action) => ({
+            name: action.name,
+            prompt: action.prompt,
+          })
+        );
+
+        onImport(sanitizedActions);
+        alert(
+          `${sanitizedActions.length}件のアクションのインポートを試みました。`
+        );
+        onClose();
+      } catch (error) {
+        console.error('アクションのインポートに失敗しました:', error);
+        alert(
+          `アクションのインポートに失敗しました: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = '';
+  };
+
+  const handleExportAllActions = () => {
+    const actionsToExport = onExportAll();
+    if (actionsToExport.length === 0) {
+      alert('エクスポートするアクションがありません。');
+      return;
+    }
+    downloadJson(actionsToExport, 'swasnap-all-actions.json');
+  };
+
+  const downloadJson = (data: CustomAction[], filename: string) => {
+    const jsonString = JSON.stringify(data, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded-lg w-full max-w-md">
+        <h3 className="text-lg font-semibold mb-4">
+          カスタムアクションの追加・編集
+        </h3>
+        <div className="space-y-4">
+          <div>
+            <label
+              htmlFor="action-name"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              アクション名
+            </label>
+            <input
+              id="action-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: 技術的な説明"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="action-prompt"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              プロンプト内容
+            </label>
+            <textarea
+              id="action-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="例: この内容について技術的な観点から詳しく説明してください。"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 h-32"
+            ></textarea>
+          </div>
+          <div className="flex justify-end space-x-3 pt-2">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-md"
+            >
+              キャンセル
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={!name.trim() || !prompt.trim()}
+              className={`px-4 py-2 rounded-md ${
+                !name.trim() || !prompt.trim()
+                  ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-700 text-white'
+              }`}
+            >
+              保存
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-6 pt-4 border-t">
+          <h4 className="text-md font-semibold mb-3">アクション管理</h4>
+          <div className="space-y-3">
+            <div>
+              <input
+                type="file"
+                accept=".json"
+                onChange={handleFileImport}
+                className="hidden"
+                id="import-actions-file"
+              />
+              <button
+                onClick={() =>
+                  document.getElementById('import-actions-file')?.click()
+                }
+                className="w-full px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-md text-sm"
+              >
+                アクションをインポート (JSON)
+              </button>
+            </div>
+            <button
+              onClick={handleExportAllActions}
+              className="w-full px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md text-sm"
+            >
+              すべてのアクションをエクスポート (JSON)
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/extract-form.tsx
+++ b/app/components/extract-form.tsx
@@ -1,15 +1,126 @@
 'use client';
 
-import { useState, FormEvent } from 'react';
+import { useState, FormEvent, useEffect } from 'react';
 import { type ArticleOutput } from '../utils/extract-content';
+
+// カスタムアクションの型定義
+interface CustomAction {
+  id: string;
+  name: string;
+  prompt: string;
+  isBuiltIn?: boolean;
+}
+
+// デフォルトのアクションリスト
+const DEFAULT_ACTIONS: CustomAction[] = [
+  {
+    id: 'summarize',
+    name: '要約',
+    prompt: 'この内容について、簡潔に要約してください。',
+    isBuiltIn: true,
+  },
+  {
+    id: 'bullet-points',
+    name: '箇条書きでまとめ',
+    prompt: 'この内容について箇条書きでまとめてください。',
+    isBuiltIn: true,
+  },
+  {
+    id: 'translate-en',
+    name: '英語に翻訳',
+    prompt: 'この内容を英語に翻訳してください。',
+    isBuiltIn: true,
+  },
+  {
+    id: 'explain-simple',
+    name: '簡単に説明',
+    prompt: 'この内容を小学生でも理解できるように簡単に説明してください。',
+    isBuiltIn: true,
+  },
+];
+
+// ローカルストレージのキー
+const STORAGE_KEY = 'swasnapcontent-custom-actions';
 
 export default function ExtractForm() {
   const [url, setUrl] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [article, setArticle] = useState<ArticleOutput | null>(null);
-  const [isCopied, setIsCopied] = useState(false);
-  const [isTrimCopied, setIsTrimCopied] = useState(false);
+  const [isPromptCopied, setIsPromptCopied] = useState(false);
+
+  // カスタムアクション関連の状態
+  const [actions, setActions] = useState<CustomAction[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newActionName, setNewActionName] = useState('');
+  const [newActionPrompt, setNewActionPrompt] = useState('');
+  const [selectedAction, setSelectedAction] = useState<CustomAction | null>(
+    null
+  );
+
+  // カスタムアクションをロード
+  useEffect(() => {
+    const loadCustomActions = () => {
+      try {
+        const storedActions = localStorage.getItem(STORAGE_KEY);
+        const customActions = storedActions ? JSON.parse(storedActions) : [];
+        setActions([...DEFAULT_ACTIONS, ...customActions]);
+      } catch (error) {
+        console.error('カスタムアクションの読み込みに失敗しました:', error);
+        setActions([...DEFAULT_ACTIONS]);
+      }
+    };
+
+    loadCustomActions();
+  }, []);
+
+  // カスタムアクションを保存
+  const saveCustomAction = () => {
+    if (!newActionName.trim() || !newActionPrompt.trim()) return;
+
+    try {
+      // デフォルトアクション以外を取得
+      const customActions = actions.filter((action) => !action.isBuiltIn);
+
+      // 新しいアクションを追加
+      const newAction: CustomAction = {
+        id: `custom-${Date.now()}`,
+        name: newActionName.trim(),
+        prompt: newActionPrompt.trim(),
+      };
+
+      const updatedActions = [...customActions, newAction];
+
+      // ローカルストレージに保存
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedActions));
+
+      // 状態を更新
+      setActions([...DEFAULT_ACTIONS, ...updatedActions]);
+      setNewActionName('');
+      setNewActionPrompt('');
+      setIsModalOpen(false);
+    } catch (error) {
+      console.error('カスタムアクションの保存に失敗しました:', error);
+    }
+  };
+
+  // カスタムアクションを削除
+  const deleteCustomAction = (id: string) => {
+    try {
+      // 削除対象以外のカスタムアクションを取得
+      const customActions = actions
+        .filter((action) => !action.isBuiltIn)
+        .filter((action) => action.id !== id);
+
+      // ローカルストレージに保存
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(customActions));
+
+      // 状態を更新
+      setActions([...DEFAULT_ACTIONS, ...customActions]);
+    } catch (error) {
+      console.error('カスタムアクションの削除に失敗しました:', error);
+    }
+  };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -75,30 +186,20 @@ export default function ExtractForm() {
     }
   };
 
-  const handleCopy = async () => {
-    if (!article?.textContent) return;
-
-    try {
-      await navigator.clipboard.writeText(article.textContent);
-      setIsCopied(true);
-      setIsTrimCopied(false);
-      setTimeout(() => setIsCopied(false), 2000);
-    } catch (error) {
-      console.error('クリップボードへのコピーに失敗しました:', error);
-    }
-  };
-
-  const handleTrimCopy = async () => {
-    if (!article?.textContent) return;
+  // 選択したアクションでコンテンツをコピー
+  const handleActionCopy = async () => {
+    if (!article?.textContent || !selectedAction) return;
 
     try {
       // 複数の空白、改行をすべて単一のスペースに置換
       const trimmedContent = article.textContent.replace(/\s+/g, ' ').trim();
 
-      await navigator.clipboard.writeText(trimmedContent);
-      setIsTrimCopied(true);
-      setIsCopied(false);
-      setTimeout(() => setIsTrimCopied(false), 2000);
+      // プロンプトを追加したコンテンツを作成
+      const contentWithPrompt = `${trimmedContent}\n\n${selectedAction.prompt}`;
+
+      await navigator.clipboard.writeText(contentWithPrompt);
+      setIsPromptCopied(true);
+      setTimeout(() => setIsPromptCopied(false), 2000);
     } catch (error) {
       console.error('クリップボードへのコピーに失敗しました:', error);
     }
@@ -142,35 +243,82 @@ export default function ExtractForm() {
             <h2 className="text-2xl font-semibold">{article.title}</h2>
           )}
 
-          <div className="flex justify-between items-center">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
             <h3 className="text-lg font-medium">抽出されたコンテンツ：</h3>
-            <div className="flex space-x-2">
-              <button
-                onClick={handleTrimCopy}
-                className={`px-4 py-1 text-sm rounded-md transition-colors ${
-                  isTrimCopied
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
-                }`}
-                title="複数の空白や改行を単一のスペースに置き換えてコピーします"
-              >
-                {isTrimCopied ? 'コピーしました！' : '整形してコピー'}
-              </button>
-              <button
-                onClick={handleCopy}
-                className={`px-4 py-1 text-sm rounded-md transition-colors ${
-                  isCopied
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
-                }`}
-              >
-                {isCopied ? 'コピーしました！' : 'コピー'}
-              </button>
-            </div>
           </div>
 
-          <div className="p-4 border border-gray-200 rounded-md bg-gray-50 whitespace-pre-wrap h-96 overflow-y-auto">
+          <div className="p-4 border border-gray-200 rounded-md bg-gray-50 whitespace-pre-wrap h-40 overflow-y-auto">
             {article.textContent || 'テキストコンテンツがありません'}
+          </div>
+
+          {/* アクション選択セクション */}
+          <div className="mt-6 p-4 border border-gray-200 rounded-md bg-gray-50">
+            <h3 className="text-lg font-medium mb-3">テキストアクション</h3>
+            <p className="text-sm text-gray-600 mb-3">
+              選択したアクションを実行すると、整形されたテキストと指定したプロンプトが一緒にコピーされます。
+            </p>
+
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+              <div className="w-full sm:w-64">
+                <select
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={selectedAction?.id || ''}
+                  onChange={(e) => {
+                    const selected = actions.find(
+                      (a) => a.id === e.target.value
+                    );
+                    setSelectedAction(selected || null);
+                  }}
+                >
+                  <option value="">アクションを選択</option>
+                  {actions.map((action) => (
+                    <option key={action.id} value={action.id}>
+                      {action.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <button
+                onClick={handleActionCopy}
+                disabled={!selectedAction}
+                className={`px-4 py-2 rounded-md transition-colors ${
+                  !selectedAction
+                    ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                    : isPromptCopied
+                    ? 'bg-green-600 text-white'
+                    : 'bg-blue-600 hover:bg-blue-700 text-white'
+                }`}
+              >
+                {isPromptCopied ? 'コピーしました！' : 'コピー'}
+              </button>
+
+              <button
+                onClick={() => setIsModalOpen(true)}
+                className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-md ml-auto"
+              >
+                カスタムアクション追加
+              </button>
+            </div>
+
+            {selectedAction && (
+              <div className="mt-3 p-3 bg-gray-100 rounded-md">
+                <p className="text-sm font-medium">
+                  選択中: {selectedAction.name}
+                </p>
+                <p className="text-sm text-gray-600 mt-1">
+                  {selectedAction.prompt}
+                </p>
+                {!selectedAction.isBuiltIn && (
+                  <button
+                    onClick={() => deleteCustomAction(selectedAction.id)}
+                    className="mt-2 text-xs text-red-600 hover:text-red-800"
+                  >
+                    このカスタムアクションを削除
+                  </button>
+                )}
+              </div>
+            )}
           </div>
 
           {article.siteName && (
@@ -182,6 +330,72 @@ export default function ExtractForm() {
           {article.byline && (
             <div className="text-sm text-gray-600">著者: {article.byline}</div>
           )}
+        </div>
+      )}
+
+      {/* カスタムアクション追加モーダル */}
+      {isModalOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg w-full max-w-md">
+            <h3 className="text-lg font-semibold mb-4">
+              カスタムアクションの追加
+            </h3>
+
+            <div className="space-y-4">
+              <div>
+                <label
+                  htmlFor="action-name"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  アクション名
+                </label>
+                <input
+                  id="action-name"
+                  type="text"
+                  value={newActionName}
+                  onChange={(e) => setNewActionName(e.target.value)}
+                  placeholder="例: 技術的な説明"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="action-prompt"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  プロンプト内容
+                </label>
+                <textarea
+                  id="action-prompt"
+                  value={newActionPrompt}
+                  onChange={(e) => setNewActionPrompt(e.target.value)}
+                  placeholder="例: この内容について技術的な観点から詳しく説明してください。"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 h-32"
+                ></textarea>
+              </div>
+
+              <div className="flex justify-end space-x-3 pt-2">
+                <button
+                  onClick={() => setIsModalOpen(false)}
+                  className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-md"
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={saveCustomAction}
+                  disabled={!newActionName.trim() || !newActionPrompt.trim()}
+                  className={`px-4 py-2 rounded-md ${
+                    !newActionName.trim() || !newActionPrompt.trim()
+                      ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                      : 'bg-blue-600 hover:bg-blue-700 text-white'
+                  }`}
+                >
+                  保存
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/app/config/default-actions.ts
+++ b/app/config/default-actions.ts
@@ -1,0 +1,27 @@
+// app/config/default-actions.ts
+
+// カスタムアクションの型定義
+export interface CustomAction {
+  name: string;
+  prompt: string;
+  isBuiltIn?: boolean;
+}
+
+// デフォルトのアクションリスト
+export const DEFAULT_ACTIONS: CustomAction[] = [
+  {
+    name: '要約',
+    prompt: 'この内容について、簡潔に要約してください。',
+    isBuiltIn: true,
+  },
+  {
+    name: '箇条書きでまとめ',
+    prompt: 'この内容について箇条書きでまとめてください。',
+    isBuiltIn: true,
+  },
+  {
+    name: '日本語に翻訳',
+    prompt: 'この内容を日本語に翻訳してください。',
+    isBuiltIn: true,
+  },
+];


### PR DESCRIPTION
## PRの概要
記事抽出フォームにカスタムアクション管理機能を追加しました。これにより、ユーザーは独自のプロンプトを定義、保存、編集、削除できるようになります。また、定義したカスタムアクションをJSON形式でインポート・エクスポートする機能も実装しました。関連するUI要素は責務ごとにコンポーネントとして分離し、コードの見通しと再利用性を向上させています。カスタムアクションはブラウザのローカルストレージに保存され、次回訪問時も利用可能です。

## 変更点
- Azure Static Web AppsのGitHub Actionsワークフローから、プルリクエストクローズ時のリソースクリーンアップに関連するジョブを削除しました。
- 抽出された記事コンテンツの表示に特化した新しいコンポーネントを追加しました。
- 定義済みおよびカスタムアクションの選択と、選択したアクションを用いた操作を行うための新しいコンポーネントを追加しました。
- カスタムアクションの定義情報の入力、編集、およびJSONファイル形式でのアクションリストのインポート・エクスポート機能を提供するモーダルコンポーネントを追加しました。
- 抽出フォームコンポーネントにおいて、以下の機能追加および関連コンポーネントへのロジック移管を行いました。
    - ユーザーが定義したカスタムアクションをブラウザのローカルストレージに保存し、アプリケーション起動時に読み込む機能を追加しました。
    - デフォルトアクションとローカルストレージから読み込んだカスタムアクションを合わせて管理し、UIに表示するロジックを実装しました。
    - 選択されたカスタムアクションのプロンプトと、抽出・整形された記事コンテンツを組み合わせてクリップボードにコピーする機能を追加しました。
    - 記事コンテンツ表示部分とアクション選択部分のUI実装を、新しく追加されたコンポーネントに置き換えました。
    - カスタムアクション管理モーダルを開閉し、データの受け渡しを行う処理を追加しました。
- カスタムアクションのデータ構造の型定義と、アプリケーションにデフォルトで含まれるアクションのリストを定義する新しいファイルを追加しました。