### PR TITLE
fix: Add SKIP_DEPLOY_ON_MISSING_SECRETS to handle Dependabot PRs

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
+++ b/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      SKIP_DEPLOY_ON_MISSING_SECRETS: true
     steps:
       - uses: actions/checkout@v3
         with:

--- a/app/authenticated/markdown-viewer/page.tsx
+++ b/app/authenticated/markdown-viewer/page.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { useState } from 'react';
-import Header from '../components/header';
-import { ThreadProvider } from '../contexts/ThreadContext';
-import { MarkdownPreview } from '../components/markdown/MarkdownPreview';
-import { OpenedFiles } from '../components/markdown/OpenedFiles';
-import { ScrollToTopButton } from '../components/markdown/ScrollToTopButton';
-import { Toolbar } from '../components/markdown/toolbar/Toolbar';
-import { ThreadHeader } from '../components/thread/ThreadHeader';
-import { useCombinedContent } from '../hooks/useCombinedContent';
-import { useDragAndDrop } from '../hooks/useDragAndDrop';
-import { useMarkdownParser } from '../hooks/useMarkdownParser';
-import { useThread } from '../contexts/ThreadContext';
-import { DEFAULT_MARKDOWN_CONTENT, NEW_PROJECT_WELCOME_CONTENT } from '../lib/markdown-constants';
+import Header from '../../components/header';
+import { ThreadProvider } from '../../contexts/ThreadContext';
+import { MarkdownPreview } from '../../components/markdown/MarkdownPreview';
+import { OpenedFiles } from '../../components/markdown/OpenedFiles';
+import { ScrollToTopButton } from '../../components/markdown/ScrollToTopButton';
+import { Toolbar } from '../../components/markdown/toolbar/Toolbar';
+import { ThreadHeader } from '../../components/thread/ThreadHeader';
+import { useCombinedContent } from '../../hooks/useCombinedContent';
+import { useDragAndDrop } from '../../hooks/useDragAndDrop';
+import { useMarkdownParser } from '../../hooks/useMarkdownParser';
+import { useThread } from '../../contexts/ThreadContext';
+import { DEFAULT_MARKDOWN_CONTENT, NEW_PROJECT_WELCOME_CONTENT } from '../../lib/markdown-constants';
 
 function MarkdownViewerContent() {
   const [error, setError] = useState<string | null>(null);

--- a/app/components/app-selector.tsx
+++ b/app/components/app-selector.tsx
@@ -21,7 +21,7 @@ const apps: AppOption[] = [
   {
     title: 'Markdownビューア',
     description: 'Markdownファイルをリアルタイムでプレビューできるエディタです',
-    href: '/markdown-viewer',
+    href: '/authenticated/markdown-viewer',
     icon: '📝',
     color: 'bg-green-500 hover:bg-green-600',
   },

--- a/app/components/auth/UserMenu.tsx
+++ b/app/components/auth/UserMenu.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+
+export default function UserMenu() {
+  const { isAuthenticated, isLoading, userEmail, login, logout } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Click outside handler
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700">
+        <span className="text-sm">...</span>
+      </div>
+    );
+  }
+
+  // Not authenticated - show login button
+  if (!isAuthenticated) {
+    return (
+      <button
+        onClick={login}
+        className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+        aria-label="ログイン"
+      >
+        <span className="mr-2">👤</span>
+        ログイン
+      </button>
+    );
+  }
+
+  // Authenticated - show user menu
+  const userInitial = userEmail ? userEmail.charAt(0).toUpperCase() : '?';
+
+  return (
+    <div className="relative" ref={menuRef}>
+      {/* User Avatar Button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-label="ユーザーメニューを開く"
+      >
+        <span className="text-sm font-medium">{userInitial}</span>
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-800 dark:ring-gray-700">
+          <div className="py-1">
+            {/* User Info */}
+            <div className="px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+              <p className="text-xs text-gray-500 dark:text-gray-400">ログイン中</p>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                {userEmail}
+              </p>
+            </div>
+
+            {/* Menu Items */}
+            <div className="py-1">
+              <button
+                onClick={() => {
+                  setIsOpen(false);
+                  logout();
+                }}
+                className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                <span className="mr-2">🚪</span>
+                ログアウト
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -7,7 +7,7 @@ interface HeaderProps {
 export default function Header({ 
   title, 
   description, 
-  showBackButton = false 
+  showBackButton = false
 }: HeaderProps = {}) {
   return (
     <header className="w-full max-w-3xl">

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface UserInfo {
+  clientPrincipal: {
+    userId: string;
+    userRoles: string[];
+    identityProvider: string;
+    userDetails: string;
+  } | null;
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await fetch('/.auth/me');
+        if (response.ok) {
+          const data = await response.json();
+          setUser(data);
+        }
+      } catch (error) {
+        console.error('Failed to fetch user info:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  const isAuthenticated = !!user?.clientPrincipal;
+  const userEmail = user?.clientPrincipal?.userDetails || '';
+  const userRoles = user?.clientPrincipal?.userRoles || [];
+
+  const login = () => {
+    window.location.href = '/.auth/login/aad';
+  };
+
+  const logout = () => {
+    window.location.href = '/.auth/logout?post_logout_redirect_uri=' + 
+                         encodeURIComponent(window.location.origin);
+  };
+
+  return {
+    user,
+    isAuthenticated,
+    isLoading,
+    userEmail,
+    userRoles,
+    login,
+    logout
+  };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,18 +5,15 @@ export default function Home() {
   return (
     <main className="flex min-h-screen flex-col">
       <Header />
-      
+
       <div className="flex-1 bg-gray-50 dark:bg-gray-900">
         <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
           <div className="text-center">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl">
-              SwaSnapContent
+              おてて動かそうのツール
             </h1>
-            <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-gray-400">
-              URLの本文抽出とMarkdownビューアを統合したWebアプリケーション
-            </p>
           </div>
-          
+
           <div className="mt-16">
             <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">
               アプリケーションを選択してください

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,19 @@
 import Header from './components/header';
 import AppSelector from './components/app-selector';
+import UserMenu from './components/auth/UserMenu';
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col">
+      {/* Top navigation bar with user menu */}
+      <nav className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-end">
+            <UserMenu />
+          </div>
+        </div>
+      </nav>
+
       <Header />
 
       <div className="flex-1 bg-gray-50 dark:bg-gray-900">

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.0.1",
+        "concurrently": "^9.2.0",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
@@ -2927,6 +2928,100 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2982,6 +3077,32 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3935,6 +4056,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -7150,6 +7281,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7326,6 +7467,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -7509,6 +7660,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -8272,6 +8436,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/trim-lines": {
@@ -9351,6 +9525,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9367,6 +9551,80 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.0.1",
-        "concurrently": "^9.2.0",
+        "concurrently": "^8.2.2",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
@@ -3079,16 +3079,18 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
-      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.1",
         "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
         "supports-color": "^8.1.1",
         "tree-kill": "^1.2.2",
         "yargs": "^17.7.2"
@@ -3098,7 +3100,7 @@
         "concurrently": "dist/bin/concurrently.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^14.13.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -3212,6 +3214,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -7862,6 +7881,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "build:api": "cd api && npm run build",
-    "swa:all": "npm run build && (cd api && npm run build) && swa start out --api-location api",
+    "swa:all": "concurrently \"npm:dev\" \"swa start http://localhost:3000 --api-location api\"",
+    "swa:build": "npm run build && (cd api && npm run build)",
     "swa:start": "swa start out --api-location api"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "concurrently": "^8.2.2",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -17,7 +17,7 @@
     },
     "routes": [
         {
-            "route": "/markdown-viewer",
+            "route": "/authenticated/*",
             "allowedRoles": [
                 "authenticated"
             ]

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -17,6 +17,12 @@
     },
     "routes": [
         {
+            "route": "/markdown-viewer",
+            "allowedRoles": [
+                "authenticated"
+            ]
+        },
+        {
             "route": "/api/*",
             "methods": [
                 "GET",


### PR DESCRIPTION
## Summary
- Add `SKIP_DEPLOY_ON_MISSING_SECRETS: true` environment variable to GitHub Actions workflow
- This allows the workflow to continue when deployment tokens are unavailable
- Specifically fixes issues with Dependabot PRs that cannot access repository secrets

## Problem
Dependabot pull requests were failing with the error:
```
deployment_token was not provided. If you are using a GitHub repository, ensure the 'repo_token' or 'azure_static_web_apps_api_token' secret is configured.
```

This occurs because Dependabot PRs cannot access repository secrets for security reasons.

## Solution
Added `SKIP_DEPLOY_ON_MISSING_SECRETS: true` to the build_and_deploy_job environment variables. This is the recommended approach by Microsoft's documentation for handling PRs from forks or automated systems that don't have access to secrets.

## Test plan
- [ ] Verify existing deployments from main branch continue to work
- [ ] Confirm Dependabot PRs no longer fail due to missing deployment token
- [ ] Check that the workflow still validates code changes even without deployment

## References
- [Azure Static Web Apps deployment token management](https://learn.microsoft.com/en-us/azure/static-web-apps/deployment-token-management)
- [Azure Static Web Apps build configuration](https://learn.microsoft.com/en-us/azure/static-web-apps/build-configuration#skip-building-the-api)

🤖 Generated with [Claude Code](https://claude.ai/code)