### PR TITLE
:sparkles: Change copy button behavior to allow copying trimmed text even when no action is selected

### DIFF
--- a/app/components/action-selector.tsx
+++ b/app/components/action-selector.tsx
@@ -48,11 +48,8 @@ export default function ActionSelector({
 
         <button
           onClick={onActionCopy}
-          disabled={!selectedAction}
           className={`px-4 py-2 rounded-md transition-colors ${
-            !selectedAction
-              ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-              : isPromptCopied
+            isPromptCopied
               ? 'bg-green-600 text-white'
               : 'bg-blue-600 hover:bg-blue-700 text-white'
           }`}

--- a/app/components/extract-form.tsx
+++ b/app/components/extract-form.tsx
@@ -287,16 +287,18 @@ export default function ExtractForm() {
 
   // 選択したアクションでコンテンツをコピー
   const handleActionCopy = async () => {
-    if (!article?.textContent || !selectedAction) return;
+    if (!article?.textContent) return;
 
     try {
       // 複数の空白、改行をすべて単一のスペースに置換
       const trimmedContent = article.textContent.replace(/\s+/g, ' ').trim();
 
-      // プロンプトを追加したコンテンツを作成
-      const contentWithPrompt = `${trimmedContent}\n\n${selectedAction.prompt}`;
+      let contentToCopy = trimmedContent;
+      if (selectedAction) {
+        contentToCopy = `${trimmedContent}\n\n${selectedAction.prompt}`;
+      }
 
-      await navigator.clipboard.writeText(contentWithPrompt);
+      await navigator.clipboard.writeText(contentToCopy);
       setIsPromptCopied(true);
       setTimeout(() => setIsPromptCopied(false), 2000);
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   },
   "engines": {
     "node": "18.17.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xiaotiantakumi/SwaSnapContent.git"
   }
 }


### PR DESCRIPTION
## What

The copy button is now always enabled.

- When no action is selected, only the trimmed article text is copied.
- When an action is selected, the prompt is appended to the copied text.
- UI feedback and button style are unified.

## Why

This change improves UX by allowing users to copy the article text even if no action is selected, as requested in #9.

Closes #9