### PR TITLE
:bug: Fix exclude patterns display and copy behavior in link collector

### DIFF
--- a/app/link-collector/link-collector-client.tsx
+++ b/app/link-collector/link-collector-client.tsx
@@ -24,7 +24,11 @@ export default function LinkCollectorClient() {
 
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const handleCollect = async (url: string, selector: string, options: CollectionOptions) => {
+  const handleCollect = async (
+    url: string,
+    selector: string,
+    options: CollectionOptions
+  ) => {
     setSuccessMessage(null);
     await collectLinks(url, selector, options);
   };
@@ -35,8 +39,8 @@ export default function LinkCollectorClient() {
   ) => {
     try {
       await copySelectedUrls(format, filteredUrls);
-      const copiedCount = filteredUrls 
-        ? filteredUrls.filter(item => selectedUrls.has(item.url)).length
+      const copiedCount = filteredUrls
+        ? filteredUrls.filter((item) => selectedUrls.has(item.url)).length
         : selectedUrls.size;
       setSuccessMessage(`${copiedCount}個のURLをコピーしました`);
       setTimeout(() => setSuccessMessage(null), 3000);
@@ -48,13 +52,17 @@ export default function LinkCollectorClient() {
   return (
     <div className="space-y-6">
       {/* Success/Error Messages */}
-      {successMessage ? <div className="rounded border border-green-200 bg-green-50 px-4 py-3 text-green-700">
+      {successMessage ? (
+        <div className="rounded border border-green-200 bg-green-50 px-4 py-3 text-green-700">
           {successMessage}
-        </div> : null}
-      
-      {error ? <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">
           <strong>エラー:</strong> {error}
-        </div> : null}
+        </div>
+      ) : null}
 
       {/* Collection Form */}
       <LinkCollectorForm
@@ -76,7 +84,7 @@ export default function LinkCollectorClient() {
               結果をクリア
             </button>
           </div>
-          
+
           <URLListDisplay
             urls={collectedUrls}
             selectedUrls={selectedUrls}
@@ -90,15 +98,34 @@ export default function LinkCollectorClient() {
       )}
 
       {/* Loading State */}
-      {isCollecting ? <div className="rounded border border-blue-200 bg-blue-50 px-4 py-3 text-blue-700">
+      {isCollecting ? (
+        <div className="rounded border border-blue-200 bg-blue-50 px-4 py-3 text-blue-700">
           <div className="flex items-center">
-            <svg className="-ml-1 mr-3 size-5 animate-spin text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 818-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            <svg
+              className="-ml-1 mr-3 size-5 animate-spin text-blue-600"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 818-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
             </svg>
-            リンクを収集中です... サーバーの負荷を避けるため、少し時間がかかる場合があります。
+            リンクを収集中です...
+            サーバーの負荷を避けるため、少し時間がかかる場合があります。
           </div>
-        </div> : null}
+        </div>
+      ) : null}
 
       {/* Help Text */}
       {collectedUrls.length === 0 && !isCollecting && (
@@ -107,10 +134,23 @@ export default function LinkCollectorClient() {
             使い方
           </h3>
           <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
-            <li>• <strong>ターゲットURL:</strong> リンクを収集したいウェブページのURLを入力してください</li>
-            <li>• <strong>CSSセレクタ:</strong> 特定の要素内のリンクのみを収集したい場合に指定します（例: .content a, #main a）</li>
-            <li>• 収集後は、フィルタ機能で不要なURLを除外し、チェックボックスで必要なURLを選択してコピーできます</li>
-            <li>• NotebookLMで使用する場合は、改行区切りまたはスペース区切りを選択できます</li>
+            <li>
+              • <strong>ターゲットURL:</strong>{' '}
+              リンクを収集したいウェブページのURLを入力してください
+            </li>
+            <li>
+              • <strong>CSSセレクタ:</strong>{' '}
+              特定の要素内のリンクのみを収集したい場合に指定します（例: .content
+              a, #main a）
+            </li>
+            <li>
+              •
+              収集後は、フィルタ機能で不要なURLを除外し、チェックボックスで必要なURLを選択してコピーできます
+            </li>
+            <li>
+              •
+              NotebookLMで使用する場合は、改行区切りまたはスペース区切りを選択できます
+            </li>
           </ul>
         </div>
       )}

--- a/app/link-collector/link-collector-client.tsx
+++ b/app/link-collector/link-collector-client.tsx
@@ -29,10 +29,16 @@ export default function LinkCollectorClient() {
     await collectLinks(url, selector, options);
   };
 
-  const handleCopy = async (format: Parameters<typeof copySelectedUrls>[0]) => {
+  const handleCopy = async (
+    format: Parameters<typeof copySelectedUrls>[0],
+    filteredUrls?: Parameters<typeof copySelectedUrls>[1]
+  ) => {
     try {
-      await copySelectedUrls(format);
-      setSuccessMessage(`${selectedUrls.size}個のURLをコピーしました`);
+      await copySelectedUrls(format, filteredUrls);
+      const copiedCount = filteredUrls 
+        ? filteredUrls.filter(item => selectedUrls.has(item.url)).length
+        : selectedUrls.size;
+      setSuccessMessage(`${copiedCount}個のURLをコピーしました`);
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
       console.error('Copy error:', err);

--- a/tests/link-collector.spec.ts
+++ b/tests/link-collector.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-import { 
-  fillLinkCollectorForm, 
+import {
+  fillLinkCollectorForm,
   waitForCollectionToComplete,
   mockCollectionAPI,
   createSuccessResponse,
-  createErrorResponse
+  createErrorResponse,
 } from './helpers/link-collector-helpers';
 
 test.describe('Link Collector E2E Tests', () => {
@@ -14,93 +14,107 @@ test.describe('Link Collector E2E Tests', () => {
     await page.goto('/link-collector');
   });
 
-  test('should display link collector form and UI elements', async ({ page }) => {
+  test('should display link collector form and UI elements', async ({
+    page,
+  }) => {
     // ページタイトルの確認（実際のタイトルに合わせて修正）
     await expect(page).toHaveTitle(/URL本文抽出アプリ|リンクコレクター/);
-    
+
     // ヘッダーの確認
     await expect(page.locator('h1')).toContainText('リンクコレクター');
-    
+
     // ダークモード切り替えボタンの確認
-    const themeToggle = page.locator('button[aria-label*="ダークモード"], button[aria-label*="ライトモード"]');
+    const themeToggle = page.locator(
+      'button[aria-label*="ダークモード"], button[aria-label*="ライトモード"]'
+    );
     await expect(themeToggle).toBeVisible();
-    
+
     // フォーム要素の確認
     const targetUrlInput = page.locator('input[type="url"]');
-    const selectorInput = page.locator('input[placeholder*="例: .main-content a"]');
+    const selectorInput = page.locator(
+      'input[placeholder*="例: .main-content a"]'
+    );
     const submitButton = page.locator('button[type="submit"]');
-    
+
     await expect(targetUrlInput).toBeVisible();
     await expect(selectorInput).toBeVisible();
     await expect(submitButton).toBeVisible();
-    
+
     // 使い方セクションの確認
     await expect(page.locator('text=使い方')).toBeVisible();
-    
+
     // スクリーンショット（初期状態）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-initial.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
-  test('should test link collection with takumi-oda.com/blog', async ({ page }) => {
+  test('should test link collection with takumi-oda.com/blog', async ({
+    page,
+  }) => {
     // テスト用のURL
     const testUrls = [
       'https://takumi-oda.com/blog/2025/01/15/sample-post-1/',
       'https://takumi-oda.com/blog/2025/01/10/sample-post-2/',
-      'https://takumi-oda.com/blog/2025/01/05/sample-post-3/'
+      'https://takumi-oda.com/blog/2025/01/05/sample-post-3/',
     ];
-    
+
     // APIをモック
     await mockCollectionAPI(page, createSuccessResponse(testUrls), 200, 1000);
 
     // フォームに入力
-    await fillLinkCollectorForm(page, 'https://takumi-oda.com/blog/', '#card-2');
-    
+    await fillLinkCollectorForm(
+      page,
+      'https://takumi-oda.com/blog/',
+      '#card-2'
+    );
+
     // スクリーンショット（入力後）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-form-filled.png',
-      fullPage: true 
+      fullPage: true,
     });
-    
+
     // APIリクエストを待つPromiseを作成
     const responsePromise = page.waitForResponse('**/api/collectLinks');
-    
+
     // リンク収集ボタンをクリック
     const submitButton = page.locator('button[type="submit"]');
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
-    
+
     // ボタンが無効化され、収集中テキストが表示されることを確認
     await expect(submitButton).toBeDisabled();
     await expect(submitButton).toContainText('収集中...');
-    
+
     // スクリーンショット（収集中）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-collecting.png',
-      fullPage: true 
+      fullPage: true,
     });
-    
+
     // APIレスポンスを待つ
     const response = await responsePromise;
     expect(response.status()).toBe(200);
-    
+
     // 収集が完了するまで待つ
     await waitForCollectionToComplete(page, true);
-    
+
     // 収集されたURLがあることを確認
-    const urlList = page.locator('.divide-y > div').filter({ hasText: 'takumi-oda.com' });
+    const urlList = page
+      .locator('.divide-y > div')
+      .filter({ hasText: 'takumi-oda.com' });
     await expect(urlList).toHaveCount(3);
-    
+
     // 統計情報が表示されていることを確認
     await expect(page.locator('text=総リンク数: 3')).toBeVisible();
     await expect(page.locator('text=ユニーク数: 3')).toBeVisible();
-    
+
     // スクリーンショット（成功時）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-success.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
@@ -108,121 +122,136 @@ test.describe('Link Collector E2E Tests', () => {
     // 空のフォームで送信ボタンをクリック
     const submitButton = page.locator('button[type="submit"]');
     await expect(submitButton).toBeDisabled();
-    
+
     // 無効なURLを入力
     await page.fill('input[type="url"]', 'invalid-url');
-    
+
     // HTML5バリデーションが働くことを確認
     const targetUrlInput = page.locator('input[type="url"]');
     await expect(targetUrlInput).toHaveAttribute('type', 'url');
-    
+
     // 有効なURLを入力すると送信ボタンが有効になることを確認
     await page.fill('input[type="url"]', 'https://example.com');
     await expect(submitButton).toBeEnabled();
-    
+
     // スクリーンショット（バリデーション状態）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-validation.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
-  test('should verify options are fixed to default values', async ({ page }) => {
+  test('should verify options are fixed to default values', async ({
+    page,
+  }) => {
     // 詳細オプションが削除されていることを確認
     await expect(page.locator('text=詳細オプション')).not.toBeVisible();
-    
+
     // クロール深度設定も存在しないことを確認
-    await expect(page.locator('label:has-text("クロール深度")')).not.toBeVisible();
-    await expect(page.locator('label:has-text("リクエスト間隔")')).not.toBeVisible();
-    
+    await expect(
+      page.locator('label:has-text("クロール深度")')
+    ).not.toBeVisible();
+    await expect(
+      page.locator('label:has-text("リクエスト間隔")')
+    ).not.toBeVisible();
+
     // スクリーンショット（簡素化されたUI）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-simplified.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
   test('should toggle dark mode correctly', async ({ page }) => {
     // ダークモード切り替えボタンを見つける
-    const themeToggle = page.locator('button[aria-label*="ダークモード"], button[aria-label*="ライトモード"]');
+    const themeToggle = page.locator(
+      'button[aria-label*="ダークモード"], button[aria-label*="ライトモード"]'
+    );
     await expect(themeToggle).toBeVisible();
-    
+
     // 初期状態のスクリーンショット
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-initial-theme.png',
-      fullPage: true 
+      fullPage: true,
     });
-    
+
     // ダークモード切り替えボタンをクリック
     await themeToggle.click();
-    
+
     // 少し待機してテーマの変更を確実にする
     await page.waitForTimeout(500);
-    
+
     // ダークモード切り替え後のスクリーンショット
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-dark-mode.png',
-      fullPage: true 
+      fullPage: true,
     });
-    
+
     // もう一度クリックして元に戻す
     await themeToggle.click();
     await page.waitForTimeout(500);
-    
+
     // ライトモードに戻った後のスクリーンショット
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-light-mode.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
   test('should handle error scenarios gracefully', async ({ page }) => {
     // APIをモックしてエラーレスポンスを返す
-    await mockCollectionAPI(page, createErrorResponse('Server error occurred'), 500, 500);
+    await mockCollectionAPI(
+      page,
+      createErrorResponse('Server error occurred'),
+      500,
+      500
+    );
 
     // フォームに入力
     await fillLinkCollectorForm(page, 'https://nonexistent-domain-12345.com');
-    
+
     // ボタンが有効になっていることを確認
     const submitButton = page.locator('button[type="submit"]');
     await expect(submitButton).toBeEnabled();
-    
+
     // APIリクエストを待つPromiseを作成
     const responsePromise = page.waitForResponse('**/api/collectLinks');
-    
+
     // ボタンをクリック
     await submitButton.click();
-    
+
     // ボタンが無効化され、収集中テキストが表示されることを確認
     await expect(submitButton).toBeDisabled();
     await expect(submitButton).toContainText('収集中...');
-    
+
     // スクリーンショット（収集中）
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-collecting-error.png',
-      fullPage: true 
+      fullPage: true,
     });
-    
+
     // APIレスポンスを待つ
     const response = await responsePromise;
     expect(response.status()).toBe(500);
-    
+
     // エラーが処理されるまで待つ
     await waitForCollectionToComplete(page, false);
-    
+
     // エラーメッセージが表示されていることを確認
     const errorDiv = page.locator('.border-red-200.bg-red-50.text-red-700');
     await expect(errorDiv).toBeVisible();
     await expect(errorDiv).toContainText('エラー:');
-    
+
     // 最終的なスクリーンショット
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-error-state.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
-  test('should filter URLs correctly with exclude patterns', async ({ page }) => {
+  test('should filter URLs correctly with exclude patterns', async ({
+    page,
+  }) => {
     // テスト用のURL（一部は除外対象）
     const testUrls = [
       'https://takumi-oda.com/blog/2025/01/15/sample-post-1/',
@@ -230,80 +259,90 @@ test.describe('Link Collector E2E Tests', () => {
       'https://takumi-oda.com/blog/2025/01/05/sample-post-3/',
       'https://takumi-oda.com/about/',
       'https://takumi-oda.com/contact/',
-      'https://external-site.com/article/1'
+      'https://external-site.com/article/1',
     ];
-    
+
     // APIをモック
     await mockCollectionAPI(page, createSuccessResponse(testUrls), 200, 1000);
 
     // フォームに入力してリンクを収集
     await fillLinkCollectorForm(page, 'https://takumi-oda.com/blog/');
-    
+
     // APIリクエストを待つPromiseを作成
     const responsePromise = page.waitForResponse('**/api/collectLinks');
-    
+
     // リンク収集ボタンをクリック
     const submitButton = page.locator('button[type="submit"]');
     await submitButton.click();
-    
+
     // APIレスポンスを待つ
     await responsePromise;
-    
+
     // 収集が完了するまで待つ
     await waitForCollectionToComplete(page, true);
-    
+
     // 初期状態では全てのURLが表示されていることを確認
     const urlList = page.locator('.divide-y > div');
     await expect(urlList).toHaveCount(6); // 全てのURL
-    
+
     // 統計情報を確認（フィルタ前）
     await expect(page.locator('text=/総リンク数: 6/')).toBeVisible();
     await expect(page.locator('text=/ユニーク数: 6/')).toBeVisible();
-    
+
     // 除外パターン入力欄を見つける
     const excludePatternInput = page.locator('input[id="exclude-pattern"]');
     await expect(excludePatternInput).toBeVisible();
-    
+
     // 除外パターンを追加（blogを含むURLを除外）
     await excludePatternInput.fill('blog');
     await excludePatternInput.press('Enter');
-    
+
     // 除外パターンが追加されたことを確認
     await expect(page.locator('text=blog')).toBeVisible();
-    
+
     // フィルタ後の統計情報を確認（about + contact + external-site = 3つ）
     // フィルタ適用時は「3 / 6」形式で表示される
     // 親要素を取得してテキスト全体を確認
-    const totalLinksDiv = page.locator('div').filter({ hasText: /総リンク数:/ }).first();
+    const totalLinksDiv = page
+      .locator('div')
+      .filter({ hasText: /総リンク数:/ })
+      .first();
     await expect(totalLinksDiv).toBeVisible();
     await expect(totalLinksDiv).toContainText('3');
-    
-    const uniqueLinksDiv = page.locator('div').filter({ hasText: /ユニーク数:/ }).first();
+
+    const uniqueLinksDiv = page
+      .locator('div')
+      .filter({ hasText: /ユニーク数:/ })
+      .first();
     await expect(uniqueLinksDiv).toBeVisible();
     await expect(uniqueLinksDiv).toContainText('3');
-    
+
     // blogを含むURLが表示されないことを確認
     const filteredUrlList = page.locator('.divide-y > div');
     const count = await filteredUrlList.count();
     expect(count).toBe(3); // about + contact + external-site
-    
+
     // blogを含むURLが除外されていることを確認
-    const blogUrls = page.locator('.divide-y > div').filter({ hasText: 'blog' });
+    const blogUrls = page
+      .locator('.divide-y > div')
+      .filter({ hasText: 'blog' });
     await expect(blogUrls).toHaveCount(0);
-    
+
     // about、contact、external-siteのURLが表示されていることを確認
     await expect(page.locator('text=/about/')).toBeVisible();
     await expect(page.locator('text=/contact/')).toBeVisible();
     await expect(page.locator('text=/external-site/')).toBeVisible();
-    
+
     // スクリーンショット
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-exclusion-patterns.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
-  test('should copy only filtered URLs when exclude patterns are applied', async ({ page }) => {
+  test('should copy only filtered URLs when exclude patterns are applied', async ({
+    page,
+  }) => {
     // テスト用のURL
     const testUrls = [
       'https://takumi-oda.com/blog/post-1/',
@@ -311,56 +350,56 @@ test.describe('Link Collector E2E Tests', () => {
       'https://takumi-oda.com/about/',
       'https://takumi-oda.com/contact/',
     ];
-    
+
     // APIをモック
     await mockCollectionAPI(page, createSuccessResponse(testUrls), 200, 1000);
 
     // フォームに入力してリンクを収集
     await fillLinkCollectorForm(page, 'https://takumi-oda.com/');
-    
+
     // APIリクエストを待つPromiseを作成
     const responsePromise = page.waitForResponse('**/api/collectLinks');
-    
+
     // リンク収集ボタンをクリック
     const submitButton = page.locator('button[type="submit"]');
     await submitButton.click();
-    
+
     // APIレスポンスを待つ
     await responsePromise;
-    
+
     // 収集が完了するまで待つ
     await waitForCollectionToComplete(page, true);
-    
+
     // 全選択チェックボックスをクリック
     const selectAllCheckbox = page.locator('input[type="checkbox"]').first();
     await selectAllCheckbox.click();
-    
+
     // 除外パターンを追加（blogを含むURLを除外）
     const excludePatternInput = page.locator('input[id="exclude-pattern"]');
     await excludePatternInput.fill('blog');
     await excludePatternInput.press('Enter');
-    
+
     // フィルタが適用されるまで少し待つ
     await page.waitForTimeout(300);
-    
+
     // コピー対象の数が正しく更新されることを確認（blogを除いた2つ）
     await expect(page.locator('button:has-text("コピー (2)")')).toBeVisible();
-    
+
     // コピーボタンをクリック
     const copyButton = page.locator('button:has-text("コピー")');
     await copyButton.click();
-    
+
     // 成功メッセージを確認
     await expect(page.locator('text=/2個のURLをコピーしました/')).toBeVisible();
-    
+
     // クリップボードの内容を確認（簡易チェック）
     // 実際のクリップボードAPIはPlaywrightでは直接アクセスできないため、
     // 成功メッセージとコピー対象数の整合性で確認
-    
+
     // スクリーンショット
-    await page.screenshot({ 
+    await page.screenshot({
       path: 'test-results/link-collector-exclusion-patterns-copy.png',
-      fullPage: true 
+      fullPage: true,
     });
   });
 
@@ -372,57 +411,64 @@ test.describe('Link Collector E2E Tests', () => {
       'https://takumi-oda.com/about/',
       'https://takumi-oda.com/contact/',
       'https://external-site.com/article/1',
-      'https://external-site.com/article/2'
+      'https://external-site.com/article/2',
     ];
-    
+
     // APIをモック
     await mockCollectionAPI(page, createSuccessResponse(testUrls), 200, 1000);
 
     // フォームに入力してリンクを収集
     await fillLinkCollectorForm(page, 'https://takumi-oda.com/');
-    
+
     // APIリクエストを待つPromiseを作成
     const responsePromise = page.waitForResponse('**/api/collectLinks');
-    
+
     // リンク収集ボタンをクリック
     const submitButton = page.locator('button[type="submit"]');
     await submitButton.click();
-    
+
     // APIレスポンスを待つ
     await responsePromise;
-    
+
     // 収集が完了するまで待つ
     await waitForCollectionToComplete(page, true);
-    
+
     // 除外パターン入力欄を見つける
     const excludePatternInput = page.locator('input[id="exclude-pattern"]');
-    
+
     // 最初の除外パターンを追加（blogを含むURLを除外）
     await excludePatternInput.fill('blog');
     await excludePatternInput.press('Enter');
-    
+
     // 2つ目の除外パターンを追加（externalを含むURLを除外）
     await excludePatternInput.fill('external');
     await excludePatternInput.press('Enter');
-    
+
     // フィルタ後の統計情報を確認（about + contactのみ）
-    const totalLinksDiv = page.locator('div').filter({ hasText: /総リンク数:/ }).first();
+    const totalLinksDiv = page
+      .locator('div')
+      .filter({ hasText: /総リンク数:/ })
+      .first();
     await expect(totalLinksDiv).toBeVisible();
     await expect(totalLinksDiv).toContainText('2');
-    
+
     // aboutとcontactのURLのみが表示されることを確認
     const filteredUrlList = page.locator('.divide-y > div');
     const count = await filteredUrlList.count();
     expect(count).toBe(2);
-    
+
     await expect(page.locator('text=/about/')).toBeVisible();
     await expect(page.locator('text=/contact/')).toBeVisible();
-    
+
     // blogとexternalを含むURLが除外されていることを確認
-    const blogUrls = page.locator('.divide-y > div').filter({ hasText: 'blog' });
+    const blogUrls = page
+      .locator('.divide-y > div')
+      .filter({ hasText: 'blog' });
     await expect(blogUrls).toHaveCount(0);
-    
-    const externalUrls = page.locator('.divide-y > div').filter({ hasText: 'external' });
+
+    const externalUrls = page
+      .locator('.divide-y > div')
+      .filter({ hasText: 'external' });
     await expect(externalUrls).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
Fix issues with exclude patterns in the link collector component:
- Statistics now correctly display filtered counts when exclude patterns are applied
- Copy operation only includes filtered URLs (excluding URLs that match exclude patterns)
- Display counts are now consistent when multiple exclude patterns are added

## Changes
- Updated `url-list-display.tsx` to show filtered statistics (filtered count / original count)
- Modified `copySelectedUrls` in `useLinkCollector.ts` to accept filtered URLs and only copy selected items from filtered list
- Fixed display count inconsistency where "全選択" showed selected count from unfiltered list instead of filtered list
- Added `selectedFilteredCount` to ensure consistent display between "全選択" and "コピー" buttons

## Testing
- Added comprehensive E2E tests for exclude patterns:
  - Single exclude pattern filtering
  - Multiple exclude patterns
  - Copy operation with excluded URLs
- All tests passing ✅