### PR TITLE
✨ リンクコレクターURLをクリック可能にする機能追加 (#31)

### DIFF
--- a/app/components/url-list-display.tsx
+++ b/app/components/url-list-display.tsx
@@ -261,9 +261,15 @@ export default function URLListDisplay({
                 />
                 
                 <div className="min-w-0 flex-1">
-                  <div className="break-all text-sm text-gray-900 dark:text-gray-100">
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="break-all rounded text-sm text-blue-600 hover:text-blue-800 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:text-blue-400 dark:hover:text-blue-300"
+                  >
                     {item.url}
-                  </div>
+                  </a>
                   
                   <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                     ソース: {item.source} | 深度: {item.depth}


### PR DESCRIPTION
## 概要
リンクコレクターで収集されたURLをクリック可能なリンクとして表示する機能を追加しました。

### 変更内容
- URLをプレーンテキスト（`<div>`）から`<a>`タグに変更
- `target="_blank"`で新しいタブで開く機能を追加  
- セキュリティ対策で`rel="noopener noreferrer"`を設定
- `onClick stopPropagation`でチェックボックスとの干渉を防止
- ブルー系リンクスタイリング（ホバー・フォーカス効果）を適用

### 解決するイシュー
Fixes #31

### 実装詳細
- **ファイル**: `app/components/url-list-display.tsx` (264-272行目)
- **セキュリティ**: `rel="noopener noreferrer"`でタブナビゲーション攻撃を防止
- **UX**: Ctrl/Cmd+Clickで新しいタブで開く標準的な動作をサポート
- **アクセシビリティ**: フォーカスリング、キーボードナビゲーション対応

### テスト済み項目
- ✅ ビルド成功
- ✅ 開発サーバー起動確認
- ✅ Linting完了（Tailwind CSS クラス順序修正済み）
- ✅ URLクリックで新しいタブで開く動作
- ✅ チェックボックス機能との干渉なし

### スクリーンショット/デモ
リンクコレクターページ（`/link-collector`）でURLが青色のクリック可能なリンクとして表示され、ホバー時に下線が表示されます。

🤖 Generated with [Claude Code](https://claude.ai/code)