### PR TITLE
🎨 Fix dark mode visibility issues

### DIFF
--- a/app/components/action-selector.tsx
+++ b/app/components/action-selector.tsx
@@ -24,16 +24,16 @@ export default function ActionSelector({
   isPromptCopied,
 }: ActionSelectorProps): JSX.Element {
   return (
-    <div className="mt-6 rounded-md border border-gray-200 bg-gray-50 p-4">
-      <h3 className="mb-3 text-lg font-medium">テキストアクション</h3>
-      <p className="mb-3 text-sm text-gray-600">
+    <div className="mt-6 rounded-md border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-800">
+      <h3 className="mb-3 text-lg font-medium text-gray-900 dark:text-white">テキストアクション</h3>
+      <p className="mb-3 text-sm text-gray-600 dark:text-gray-300">
         選択したアクションを実行すると、整形されたテキストと指定したプロンプトが一緒にコピーされます。
       </p>
 
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
         <div className="w-full sm:w-64">
           <select
-            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             value={selectedAction?.name || ''}
             onChange={(e) => onSelectedActionChange(e.target.value || null)}
           >
@@ -59,20 +59,20 @@ export default function ActionSelector({
 
         <button
           onClick={onOpenCustomActionModal}
-          className="ml-auto rounded-md bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300"
+          className="ml-auto rounded-md bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500"
         >
           カスタムアクション
         </button>
       </div>
 
       {selectedAction ? (
-        <div className="mt-3 rounded-md bg-gray-100 p-3">
-          <p className="text-sm font-medium">選択中: {selectedAction.name}</p>
-          <p className="mt-1 text-sm text-gray-600">{selectedAction.prompt}</p>
+        <div className="mt-3 rounded-md bg-gray-100 p-3 dark:bg-gray-700">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">選択中: {selectedAction.name}</p>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{selectedAction.prompt}</p>
           {!selectedAction.isBuiltIn ? (
             <button
               onClick={() => onDeleteCustomAction(selectedAction.name)}
-              className="mt-2 text-xs text-red-600 hover:text-red-800"
+              className="mt-2 text-xs text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
             >
               このカスタムアクションを削除
             </button>

--- a/app/components/article-display.tsx
+++ b/app/components/article-display.tsx
@@ -10,27 +10,27 @@ export default function ArticleDisplay({ article }: ArticleDisplayProps): JSX.El
   return (
     <div className="mt-8 space-y-4">
       {article.title ? (
-        <h2 className="text-2xl font-semibold">{article.title}</h2>
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">{article.title}</h2>
       ) : null}
 
       <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
-        <h3 className="text-lg font-medium">抽出されたコンテンツ：</h3>
+        <h3 className="text-lg font-medium text-gray-900 dark:text-white">抽出されたコンテンツ：</h3>
       </div>
 
-      <div className="h-40 overflow-y-auto whitespace-pre-wrap rounded-md border border-gray-200 bg-gray-50 p-4">
+      <div className="h-40 overflow-y-auto whitespace-pre-wrap rounded-md border border-gray-200 bg-gray-50 p-4 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
         {article.textContent || 'テキストコンテンツがありません'}
       </div>
 
       {/* アクション選択セクションはこのコンポーネントの外にあります */}
 
       {article.siteName ? (
-        <div className="text-sm text-gray-600">
+        <div className="text-sm text-gray-600 dark:text-gray-400">
           サイト名: {article.siteName}
         </div>
       ) : null}
 
       {article.byline ? (
-        <div className="text-sm text-gray-600">著者: {article.byline}</div>
+        <div className="text-sm text-gray-600 dark:text-gray-400">著者: {article.byline}</div>
       ) : null}
     </div>
   );

--- a/app/components/extract-form.tsx
+++ b/app/components/extract-form.tsx
@@ -319,7 +319,7 @@ export default function ExtractForm() {
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="URLを入力"
-            className="grow rounded-md border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="grow rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400"
             disabled={isLoading}
           />
           <button
@@ -357,7 +357,7 @@ export default function ExtractForm() {
           {/* 選択中のアクションを編集するボタンを追加 */}
           {selectedAction && !selectedAction.isBuiltIn ? <button
               onClick={() => handleOpenModalForEdit(selectedAction)}
-              className="ml-2 mt-2 rounded-md bg-yellow-500 px-3 py-1 text-sm text-white hover:bg-yellow-600"
+              className="ml-2 mt-2 rounded-md bg-yellow-500 px-3 py-1 text-sm text-white hover:bg-yellow-600 dark:bg-yellow-600 dark:hover:bg-yellow-700"
             >
               選択中アクションを編集
             </button> : null}


### PR DESCRIPTION
## Summary
- Fix text visibility issues in dark mode for URL extractor app
- Improve contrast for input fields and form elements
- Ensure consistent dark mode styling across all components

## Changes Made
- **Input fields**: Added proper dark mode background (`dark:bg-gray-700`) and text colors (`dark:text-white`)
- **Action selector**: Updated background, text, and button colors for better contrast
- **Article display**: Fixed content area and text visibility in dark mode
- **Placeholder text**: Updated to use Tailwind CSS v3 syntax (`placeholder:text-*`)

## Test Results
- ✅ Build successful
- ✅ All E2E tests passing (6/6)
- ✅ Linting warnings addressed

## Screenshots
The reported issue showed poor text visibility in dark mode, particularly:
- Black text on dark background ("おてて動かそう")
- White input fields that didn't match dark theme
- Poor contrast in action selector components

These have all been resolved with proper dark mode color schemes.

🤖 Generated with [Claude Code](https://claude.ai/code)