### PR TITLE
fix: Add SKIP_DEPLOY_ON_MISSING_SECRETS to handle Dependabot PRs

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
+++ b/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      SKIP_DEPLOY_ON_MISSING_SECRETS: true
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary
- Add `SKIP_DEPLOY_ON_MISSING_SECRETS: true` environment variable to GitHub Actions workflow
- This allows the workflow to continue when deployment tokens are unavailable
- Specifically fixes issues with Dependabot PRs that cannot access repository secrets

## Problem
Dependabot pull requests were failing with the error:
```
deployment_token was not provided. If you are using a GitHub repository, ensure the 'repo_token' or 'azure_static_web_apps_api_token' secret is configured.
```

This occurs because Dependabot PRs cannot access repository secrets for security reasons.

## Solution
Added `SKIP_DEPLOY_ON_MISSING_SECRETS: true` to the build_and_deploy_job environment variables. This is the recommended approach by Microsoft's documentation for handling PRs from forks or automated systems that don't have access to secrets.

## Test plan
- [ ] Verify existing deployments from main branch continue to work
- [ ] Confirm Dependabot PRs no longer fail due to missing deployment token
- [ ] Check that the workflow still validates code changes even without deployment

## References
- [Azure Static Web Apps deployment token management](https://learn.microsoft.com/en-us/azure/static-web-apps/deployment-token-management)
- [Azure Static Web Apps build configuration](https://learn.microsoft.com/en-us/azure/static-web-apps/build-configuration#skip-building-the-api)

🤖 Generated with [Claude Code](https://claude.ai/code)