### PR TITLE
feat: 100マス計算アプリを追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,11 @@
     "public/workbox-*.js",
     "*.config.js",
     "*.config.ts",
-    "node_modules/**"
+    "node_modules/**",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "vitest.setup.ts"
   ],
   "plugins": [
     "@typescript-eslint",

--- a/api/host.json
+++ b/api/host.json
@@ -20,8 +20,8 @@
     },
     "http": {
         "cors": {
-            "allowedOrigins": ["http://localhost:3000", "http://localhost:3001"],
-            "allowedMethods": ["GET", "POST", "OPTIONS"],
+            "allowedOrigins": ["http://localhost:3000", "http://localhost:3001", "http://localhost:4280"],
+            "allowedMethods": ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],
             "allowedHeaders": ["Content-Type", "Authorization"]
         }
     }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,9 +8,11 @@
             "name": "url-content-extractor-api",
             "version": "1.0.0",
             "dependencies": {
+                "@azure/data-tables": "^13.3.2",
                 "@azure/functions": "^4.0.0",
                 "@mozilla/readability": "^0.6.0",
                 "jsdom": "^22.1.0",
+                "uuid": "^14.0.0",
                 "web-link-collector": "^1.0.10"
             },
             "devDependencies": {
@@ -20,11 +22,133 @@
                 "typescript": "^5.3.3"
             }
         },
+        "node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+            "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-util": "^1.13.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-client": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+            "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-paging": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+            "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline": {
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+            "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
+                "@typespec/ts-http-runtime": "^0.3.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-tracing": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+            "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-util": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+            "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-xml": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+            "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+            "dependencies": {
+                "fast-xml-parser": "^5.5.9",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/data-tables": {
+            "version": "13.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.3.2.tgz",
+            "integrity": "sha512-PZ8e4SnCpTQEbQ1P+CK6NR7Vhb86Jw1S1qJi2IcF1ij4qiPX2b4vIemwNPkYg/gZGMqKbxkPvGRpRmEbBYdXuA==",
+            "dependencies": {
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.2",
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.0",
+                "@azure/core-tracing": "^1.2.0",
+                "@azure/core-util": "^1.11.0",
+                "@azure/core-xml": "^1.4.4",
+                "@azure/logger": "^1.1.4",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@azure/functions": {
             "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.0.tgz",
             "integrity": "sha512-y1caGX6LYrA7msAckQVb/quFOhWHSPiGzWfIML17t0ee2ydpinJTBF+Sti+URfLAH63dtmXJR4meraZkhhK9tw==",
-            "license": "MIT",
             "dependencies": {
                 "cookie": "^0.7.0",
                 "long": "^4.0.0",
@@ -34,39 +158,56 @@
                 "node": ">=18.0"
             }
         },
+        "node_modules/@azure/logger": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+            "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+            "dependencies": {
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@fastify/busboy": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
             "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/@mozilla/readability": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
             "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ]
+        },
         "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "license": "MIT",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@types/jsdom": {
             "version": "21.1.7",
-            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
             "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
@@ -78,7 +219,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
             "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -87,21 +227,73 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "dev": true
+        },
+        "node_modules/@types/yauzl": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "dev": true,
-            "license": "MIT"
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@typespec/ts-http-runtime": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+            "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-            "deprecated": "Use your platform's native atob() and btoa() methods instead",
-            "license": "BSD-3-Clause"
+            "deprecated": "Use your platform's native atob() and btoa() methods instead"
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "license": "MIT",
             "dependencies": {
                 "debug": "4"
             },
@@ -113,7 +305,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -122,7 +313,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -136,23 +326,19 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT"
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/azure-functions-core-tools": {
             "version": "4.0.7030",
-            "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.7030.tgz",
             "integrity": "sha512-rsnAH5jVfkZKj7L6vYyDC0lDi3MxkJrngIIBJVc24ygG5Yl339iCD2PkGYRZLaupzj67zirOllfT4vFf8BKq2A==",
             "dev": true,
             "hasInstallScript": true,
             "hasShrinkwrap": true,
-            "license": "MIT",
             "os": [
                 "win32",
                 "darwin",
@@ -174,72 +360,40 @@
                 "node": ">=6.9.1"
             }
         },
-        "node_modules/azure-functions-core-tools/node_modules/@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-            "dev": true
-        },
-        "node_modules/azure-functions-core-tools/node_modules/@types/node": {
-            "version": "18.15.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-            "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-            "dev": true,
-            "optional": true
-        },
-        "node_modules/azure-functions-core-tools/node_modules/@types/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+        "node_modules/azure-functions-core-tools/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
             "dependencies": {
+                "agent-base": "6",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 6"
             }
         },
-        "node_modules/azure-functions-core-tools/node_modules/ansi-styles": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
-            "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
-            "dev": true,
-            "dependencies": {
-                "@types/color-name": "^1.1.1",
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/balanced-match": {
+        "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
-        "node_modules/azure-functions-core-tools/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/azure-functions-core-tools/node_modules/buffer-crc32": {
+        "node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
@@ -248,7 +402,19 @@
                 "node": "*"
             }
         },
-        "node_modules/azure-functions-core-tools/node_modules/chalk": {
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/chalk": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
             "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
@@ -261,316 +427,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/azure-functions-core-tools/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/azure-functions-core-tools/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/extract-zip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "get-stream": "^5.1.0",
-                "yauzl": "^2.10.0"
-            },
-            "bin": {
-                "extract-zip": "cli.js"
-            },
-            "engines": {
-                "node": ">= 10.17.0"
-            },
-            "optionalDependencies": {
-                "@types/yauzl": "^2.9.1"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-            "dev": true,
-            "dependencies": {
-                "pend": "~1.2.0"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/azure-functions-core-tools/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dev": true,
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/glob": {
-            "version": "9.3.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "minimatch": "^8.0.2",
-                "minipass": "^4.2.4",
-                "path-scurry": "^1.6.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/azure-functions-core-tools/node_modules/minimatch": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/minipass": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/azure-functions-core-tools/node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/path-scurry/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "dev": true
-        },
-        "node_modules/azure-functions-core-tools/node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/rimraf": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-            "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^9.2.0"
-            },
-            "bin": {
-                "rimraf": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/supports-color": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-            "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/azure-functions-core-tools/node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
-        },
-        "node_modules/azure-functions-core-tools/node_modules/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-            "dev": true,
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
-            }
-        },
-        "node_modules/boolbase": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "license": "ISC"
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/cheerio": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
             "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
-            "license": "MIT",
             "dependencies": {
                 "cheerio-select": "^2.1.0",
                 "dom-serializer": "^2.0.0",
@@ -595,7 +455,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
             "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-select": "^5.1.0",
@@ -609,10 +468,9 @@
             }
         },
         "node_modules/cheerio/node_modules/undici": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
-            "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
-            "license": "MIT",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
             "engines": {
                 "node": ">=20.18.1"
             }
@@ -621,7 +479,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
             "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
@@ -630,7 +487,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -644,7 +500,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -655,14 +510,12 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "license": "MIT"
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -674,7 +527,6 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -683,7 +535,6 @@
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
             "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.1.0",
@@ -699,7 +550,6 @@
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
             "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
             },
@@ -711,7 +561,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
             "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
-            "license": "MIT",
             "dependencies": {
                 "rrweb-cssom": "^0.6.0"
             },
@@ -723,7 +572,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
             "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
-            "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -737,7 +585,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
             "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -753,14 +600,12 @@
         "node_modules/decimal.js": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-            "license": "MIT"
+            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -769,7 +614,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -783,7 +627,6 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -800,15 +643,13 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/fb55"
                 }
-            ],
-            "license": "BSD-2-Clause"
+            ]
         },
         "node_modules/domexception": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
             "deprecated": "Use your platform's native DOMException instead",
-            "license": "MIT",
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -820,7 +661,6 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -835,7 +675,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
             "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -849,7 +688,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -862,14 +700,12 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/encoding-sniffer": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
             "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-            "license": "MIT",
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "whatwg-encoding": "^3.1.1"
@@ -882,7 +718,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "license": "MIT",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -890,11 +726,19 @@
                 "node": ">=18"
             }
         },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
         "node_modules/entities": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
             "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -906,7 +750,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -915,16 +758,14 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -936,7 +777,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -951,16 +791,79 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "bin": {
+                "extract-zip": "cli.js"
+            },
+            "engines": {
+                "node": ">= 10.17.0"
+            },
+            "optionalDependencies": {
+                "@types/yauzl": "^2.9.1"
+            }
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+            "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.2.0",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.3.0",
+                "xml-naming": "^0.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "dev": true,
+            "dependencies": {
+                "pend": "~1.2.0"
             }
         },
         "node_modules/form-data": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
             "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -972,11 +875,16 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -985,7 +893,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -994,7 +901,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -1018,7 +924,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -1027,11 +932,44 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dev": true,
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/glob": {
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "minimatch": "^8.0.2",
+                "minipass": "^4.2.4",
+                "path-scurry": "^1.6.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1039,11 +977,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/has-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1055,7 +1001,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -1067,10 +1012,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -1082,7 +1026,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-            "license": "MIT",
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -1091,9 +1034,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-            "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+            "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -1101,19 +1044,28 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
-                "domutils": "^3.2.1",
-                "entities": "^6.0.0"
+                "domutils": "^3.2.2",
+                "entities": "^7.0.1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/http-proxy-agent": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "license": "MIT",
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -1127,7 +1079,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "license": "MIT",
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -1140,7 +1091,6 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -1152,7 +1102,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -1160,14 +1109,12 @@
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-            "license": "MIT"
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "license": "MIT",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -1177,9 +1124,7 @@
         },
         "node_modules/jsdom": {
             "version": "22.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
             "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
-            "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.6",
                 "cssstyle": "^3.0.0",
@@ -1220,14 +1165,18 @@
         "node_modules/long": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -1236,7 +1185,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1245,7 +1193,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -1253,17 +1200,39 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/minimatch": {
+            "version": "8.0.7",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+            "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -1274,14 +1243,21 @@
         "node_modules/nwsapi": {
             "version": "2.2.20",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
-            "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
-            "license": "MIT"
+            "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA=="
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
         },
         "node_modules/p-limit": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
             "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
-            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^1.1.1"
             },
@@ -1296,7 +1272,6 @@
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
             "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-            "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
             },
@@ -1308,7 +1283,6 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
             "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-            "license": "MIT",
             "dependencies": {
                 "domhandler": "^5.0.3",
                 "parse5": "^7.0.0"
@@ -1321,7 +1295,6 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
             "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-            "license": "MIT",
             "dependencies": {
                 "parse5": "^7.0.0"
             },
@@ -1329,11 +1302,64 @@
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true
+        },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/psl": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -1341,11 +1367,20 @@
                 "url": "https://github.com/sponsors/lupomontero"
             }
         },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "dev": true,
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -1353,14 +1388,12 @@
         "node_modules/querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "license": "MIT"
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1368,26 +1401,40 @@
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-            "license": "MIT"
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+        },
+        "node_modules/rimraf": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+            "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^9.2.0"
+            },
+            "bin": {
+                "rimraf": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/rrweb-cssom": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-            "license": "MIT"
+            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "license": "MIT"
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-            "license": "ISC",
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -1399,7 +1446,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -1413,9 +1459,31 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strnum": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+            "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ]
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -1424,14 +1492,12 @@
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-            "license": "MIT"
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "node_modules/tough-cookie": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
             "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -1446,7 +1512,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
             "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-            "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.0"
             },
@@ -1454,12 +1519,15 @@
                 "node": ">=14"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        },
         "node_modules/typescript": {
             "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -1472,7 +1540,6 @@
             "version": "5.29.0",
             "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
             "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },
@@ -1484,14 +1551,12 @@
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -1500,17 +1565,27 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "license": "MIT",
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/w3c-xmlserializer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-            "license": "MIT",
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -1520,9 +1595,7 @@
         },
         "node_modules/web-link-collector": {
             "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/web-link-collector/-/web-link-collector-1.0.10.tgz",
             "integrity": "sha512-dzfW2Ck2/hR8g16HGqUywUIowtPFsSv0W05LO6EUqSF5mI2xQUMAi2NpDbw3QWjlw6ktuZustyx5OG9212jgXQ==",
-            "license": "MIT",
             "dependencies": {
                 "cheerio": "^1.0.0-rc.12",
                 "js-yaml": "^4.1.0",
@@ -1541,7 +1614,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
             }
@@ -1550,7 +1622,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-            "license": "MIT",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -1562,7 +1634,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -1571,7 +1642,6 @@
             "version": "12.0.1",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
             "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-            "license": "MIT",
             "dependencies": {
                 "tr46": "^4.1.1",
                 "webidl-conversions": "^7.0.0"
@@ -1584,7 +1654,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -1597,11 +1666,16 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
+        },
         "node_modules/ws": {
             "version": "8.18.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
             "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -1622,22 +1696,33 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
             "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "license": "MIT"
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
@@ -1646,7 +1731,6 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -1664,16 +1748,24 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
         },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "dev": true,
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
+        },
         "node_modules/yocto-queue": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-            "license": "MIT",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
             "engines": {
                 "node": ">=12.20"
             },

--- a/api/package.json
+++ b/api/package.json
@@ -11,9 +11,11 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
+        "@azure/data-tables": "^13.3.2",
         "@azure/functions": "^4.0.0",
         "@mozilla/readability": "^0.6.0",
         "jsdom": "^22.1.0",
+        "uuid": "^14.0.0",
         "web-link-collector": "^1.0.10"
     },
     "devDependencies": {

--- a/api/src/functions/sansuAdminPinReset.ts
+++ b/api/src/functions/sansuAdminPinReset.ts
@@ -1,0 +1,48 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+import { requireAuthenticated } from '../shared/swaAuth';
+import { USERS_PARTITION, usersTable } from '../shared/tableClient';
+
+app.http('sansuAdminPinReset', {
+  methods: ['PATCH'],
+  authLevel: 'anonymous',
+  route: 'sansu/admin/users/{userId}/pin',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const principal = requireAuthenticated(req);
+    if (!principal) {
+      return { status: 401, jsonBody: { error: 'unauthorized' } };
+    }
+    const userId = req.params.userId;
+    if (!userId) {
+      return { status: 400, jsonBody: { error: 'userId required' } };
+    }
+    try {
+      const body = (await req.json()) as {
+        pinHash?: string;
+        pinSalt?: string;
+      };
+      if (!body.pinHash || !body.pinSalt) {
+        return { status: 400, jsonBody: { error: 'missing fields' } };
+      }
+      const table = await usersTable();
+      await table.updateEntity(
+        {
+          partitionKey: USERS_PARTITION,
+          rowKey: userId,
+          pinHash: body.pinHash,
+          pinSalt: body.pinSalt,
+          pinResetAt: Date.now(),
+          pinResetBy: principal.userDetails ?? principal.userId,
+        },
+        'Merge'
+      );
+      return { status: 200, jsonBody: { ok: true } };
+    } catch (e) {
+      context.error('sansuAdminPinReset error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});

--- a/api/src/functions/sansuAdminSummary.ts
+++ b/api/src/functions/sansuAdminSummary.ts
@@ -1,0 +1,48 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+import { type SansuSessionEntity, type SansuUserEntity } from '../shared/sansuTypes';
+import { requireAuthenticated } from '../shared/swaAuth';
+import {
+  sessionsTable,
+  USERS_PARTITION,
+  usersTable,
+} from '../shared/tableClient';
+
+app.http('sansuAdminSummary', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'sansu/admin/summary',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    if (!requireAuthenticated(req)) {
+      return { status: 401, jsonBody: { error: 'unauthorized' } };
+    }
+    try {
+      const uTable = await usersTable();
+      let totalUsers = 0;
+      for await (const _u of uTable.listEntities<SansuUserEntity>({
+        queryOptions: { filter: `PartitionKey eq '${USERS_PARTITION}'` },
+      })) {
+        void _u;
+        totalUsers++;
+      }
+      const sTable = await sessionsTable();
+      let totalSessions = 0;
+      const sessionsByDate: Record<string, number> = {};
+      for await (const s of sTable.listEntities<SansuSessionEntity>({})) {
+        totalSessions++;
+        const day = new Date(s.completedAt).toISOString().slice(0, 10);
+        sessionsByDate[day] = (sessionsByDate[day] ?? 0) + 1;
+      }
+      return {
+        status: 200,
+        jsonBody: { totalUsers, totalSessions, sessionsByDate },
+      };
+    } catch (e) {
+      context.error('sansuAdminSummary error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});

--- a/api/src/functions/sansuAdminUsers.ts
+++ b/api/src/functions/sansuAdminUsers.ts
@@ -1,0 +1,37 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+import {
+  type SansuUserEntity,
+  toPublic,
+} from '../shared/sansuTypes';
+import { requireAuthenticated } from '../shared/swaAuth';
+import { USERS_PARTITION, usersTable } from '../shared/tableClient';
+
+app.http('sansuAdminUsers', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'sansu/admin/users',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    if (!requireAuthenticated(req)) {
+      return { status: 401, jsonBody: { error: 'unauthorized' } };
+    }
+    try {
+      const table = await usersTable();
+      const iter = table.listEntities<SansuUserEntity>({
+        queryOptions: { filter: `PartitionKey eq '${USERS_PARTITION}'` },
+      });
+      const users = [];
+      for await (const e of iter) {
+        users.push(toPublic(e));
+      }
+      users.sort((a, b) => b.lastPlayedAt - a.lastPlayedAt);
+      return { status: 200, jsonBody: users };
+    } catch (e) {
+      context.error('sansuAdminUsers error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});

--- a/api/src/functions/sansuSessions.ts
+++ b/api/src/functions/sansuSessions.ts
@@ -1,0 +1,146 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+import {
+  type SansuSession,
+  type SansuSessionEntity,
+  type SansuUserEntity,
+  toPublic,
+} from '../shared/sansuTypes';
+import {
+  reverseTimestamp,
+  sessionsTable,
+  USERS_PARTITION,
+  usersTable,
+} from '../shared/tableClient';
+
+app.http('sansuSessionsPost', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  route: 'sansu/sessions',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    try {
+      const body = (await req.json()) as SansuSession;
+      if (!body.id || !body.userId) {
+        return { status: 400, jsonBody: { error: 'missing fields' } };
+      }
+      const sTable = await sessionsTable();
+      const entity: SansuSessionEntity = {
+        partitionKey: body.userId,
+        rowKey: `${reverseTimestamp(body.completedAt)}_${body.id}`,
+        id: body.id,
+        userName: body.userName,
+        levelStr: String(body.level),
+        operation: body.operation,
+        isDaily: body.isDaily,
+        startedAt: body.startedAt,
+        completedAt: body.completedAt,
+        durationMs: body.durationMs,
+        totalProblems: body.totalProblems,
+        correctCount: body.correctCount,
+        pointsEarned: body.pointsEarned,
+        newBadgesJson: JSON.stringify(body.newBadges ?? []),
+      };
+      try {
+        await sTable.createEntity(entity);
+      } catch (e) {
+        if ((e as { statusCode?: number }).statusCode !== 409) {
+          throw e;
+        }
+      }
+
+      // Update user aggregates
+      const uTable = await usersTable();
+      try {
+        const user = await uTable.getEntity<SansuUserEntity>(
+          USERS_PARTITION,
+          body.userId
+        );
+        const badges = new Set<string>([
+          ...JSON.parse(user.earnedBadgesJson) as string[],
+          ...(body.newBadges ?? []),
+        ]);
+        const best = JSON.parse(user.bestTimesJson) as Record<string, number>;
+        const key = `lv${body.level}:${body.operation}`;
+        const isPerfect = body.correctCount === body.totalProblems;
+        if (isPerfect && (!best[key] || body.durationMs < best[key])) {
+          best[key] = body.durationMs;
+        }
+        const updated: Partial<SansuUserEntity> & {
+          partitionKey: string;
+          rowKey: string;
+        } = {
+          partitionKey: USERS_PARTITION,
+          rowKey: body.userId,
+          totalPoints: user.totalPoints + body.pointsEarned,
+          totalSessions: user.totalSessions + 1,
+          earnedBadgesJson: JSON.stringify(Array.from(badges)),
+          bestTimesJson: JSON.stringify(best),
+          lastPlayedAt: body.completedAt,
+          lastPlayedDate: new Date(body.completedAt)
+            .toISOString()
+            .slice(0, 10),
+        };
+        await uTable.updateEntity(updated, 'Merge');
+      } catch (e) {
+        context.warn('User aggregate update failed', e);
+      }
+
+      return { status: 201, jsonBody: { ok: true } };
+    } catch (e) {
+      context.error('sansuSessionsPost error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});
+
+app.http('sansuSessionsGet', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'sansu/sessions',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const userId = req.query.get('userId');
+    if (!userId) return { status: 400, jsonBody: { error: 'userId required' } };
+    try {
+      const table = await sessionsTable();
+      const iter = table.listEntities<SansuSessionEntity>({
+        queryOptions: {
+          filter: `PartitionKey eq '${userId.replace(/'/g, "''")}'`,
+        },
+      });
+      const sessions: SansuSession[] = [];
+      for await (const e of iter) {
+        sessions.push({
+          id: e.id,
+          userId,
+          userName: e.userName,
+          level: /^\d+$/.test(e.levelStr) ? Number(e.levelStr) : 'mix',
+          operation: e.operation as SansuSession['operation'],
+          isDaily: e.isDaily,
+          startedAt: e.startedAt,
+          completedAt: e.completedAt,
+          durationMs: e.durationMs,
+          totalProblems: e.totalProblems,
+          correctCount: e.correctCount,
+          pointsEarned: e.pointsEarned,
+          newBadges: JSON.parse(e.newBadgesJson),
+        });
+        if (sessions.length >= 200) break;
+      }
+      // already sorted descending due to reversed timestamp rowKey
+      sessions.reverse(); // return ascending chronological for charts
+      return { status: 200, jsonBody: sessions };
+    } catch (e) {
+      context.error('sansuSessionsGet error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});
+
+// Suppress unused export lint
+void toPublic;

--- a/api/src/functions/sansuUsers.ts
+++ b/api/src/functions/sansuUsers.ts
@@ -1,0 +1,154 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  type SansuUserEntity,
+  toPublic,
+} from '../shared/sansuTypes';
+import { USERS_PARTITION, usersTable } from '../shared/tableClient';
+
+app.http('sansuUsersGet', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'sansu/users',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const name = req.query.get('name');
+    const userId = req.query.get('userId');
+    try {
+      const table = await usersTable();
+      if (userId) {
+        try {
+          const entity = await table.getEntity<SansuUserEntity>(
+            USERS_PARTITION,
+            userId
+          );
+          return { status: 200, jsonBody: toPublic(entity) };
+        } catch (e) {
+          if ((e as { statusCode?: number }).statusCode === 404) {
+            return { status: 404, jsonBody: { error: 'not found' } };
+          }
+          throw e;
+        }
+      }
+      if (name) {
+        const iter = table.listEntities<SansuUserEntity>({
+          queryOptions: {
+            filter: `PartitionKey eq '${USERS_PARTITION}' and name eq '${name.replace(/'/g, "''")}'`,
+          },
+        });
+        for await (const entity of iter) {
+          return { status: 200, jsonBody: toPublic(entity) };
+        }
+        return { status: 404, jsonBody: { error: 'not found' } };
+      }
+      return { status: 400, jsonBody: { error: 'name or userId required' } };
+    } catch (e) {
+      context.error('sansuUsersGet error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});
+
+app.http('sansuUsersCreate', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  route: 'sansu/users',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    try {
+      const body = (await req.json()) as {
+        name?: string;
+        avatar?: string;
+        themeColor?: string;
+        pinHash?: string;
+        pinSalt?: string;
+      };
+      if (
+        !body.name ||
+        !body.avatar ||
+        !body.themeColor ||
+        !body.pinHash ||
+        !body.pinSalt
+      ) {
+        return { status: 400, jsonBody: { error: 'missing fields' } };
+      }
+
+      const table = await usersTable();
+      const id = body.pinSalt; // client passes a UUID as salt to use as user ID
+      const now = Date.now();
+      const entity: SansuUserEntity = {
+        partitionKey: USERS_PARTITION,
+        rowKey: id,
+        name: body.name.slice(0, 24),
+        avatar: body.avatar,
+        themeColor: body.themeColor,
+        createdAt: now,
+        totalPoints: 0,
+        earnedBadgesJson: '[]',
+        bestTimesJson: '{}',
+        currentStreakDays: 0,
+        lastPlayedDate: '',
+        lastPlayedAt: 0,
+        totalSessions: 0,
+        pinHash: body.pinHash,
+        pinSalt: body.pinSalt,
+      };
+      try {
+        await table.createEntity(entity);
+      } catch (e) {
+        if ((e as { statusCode?: number }).statusCode === 409) {
+          return { status: 409, jsonBody: { error: 'user already exists' } };
+        }
+        throw e;
+      }
+      return { status: 201, jsonBody: toPublic(entity) };
+    } catch (e) {
+      context.error('sansuUsersCreate error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});
+
+app.http('sansuUsersVerify', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  route: 'sansu/users/verify',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    try {
+      const body = (await req.json()) as { userId?: string; pinHash?: string };
+      if (!body.userId || !body.pinHash) {
+        return { status: 400, jsonBody: { error: 'missing fields' } };
+      }
+      const table = await usersTable();
+      try {
+        const entity = await table.getEntity<SansuUserEntity>(
+          USERS_PARTITION,
+          body.userId
+        );
+        if (entity.pinHash !== body.pinHash) {
+          return { status: 200, jsonBody: { ok: false } };
+        }
+        return { status: 200, jsonBody: { ok: true, user: toPublic(entity) } };
+      } catch (e) {
+        if ((e as { statusCode?: number }).statusCode === 404) {
+          return { status: 404, jsonBody: { ok: false, error: 'not found' } };
+        }
+        throw e;
+      }
+    } catch (e) {
+      context.error('sansuUsersVerify error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});
+
+// Helper export (not a function) for re-use
+export const _uuid = uuidv4;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,11 @@ import { app } from '@azure/functions';
 // 全ての関数をインポート
 import './functions/extractContent';
 import './functions/collectLinks';
+import './functions/sansuUsers';
+import './functions/sansuSessions';
+import './functions/sansuAdminUsers';
+import './functions/sansuAdminPinReset';
+import './functions/sansuAdminSummary';
 
 // 明示的なエクスポート
 export { app };

--- a/api/src/shared/sansuTypes.ts
+++ b/api/src/shared/sansuTypes.ts
@@ -1,0 +1,105 @@
+export type SansuUserPublic = {
+  id: string;
+  name: string;
+  avatar: string;
+  themeColor: string;
+  createdAt: number;
+  totalPoints: number;
+  earnedBadges: string[];
+  bestTimesByLevel: Record<string, number>;
+  currentStreakDays: number;
+  lastPlayedDate: string;
+  lastPlayedAt: number;
+  totalSessions: number;
+  pinResetAt?: number;
+  pinResetBy?: string;
+};
+
+export type SansuUserEntity = {
+  partitionKey: string;
+  rowKey: string;
+  name: string;
+  avatar: string;
+  themeColor: string;
+  createdAt: number;
+  totalPoints: number;
+  earnedBadgesJson: string;
+  bestTimesJson: string;
+  currentStreakDays: number;
+  lastPlayedDate: string;
+  lastPlayedAt: number;
+  totalSessions: number;
+  pinHash: string;
+  pinSalt: string;
+  pinResetAt?: number;
+  pinResetBy?: string;
+};
+
+export function toPublic(e: SansuUserEntity): SansuUserPublic {
+  return {
+    id: e.rowKey,
+    name: e.name,
+    avatar: e.avatar,
+    themeColor: e.themeColor,
+    createdAt: e.createdAt,
+    totalPoints: e.totalPoints,
+    earnedBadges: safeParseArray(e.earnedBadgesJson),
+    bestTimesByLevel: safeParseObject(e.bestTimesJson),
+    currentStreakDays: e.currentStreakDays,
+    lastPlayedDate: e.lastPlayedDate,
+    lastPlayedAt: e.lastPlayedAt,
+    totalSessions: e.totalSessions,
+    pinResetAt: e.pinResetAt,
+    pinResetBy: e.pinResetBy,
+  };
+}
+
+function safeParseArray(s: string): string[] {
+  try {
+    return Array.isArray(JSON.parse(s)) ? JSON.parse(s) : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeParseObject(s: string): Record<string, number> {
+  try {
+    const v = JSON.parse(s);
+    return typeof v === 'object' && v !== null ? v : {};
+  } catch {
+    return {};
+  }
+}
+
+export type SansuSession = {
+  id: string;
+  userId: string;
+  userName: string;
+  level: number | 'mix';
+  operation: 'add' | 'sub' | 'mul' | 'div' | 'mixed';
+  isDaily: boolean;
+  startedAt: number;
+  completedAt: number;
+  durationMs: number;
+  totalProblems: number;
+  correctCount: number;
+  pointsEarned: number;
+  newBadges: string[];
+};
+
+export type SansuSessionEntity = {
+  partitionKey: string;
+  rowKey: string;
+  id: string;
+  userName: string;
+  levelStr: string;
+  operation: string;
+  isDaily: boolean;
+  startedAt: number;
+  completedAt: number;
+  durationMs: number;
+  totalProblems: number;
+  correctCount: number;
+  pointsEarned: number;
+  newBadgesJson: string;
+};

--- a/api/src/shared/swaAuth.ts
+++ b/api/src/shared/swaAuth.ts
@@ -1,0 +1,30 @@
+import type { HttpRequest } from '@azure/functions';
+
+export type ClientPrincipal = {
+  userId: string;
+  userRoles: string[];
+  identityProvider: string;
+  userDetails: string;
+};
+
+export function parseClientPrincipal(
+  request: HttpRequest
+): ClientPrincipal | null {
+  const header = request.headers.get('x-ms-client-principal');
+  if (!header) return null;
+  try {
+    const decoded = Buffer.from(header, 'base64').toString('utf-8');
+    return JSON.parse(decoded) as ClientPrincipal;
+  } catch {
+    return null;
+  }
+}
+
+export function requireAuthenticated(
+  request: HttpRequest
+): ClientPrincipal | null {
+  const principal = parseClientPrincipal(request);
+  if (!principal) return null;
+  if (!principal.userRoles?.includes('authenticated')) return null;
+  return principal;
+}

--- a/api/src/shared/tableClient.ts
+++ b/api/src/shared/tableClient.ts
@@ -1,0 +1,51 @@
+import { TableClient, TableServiceClient } from '@azure/data-tables';
+
+const CONNECTION =
+  process.env.SANSU_STORAGE_CONNECTION ??
+  process.env.AzureWebJobsStorage ??
+  'UseDevelopmentStorage=true';
+
+const TABLE_USERS = 'SansuUsers';
+const TABLE_SESSIONS = 'SansuSessions';
+
+let ensured = false;
+
+async function ensureTables(): Promise<void> {
+  if (ensured) return;
+  const svc = TableServiceClient.fromConnectionString(CONNECTION, {
+    allowInsecureConnection: CONNECTION.includes('UseDevelopmentStorage'),
+  });
+  for (const table of [TABLE_USERS, TABLE_SESSIONS]) {
+    try {
+      await svc.createTable(table);
+    } catch (e) {
+      // ignore if already exists
+      const status = (e as { statusCode?: number }).statusCode;
+      if (status && status !== 409) {
+        throw e;
+      }
+    }
+  }
+  ensured = true;
+}
+
+export async function usersTable(): Promise<TableClient> {
+  await ensureTables();
+  return TableClient.fromConnectionString(CONNECTION, TABLE_USERS, {
+    allowInsecureConnection: CONNECTION.includes('UseDevelopmentStorage'),
+  });
+}
+
+export async function sessionsTable(): Promise<TableClient> {
+  await ensureTables();
+  return TableClient.fromConnectionString(CONNECTION, TABLE_SESSIONS, {
+    allowInsecureConnection: CONNECTION.includes('UseDevelopmentStorage'),
+  });
+}
+
+export const USERS_PARTITION = 'v1';
+
+export function reverseTimestamp(ts: number): string {
+  const max = 99999999999999;
+  return String(max - ts).padStart(14, '0');
+}

--- a/app/authenticated/sansu-100-admin/page.tsx
+++ b/app/authenticated/sansu-100-admin/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import Link from 'next/link';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import { sansuAdminApi, type AdminUserSummary } from '../../sansu-100/lib/api-client';
+
+type Summary = {
+  totalUsers: number;
+  totalSessions: number;
+  sessionsByDate: Record<string, number>;
+};
+
+export default function SansuAdminHome(): React.JSX.Element {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [users, setUsers] = useState<AdminUserSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([sansuAdminApi.getSummary(), sansuAdminApi.listUsers()])
+      .then(([s, u]) => {
+        setSummary(s);
+        setUsers(u);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'エラー'));
+  }, []);
+
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+        <Header
+          title="📋 100マス計算 管理画面"
+          description="練習状況の把握とユーザー管理"
+          showBackButton
+        />
+
+        {error ? (
+          <p className="rounded-lg bg-red-100 p-3 text-sm text-red-700 dark:bg-red-900/40 dark:text-red-300">
+            {error}
+          </p>
+        ) : null}
+
+        {summary ? (
+          <section className="grid grid-cols-3 gap-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <Stat label="ユーザー数" value={String(summary.totalUsers)} />
+            <Stat label="累計セッション" value={String(summary.totalSessions)} />
+            <Stat
+              label="本日"
+              value={String(
+                summary.sessionsByDate[new Date().toISOString().slice(0, 10)] ??
+                  0
+              )}
+            />
+          </section>
+        ) : null}
+
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            👥 ユーザー一覧
+          </h2>
+          {users === null ? (
+            <p className="text-gray-600 dark:text-gray-400">読み込み中...</p>
+          ) : users.length === 0 ? (
+            <p className="text-gray-600 dark:text-gray-400">
+              まだユーザーが登録されていません
+            </p>
+          ) : (
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {users.map((u) => (
+                <li key={u.id}>
+                  <Link
+                    href={`/authenticated/sansu-100-admin/user?userId=${encodeURIComponent(u.id)}`}
+                    className="block rounded-xl border border-gray-200 bg-gray-50 p-4 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-5xl">{u.avatar}</span>
+                      <div className="flex-1">
+                        <h3 className="font-bold text-gray-900 dark:text-gray-100">
+                          {u.name}
+                        </h3>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          色: {u.themeColor} / 作成日:{' '}
+                          {new Date(u.createdAt).toLocaleDateString('ja-JP')}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          練習 {u.totalSessions}回 / バッジ{' '}
+                          {u.earnedBadges.length}個
+                        </p>
+                        {u.lastPlayedAt > 0 ? (
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            最終練習:{' '}
+                            {new Date(u.lastPlayedAt).toLocaleString('ja-JP', {
+                              month: '2-digit',
+                              day: '2-digit',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-gray-100 p-3 text-center dark:bg-gray-700">
+      <p className="text-xs text-gray-600 dark:text-gray-400">{label}</p>
+      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/app/authenticated/sansu-100-admin/user/page.tsx
+++ b/app/authenticated/sansu-100-admin/user/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import React, { Suspense, useEffect, useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import PinPad from '../../../sansu-100/components/PinPad';
+import { formatDuration } from '../../../sansu-100/components/SessionTimer';
+import {
+  sansuAdminApi,
+  sansuApi,
+  type AdminUserSummary,
+} from '../../../sansu-100/lib/api-client';
+import { hashPin } from '../../../sansu-100/lib/pin-hash';
+import type { SansuSession } from '../../../sansu-100/lib/types';
+
+function UserDetailInner(): React.JSX.Element {
+  const router = useRouter();
+  const params = useSearchParams();
+  const userId = params.get('userId') ?? '';
+
+  const [user, setUser] = useState<AdminUserSummary | null>(null);
+  const [sessions, setSessions] = useState<SansuSession[]>([]);
+  const [showReset, setShowReset] = useState(false);
+  const [newPin, setNewPin] = useState('');
+  const [resetError, setResetError] = useState<string | null>(null);
+  const [resetSuccess, setResetSuccess] = useState(false);
+  const [showAvatarReminder, setShowAvatarReminder] = useState(false);
+
+  useEffect(() => {
+    if (!userId) {
+      router.replace('/authenticated/sansu-100-admin');
+      return;
+    }
+    sansuAdminApi
+      .listUsers()
+      .then((list) => {
+        const u = list.find((x) => x.id === userId);
+        if (!u) {
+          router.replace('/authenticated/sansu-100-admin');
+          return;
+        }
+        setUser(u);
+      })
+      .catch(console.error);
+    sansuApi.getSessions(userId).then(setSessions).catch(console.error);
+  }, [userId, router]);
+
+  const handleReset = async (pinValue: string = newPin) => {
+    if (!user || pinValue.length !== 4) return;
+    setResetError(null);
+    try {
+      const hash = await hashPin(pinValue, user.id);
+      await sansuAdminApi.resetPin(user.id, hash, user.id);
+      setResetSuccess(true);
+      setShowReset(false);
+      setNewPin('');
+    } catch (e) {
+      setResetError(e instanceof Error ? e.message : 'エラー');
+    }
+  };
+
+  if (!user) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <Header
+          title={`${user.avatar} ${user.name}`}
+          description="ユーザー詳細・リカバリー操作"
+          showBackButton
+        />
+
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <div className="flex items-center gap-4">
+            <span className="text-7xl">{user.avatar}</span>
+            <div className="flex-1 text-sm text-gray-700 dark:text-gray-300">
+              <p>
+                <strong>名前:</strong> {user.name}
+              </p>
+              <p>
+                <strong>テーマカラー:</strong> {user.themeColor}
+              </p>
+              <p>
+                <strong>作成日時:</strong>{' '}
+                {new Date(user.createdAt).toLocaleString('ja-JP')}
+              </p>
+              <p>
+                <strong>最終練習:</strong>{' '}
+                {user.lastPlayedAt > 0
+                  ? new Date(user.lastPlayedAt).toLocaleString('ja-JP')
+                  : '—'}
+              </p>
+              <p>
+                <strong>累計:</strong> {user.totalSessions}回 /{' '}
+                {user.totalPoints}pt / バッジ {user.earnedBadges.length}個
+              </p>
+              {user.pinResetAt ? (
+                <p className="text-amber-700 dark:text-amber-300">
+                  <strong>最終PINリセット:</strong>{' '}
+                  {new Date(user.pinResetAt).toLocaleString('ja-JP')}（
+                  {user.pinResetBy ?? 'admin'}）
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 border-t border-gray-200 pt-4 dark:border-gray-700 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => setShowAvatarReminder(true)}
+              className="flex-1 rounded-lg bg-blue-100 px-4 py-3 font-bold text-blue-900 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-200 dark:hover:bg-blue-900/60"
+            >
+              🪞 アバターを教える
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowReset(true);
+                setResetSuccess(false);
+                setResetError(null);
+                setNewPin('');
+              }}
+              className="flex-1 rounded-lg bg-amber-500 px-4 py-3 font-bold text-white hover:bg-amber-600"
+            >
+              🔑 PIN を再設定
+            </button>
+          </div>
+
+          {resetSuccess ? (
+            <div className="rounded-lg bg-green-100 p-3 text-sm text-green-800 dark:bg-green-900/40 dark:text-green-200">
+              ✅ PIN を新しく設定しました。お子さんに新しい4桁の番号を伝えてください。
+            </div>
+          ) : null}
+        </section>
+
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            🕒 最近の練習
+          </h2>
+          {sessions.length === 0 ? (
+            <p className="text-gray-600 dark:text-gray-400">記録なし</p>
+          ) : (
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+              {sessions
+                .slice(-15)
+                .reverse()
+                .map((s) => (
+                  <li
+                    key={s.id}
+                    className="flex items-center justify-between py-2 text-sm"
+                  >
+                    <span className="text-gray-600 dark:text-gray-400">
+                      {new Date(s.completedAt).toLocaleString('ja-JP', {
+                        month: '2-digit',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                    <span className="font-mono font-semibold text-gray-900 dark:text-gray-100">
+                      Lv.{s.level} {s.operation} ・{' '}
+                      {formatDuration(s.durationMs)} ・ {s.correctCount}/
+                      {s.totalProblems}
+                    </span>
+                  </li>
+                ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      {showAvatarReminder ? (
+        <button
+          type="button"
+          className="fixed inset-0 z-50 flex w-full items-center justify-center bg-black/70 p-4"
+          onClick={() => setShowAvatarReminder(false)}
+          aria-label="アバター表示を閉じる"
+        >
+          <div className="flex flex-col items-center gap-4 rounded-3xl bg-white p-10 shadow-2xl dark:bg-gray-800">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              この子のアバターはこれ
+            </p>
+            <span className="text-9xl">{user.avatar}</span>
+            <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+              {user.name}
+            </p>
+            <p className="rounded-lg bg-blue-600 px-6 py-2 font-bold text-white">
+              タップで閉じる
+            </p>
+          </div>
+        </button>
+      ) : null}
+
+      {showReset ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm space-y-4 rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800">
+            <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+              新しいPINを設定
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              お子さんに伝える 4桁の番号を入力してください
+            </p>
+            <PinPad
+              value={newPin}
+              onChange={setNewPin}
+              onSubmit={handleReset}
+              error={resetError}
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowReset(false)}
+                className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                やめる
+              </button>
+              <button
+                type="button"
+                disabled={newPin.length !== 4}
+                onClick={() => handleReset()}
+                className="flex-1 rounded-lg bg-amber-600 px-4 py-2 font-bold text-white hover:bg-amber-700 disabled:bg-gray-400"
+              >
+                設定する
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}
+
+export default function AdminUserDetailPage(): React.JSX.Element {
+  return (
+    <Suspense fallback={<main className="p-8" />}>
+      <UserDetailInner />
+    </Suspense>
+  );
+}

--- a/app/components/app-selector.tsx
+++ b/app/components/app-selector.tsx
@@ -34,6 +34,13 @@ const apps: AppOption[] = [
     icon: '🔗',
     color: 'bg-purple-500 hover:bg-purple-600',
   },
+  {
+    title: '100マス計算',
+    description: 'たし算・ひき算・かけ算・わり算を100問。タイム・バッジ・グラフでゲーミフィケーション',
+    href: '/sansu-100',
+    icon: '🧮',
+    color: 'bg-orange-500 hover:bg-orange-600',
+  },
 ];
 
 export default function AppSelector(): React.JSX.Element {

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -6,23 +6,28 @@ interface HeaderProps {
   title?: string;
   description?: string;
   showBackButton?: boolean;
+  backHref?: string;
+  backLabel?: string;
 }
 
-export default function Header({ 
-  title, 
-  description, 
-  showBackButton = false
+export default function Header({
+  title,
+  description,
+  showBackButton = false,
+  backHref = '/',
+  backLabel,
 }: HeaderProps = {}): React.JSX.Element {
+  const label = backLabel ?? (backHref === '/' ? 'アプリ選択に戻る' : 'もどる');
   return (
     <header className="w-full max-w-3xl">
       {showBackButton ? (
         <div className="mb-4">
-          <Link 
-            href="/" 
+          <Link
+            href={backHref}
             className="inline-flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
             data-testid="back-to-home"
           >
-            ← アプリ選択に戻る
+            ← {label}
           </Link>
         </div>
       ) : null}

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -1,72 +1,72 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+
+type Theme = 'dark' | 'light';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const saved = window.localStorage.getItem('theme');
+  if (saved === 'dark' || saved === 'light') return saved;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+function applyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') return;
+  if (theme === 'dark') document.documentElement.classList.add('dark');
+  else document.documentElement.classList.remove('dark');
+}
 
 export default function ThemeToggle(): React.JSX.Element {
-  const [isDark, setIsDark] = useState(false);
+  const [theme, setTheme] = useState<Theme>('light');
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    const initial = getInitialTheme();
+    setTheme(initial);
+    applyTheme(initial);
     setMounted(true);
-    
-    // 現在のテーマ状態を確認（DOMの実際の状態を基準に）
-    const currentIsDark = document.documentElement.classList.contains('dark');
-    setIsDark(currentIsDark);
-    
-    // テーマ変更の監視
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-          const hasDarkClass = document.documentElement.classList.contains('dark');
-          setIsDark(hasDarkClass);
-        }
-      });
-    });
-    
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class']
-    });
-    
-    return () => observer.disconnect();
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== 'theme') return;
+      const next = e.newValue === 'dark' ? 'dark' : 'light';
+      setTheme(next);
+      applyTheme(next);
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
   }, []);
 
-  const toggleTheme = () => {
-    const newIsDark = !isDark;
-    
-    
-    if (newIsDark) {
-      document.documentElement.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
+  const toggle = (): void => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    applyTheme(next);
+    try {
+      window.localStorage.setItem('theme', next);
+    } catch {
+      // ignore quota errors
     }
-    
-    setIsDark(newIsDark);
   };
 
-  // サーバーサイドレンダリング時はボタンを表示しない
-  if (!mounted) {
-    return (
-      <div className="size-9 p-2" />
-    );
-  }
+  if (!mounted) return <div className="size-9 p-2" />;
+
+  const isDark = theme === 'dark';
 
   return (
     <button
-      onClick={toggleTheme}
+      type="button"
+      onClick={toggle}
       className="rounded-md bg-gray-100 p-2 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
       aria-label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
       title={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
     >
       {isDark ? (
-        // ライトモードアイコン（太陽）
         <svg className="size-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
           <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
         </svg>
       ) : (
-        // ダークモードアイコン（月）
         <svg className="size-5 text-gray-700" fill="currentColor" viewBox="0 0 20 20">
           <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
         </svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <head>
         <meta name="application-name" content="URL本文抽出アプリ" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -47,10 +47,15 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{
           __html: `
             (function() {
-              const theme = localStorage.getItem('theme');
-              const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+              var theme = localStorage.getItem('theme');
+              var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
               if (theme === 'dark' || (!theme && systemPrefersDark)) {
                 document.documentElement.classList.add('dark');
+              }
+              if (location.hostname === 'localhost' && 'serviceWorker' in navigator) {
+                navigator.serviceWorker.getRegistrations().then(function(regs) {
+                  regs.forEach(function(reg) { reg.unregister(); });
+                });
               }
             })();
           `

--- a/app/sansu-100/admin999/page.tsx
+++ b/app/sansu-100/admin999/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import Link from 'next/link';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import { sansuAdminApi, type AdminUserSummary } from '../lib/api-client';
+
+type Summary = {
+  totalUsers: number;
+  totalSessions: number;
+  sessionsByDate: Record<string, number>;
+};
+
+export default function SansuAdmin999Home(): React.JSX.Element {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [users, setUsers] = useState<AdminUserSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([sansuAdminApi.getSummary(), sansuAdminApi.listUsers()])
+      .then(([s, u]) => {
+        setSummary(s);
+        setUsers(u);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'エラー'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+        <Header
+          title="📋 管理画面"
+          description="練習状況の把握とユーザー管理"
+          showBackButton
+          backHref="/sansu-100"
+          backLabel="ホームにもどる"
+        />
+
+        {error ? (
+          <p className="rounded-lg bg-red-100 p-3 text-sm text-red-700 dark:bg-red-900/40 dark:text-red-300">
+            {error}
+          </p>
+        ) : null}
+
+        {loading ? (
+          <p className="text-center text-gray-500 dark:text-gray-400">
+            読み込み中...
+          </p>
+        ) : null}
+
+        {summary ? (
+          <section className="grid grid-cols-3 gap-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <Stat label="ユーザー数" value={String(summary.totalUsers)} />
+            <Stat label="累計セッション" value={String(summary.totalSessions)} />
+            <Stat
+              label="本日"
+              value={String(
+                summary.sessionsByDate[new Date().toISOString().slice(0, 10)] ?? 0
+              )}
+            />
+          </section>
+        ) : null}
+
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            👥 ユーザー一覧
+          </h2>
+          {!loading && users !== null && users.length === 0 ? (
+            <p className="text-gray-600 dark:text-gray-400">
+              まだユーザーが登録されていません
+            </p>
+          ) : null}
+          {users && users.length > 0 ? (
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {users.map((u) => (
+                <li key={u.id}>
+                  <Link
+                    href={`/sansu-100/admin999/user?userId=${encodeURIComponent(u.id)}`}
+                    className="block rounded-xl border border-gray-200 bg-gray-50 p-4 transition-colors hover:bg-blue-50 dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-5xl">{u.avatar}</span>
+                      <div className="min-w-0 flex-1">
+                        <h3 className="font-bold text-gray-900 dark:text-gray-100">
+                          {u.name}
+                        </h3>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          練習 {u.totalSessions}回 / {u.totalPoints}pt / バッジ{' '}
+                          {u.earnedBadges.length}個
+                        </p>
+                        {u.lastPlayedAt > 0 ? (
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            最終:{' '}
+                            {new Date(u.lastPlayedAt).toLocaleString('ja-JP', {
+                              month: '2-digit',
+                              day: '2-digit',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </p>
+                        ) : (
+                          <p className="text-xs text-gray-400 dark:text-gray-500">
+                            まだ練習していない
+                          </p>
+                        )}
+                      </div>
+                      <span className="text-gray-400 dark:text-gray-500">›</span>
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-gray-100 p-3 text-center dark:bg-gray-700">
+      <p className="text-xs text-gray-600 dark:text-gray-400">{label}</p>
+      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/app/sansu-100/admin999/user/page.tsx
+++ b/app/sansu-100/admin999/user/page.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import React, { Suspense, useEffect, useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import PinPad from '../../components/PinPad';
+import { formatDuration } from '../../components/SessionTimer';
+import {
+  sansuAdminApi,
+  sansuApi,
+  type AdminUserSummary,
+} from '../../lib/api-client';
+import { hashPin } from '../../lib/pin-hash';
+import type { SansuSession } from '../../lib/types';
+
+function UserDetailInner(): React.JSX.Element {
+  const router = useRouter();
+  const params = useSearchParams();
+  const userId = params.get('userId') ?? '';
+
+  const [user, setUser] = useState<AdminUserSummary | null>(null);
+  const [sessions, setSessions] = useState<SansuSession[]>([]);
+  const [showReset, setShowReset] = useState(false);
+  const [newPin, setNewPin] = useState('');
+  const [resetError, setResetError] = useState<string | null>(null);
+  const [resetSuccess, setResetSuccess] = useState(false);
+  const [showAvatarReminder, setShowAvatarReminder] = useState(false);
+
+  useEffect(() => {
+    if (!userId) {
+      router.replace('/sansu-100/admin999');
+      return;
+    }
+    sansuAdminApi
+      .listUsers()
+      .then((list) => {
+        const u = list.find((x) => x.id === userId);
+        if (!u) {
+          router.replace('/sansu-100/admin999');
+          return;
+        }
+        setUser(u);
+      })
+      .catch(console.error);
+    sansuApi.getSessions(userId).then(setSessions).catch(console.error);
+  }, [userId, router]);
+
+  const handleReset = async (pinValue: string = newPin) => {
+    if (!user || pinValue.length !== 4) return;
+    setResetError(null);
+    try {
+      const hash = await hashPin(pinValue, user.id);
+      await sansuAdminApi.resetPin(user.id, hash, user.id);
+      setResetSuccess(true);
+      setShowReset(false);
+      setNewPin('');
+    } catch (e) {
+      setResetError(e instanceof Error ? e.message : 'エラー');
+    }
+  };
+
+  if (!user)
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+        <p className="text-gray-500 dark:text-gray-400">読み込み中...</p>
+      </main>
+    );
+
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <Header
+          title={`${user.avatar} ${user.name}`}
+          description="ユーザー詳細・リカバリー操作"
+          showBackButton
+          backHref="/sansu-100/admin999"
+          backLabel="ユーザー一覧にもどる"
+        />
+
+        {/* Identity card */}
+        <section className="space-y-4 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <div className="flex items-center gap-4">
+            <span className="text-7xl">{user.avatar}</span>
+            <div className="flex-1 space-y-1 text-sm text-gray-700 dark:text-gray-300">
+              <p>
+                <strong>名前:</strong> {user.name}
+              </p>
+              <p>
+                <strong>テーマカラー:</strong> {user.themeColor}
+              </p>
+              <p>
+                <strong>作成日時:</strong>{' '}
+                {new Date(user.createdAt).toLocaleString('ja-JP')}
+              </p>
+              <p>
+                <strong>最終練習:</strong>{' '}
+                {user.lastPlayedAt > 0
+                  ? new Date(user.lastPlayedAt).toLocaleString('ja-JP')
+                  : '—'}
+              </p>
+              <p>
+                <strong>累計:</strong> {user.totalSessions}回 /{' '}
+                {user.totalPoints}pt / バッジ {user.earnedBadges.length}個
+              </p>
+              {user.pinResetAt ? (
+                <p className="text-amber-700 dark:text-amber-300">
+                  <strong>最終PINリセット:</strong>{' '}
+                  {new Date(user.pinResetAt).toLocaleString('ja-JP')}（
+                  {user.pinResetBy ?? 'admin'}）
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 border-t border-gray-200 pt-4 dark:border-gray-700 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => setShowAvatarReminder(true)}
+              className="flex-1 rounded-lg bg-blue-100 px-4 py-3 font-bold text-blue-900 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-200 dark:hover:bg-blue-900/60"
+            >
+              🪞 アバターを教える
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowReset(true);
+                setResetSuccess(false);
+                setResetError(null);
+                setNewPin('');
+              }}
+              className="flex-1 rounded-lg bg-amber-500 px-4 py-3 font-bold text-white hover:bg-amber-600"
+            >
+              🔑 PIN を再設定
+            </button>
+          </div>
+
+          {resetSuccess ? (
+            <div className="rounded-lg bg-green-100 p-3 text-sm text-green-800 dark:bg-green-900/40 dark:text-green-200">
+              ✅ PIN を新しく設定しました。お子さんに新しい4桁の番号を伝えてください。
+            </div>
+          ) : null}
+        </section>
+
+        {/* Badges */}
+        {user.earnedBadges.length > 0 ? (
+          <section className="rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <h2 className="mb-3 text-xl font-bold text-gray-900 dark:text-gray-100">
+              🏅 獲得バッジ ({user.earnedBadges.length}個)
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {user.earnedBadges.map((id) => (
+                <span
+                  key={id}
+                  className="rounded-lg bg-yellow-100 px-2 py-1 text-xs font-semibold text-yellow-900 dark:bg-yellow-900/30 dark:text-yellow-200"
+                >
+                  {id}
+                </span>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Session history */}
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            🕒 最近の練習（最新15件）
+          </h2>
+          {sessions.length === 0 ? (
+            <p className="text-gray-600 dark:text-gray-400">記録なし</p>
+          ) : (
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+              {sessions
+                .slice(-15)
+                .reverse()
+                .map((s) => (
+                  <li
+                    key={s.id}
+                    className="flex items-center justify-between py-2 text-sm"
+                  >
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {new Date(s.completedAt).toLocaleString('ja-JP', {
+                        month: '2-digit',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                    <span className="font-mono font-semibold text-gray-900 dark:text-gray-100">
+                      Lv.{s.level} {s.operation} · {formatDuration(s.durationMs)}{' '}
+                      · {s.correctCount}/{s.totalProblems}
+                    </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      +{s.pointsEarned}pt
+                    </span>
+                  </li>
+                ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      {/* Avatar reminder fullscreen */}
+      {showAvatarReminder ? (
+        <button
+          type="button"
+          className="fixed inset-0 z-50 flex w-full items-center justify-center bg-black/70 p-4"
+          onClick={() => setShowAvatarReminder(false)}
+          aria-label="アバター表示を閉じる"
+        >
+          <div className="flex flex-col items-center gap-4 rounded-3xl bg-white p-10 shadow-2xl dark:bg-gray-800">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              この子のアバターはこれ
+            </p>
+            <span className="text-9xl">{user.avatar}</span>
+            <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+              {user.name}
+            </p>
+            <p className="rounded-lg bg-blue-600 px-6 py-2 font-bold text-white">
+              タップで閉じる
+            </p>
+          </div>
+        </button>
+      ) : null}
+
+      {/* PIN reset dialog */}
+      {showReset ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm space-y-4 rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800">
+            <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+              新しいPINを設定
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              お子さんに伝える 4桁の番号を入力してください
+            </p>
+            <PinPad
+              value={newPin}
+              onChange={setNewPin}
+              onSubmit={handleReset}
+              error={resetError}
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowReset(false)}
+                className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                やめる
+              </button>
+              <button
+                type="button"
+                disabled={newPin.length !== 4}
+                onClick={() => handleReset()}
+                className="flex-1 rounded-lg bg-amber-600 px-4 py-2 font-bold text-white hover:bg-amber-700 disabled:bg-gray-400"
+              >
+                設定する
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}
+
+export default function Admin999UserDetailPage(): React.JSX.Element {
+  return (
+    <Suspense fallback={<main className="p-8" />}>
+      <UserDetailInner />
+    </Suspense>
+  );
+}

--- a/app/sansu-100/components/AvatarPicker.tsx
+++ b/app/sansu-100/components/AvatarPicker.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+
+import { AVATARS } from '../lib/avatar';
+
+interface AvatarPickerProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function AvatarPicker({
+  value,
+  onChange,
+}: AvatarPickerProps): React.JSX.Element {
+  return (
+    <div className="grid grid-cols-6 gap-2 sm:grid-cols-8">
+      {AVATARS.map((emoji) => (
+        <button
+          key={emoji}
+          type="button"
+          onClick={() => onChange(emoji)}
+          className={`flex aspect-square items-center justify-center rounded-xl text-3xl transition-all sm:text-4xl ${
+            value === emoji
+              ? 'scale-110 bg-blue-100 ring-4 ring-blue-500 dark:bg-blue-900/40'
+              : 'bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600'
+          }`}
+          aria-pressed={value === emoji}
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/sansu-100/components/BadgeShowcase.tsx
+++ b/app/sansu-100/components/BadgeShowcase.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+
+import { BADGE_CATALOG, TIER_COLORS, type BadgeDef } from '../lib/badge-catalog';
+
+interface BadgeShowcaseProps {
+  earned: string[];
+}
+
+const CATEGORY_LABELS: Record<BadgeDef['category'], string> = {
+  sessions: '🏃 れんしゅう回数',
+  perfect: '💯 パーフェクト',
+  speed: '⚡ スピード',
+  streak: '🔥 れんぞく日数',
+  master: '🎓 演算マスター',
+  timing: '🕐 じかんたい',
+  daily: '📅 デイリー',
+  special: '✨ とくべつ',
+  meta: '🏆 メタ',
+};
+
+export default function BadgeShowcase({
+  earned,
+}: BadgeShowcaseProps): React.JSX.Element {
+  const earnedSet = new Set(earned);
+  const categories = Array.from(
+    new Set(BADGE_CATALOG.map((b) => b.category))
+  );
+
+  return (
+    <div className="space-y-6" data-testid="badge-showcase">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          🏅 バッジコレクション
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          {earned.length} / {BADGE_CATALOG.length} 個
+        </p>
+      </div>
+      {categories.map((cat) => {
+        const badges = BADGE_CATALOG.filter((b) => b.category === cat);
+        return (
+          <div key={cat} className="space-y-2">
+            <h3 className="text-sm font-bold text-gray-700 dark:text-gray-300">
+              {CATEGORY_LABELS[cat]}
+            </h3>
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
+              {badges.map((b) => {
+                const has = earnedSet.has(b.id);
+                return (
+                  <div
+                    key={b.id}
+                    className={`flex flex-col items-center gap-1 rounded-xl p-2 text-center transition-all ${
+                      has
+                        ? `bg-gradient-to-br ${TIER_COLORS[b.tier]} shadow-md`
+                        : 'bg-gray-200 dark:bg-gray-700'
+                    }`}
+                    title={has ? b.description : '？？？'}
+                  >
+                    <span
+                      className={`text-3xl ${has ? '' : 'opacity-30 grayscale'}`}
+                    >
+                      {has ? b.icon : '❓'}
+                    </span>
+                    <span
+                      className={`text-xs font-bold leading-tight ${
+                        has ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'
+                      }`}
+                    >
+                      {has ? b.name : '？？？'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/sansu-100/components/BadgeUnlockOverlay.tsx
+++ b/app/sansu-100/components/BadgeUnlockOverlay.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import confetti from 'canvas-confetti';
+import { AnimatePresence, motion } from 'framer-motion';
+
+import { BADGES_BY_ID, TIER_COLORS, type BadgeDef } from '../lib/badge-catalog';
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+interface BadgeUnlockOverlayProps {
+  badgeIds: string[];
+  onDone: () => void;
+}
+
+function fireConfetti(tier: BadgeDef['tier']) {
+  const colors =
+    tier === 'rainbow'
+      ? ['#ff5e7e', '#ffd966', '#7ee59a', '#7ec9ff', '#c084fc']
+      : tier === 'gold'
+        ? ['#ffd966', '#ffbb33']
+        : tier === 'silver'
+          ? ['#d6d6d6', '#a3a3a3']
+          : ['#cd7f32', '#a0522d'];
+  confetti({ particleCount: 80, spread: 80, origin: { y: 0.6 }, colors });
+  confetti({ particleCount: 60, angle: 60, spread: 55, origin: { x: 0 }, colors });
+  confetti({ particleCount: 60, angle: 120, spread: 55, origin: { x: 1 }, colors });
+}
+
+export default function BadgeUnlockOverlay({
+  badgeIds,
+  onDone,
+}: BadgeUnlockOverlayProps): React.JSX.Element | null {
+  const [idx, setIdx] = useState(0);
+  const settings =
+    typeof window !== 'undefined' ? storage.getSettings() : { soundOn: true };
+
+  const badge: BadgeDef | undefined = BADGES_BY_ID[badgeIds[idx]];
+
+  useEffect(() => {
+    if (!badge) return;
+    fireConfetti(badge.tier);
+    if (settings.soundOn) sound.fanfare();
+    const timer = setTimeout(() => {
+      if (idx + 1 < badgeIds.length) setIdx(idx + 1);
+      else onDone();
+    }, 3500);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idx]);
+
+  if (badgeIds.length === 0) return null;
+  if (!badge) return null;
+
+  const handleNext = () => {
+    if (idx + 1 < badgeIds.length) setIdx(idx + 1);
+    else onDone();
+  };
+
+  return (
+    <button
+      type="button"
+      className="fixed inset-0 z-50 flex w-full flex-col items-center justify-center bg-black/70 p-4 text-left"
+      onClick={handleNext}
+      aria-label="新しいバッジ獲得 つぎへ"
+      data-testid="badge-unlock-overlay"
+    >
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={badge.id}
+          initial={{ scale: 0, rotateY: 180, opacity: 0 }}
+          animate={{ scale: 1, rotateY: 0, opacity: 1 }}
+          exit={{ scale: 0.8, opacity: 0 }}
+          transition={{ type: 'spring', stiffness: 120, damping: 14 }}
+          className="flex flex-col items-center gap-4"
+        >
+          <p className="text-3xl font-black text-white drop-shadow-lg sm:text-4xl">
+            ✨ NEW BADGE！ ✨
+          </p>
+          <div
+            className={`flex flex-col items-center gap-3 rounded-3xl bg-gradient-to-br ${TIER_COLORS[badge.tier]} p-6 shadow-2xl`}
+          >
+            <div className="text-8xl drop-shadow-lg">{badge.icon}</div>
+            <div className="rounded-xl bg-white/90 px-6 py-2 dark:bg-black/40">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {badge.name}
+              </p>
+            </div>
+            <p className="max-w-xs text-center text-sm font-semibold text-white drop-shadow">
+              {badge.description}
+            </p>
+          </div>
+          <p className="mt-2 text-sm text-white/80">
+            タップで {idx + 1 < badgeIds.length ? 'つぎへ →' : 'とじる'}（
+            {idx + 1}/{badgeIds.length}）
+          </p>
+        </motion.div>
+      </AnimatePresence>
+    </button>
+  );
+}

--- a/app/sansu-100/components/ColorPicker.tsx
+++ b/app/sansu-100/components/ColorPicker.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+
+import { THEME_COLOR_CLASSES, THEME_COLORS } from '../lib/avatar';
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+const LABELS: Record<string, string> = {
+  pink: 'ピンク',
+  blue: 'ブルー',
+  green: 'グリーン',
+  yellow: 'イエロー',
+  purple: 'パープル',
+  orange: 'オレンジ',
+};
+
+export default function ColorPicker({
+  value,
+  onChange,
+}: ColorPickerProps): React.JSX.Element {
+  return (
+    <div className="grid grid-cols-6 gap-2">
+      {THEME_COLORS.map((c) => {
+        const theme = THEME_COLOR_CLASSES[c];
+        return (
+          <button
+            key={c}
+            type="button"
+            onClick={() => onChange(c)}
+            className={`flex flex-col items-center gap-1 rounded-xl border-2 p-2 transition-all ${
+              value === c
+                ? 'scale-110 border-gray-900 dark:border-white'
+                : 'border-transparent hover:border-gray-300 dark:hover:border-gray-600'
+            }`}
+            aria-pressed={value === c}
+          >
+            <span
+              className={`block size-10 rounded-full bg-gradient-to-br ${theme.gradient}`}
+            />
+            <span className="text-xs text-gray-700 dark:text-gray-300">
+              {LABELS[c]}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/sansu-100/components/LevelPicker.tsx
+++ b/app/sansu-100/components/LevelPicker.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+
+import { LEVELS } from '../lib/levels';
+import type { LevelId, Operation } from '../lib/types';
+
+interface LevelPickerProps {
+  onPick: (level: LevelId, operation: Operation) => void;
+}
+
+const OP_COLORS: Record<string, string> = {
+  add: 'from-green-400 to-green-600',
+  sub: 'from-yellow-400 to-yellow-600',
+  mul: 'from-red-400 to-red-600',
+  div: 'from-purple-400 to-purple-600',
+};
+
+export default function LevelPicker({
+  onPick,
+}: LevelPickerProps): React.JSX.Element {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {LEVELS.map((lv) => (
+          <button
+            key={lv.id}
+            type="button"
+            onClick={() => onPick(lv.id, lv.operation)}
+            className={`group rounded-2xl bg-gradient-to-br ${OP_COLORS[lv.operation]} p-5 text-left text-white shadow-md transition-transform hover:scale-[1.02]`}
+            data-testid={`level-pick-${lv.id}`}
+          >
+            <div className="flex items-baseline justify-between">
+              <h3 className="text-xl font-bold">{lv.label}</h3>
+              <span className="text-sm opacity-90">Lv.{lv.id}</span>
+            </div>
+            <p className="mt-1 text-sm opacity-90">{lv.description}</p>
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => onPick('mix', 'mixed')}
+        className="w-full rounded-2xl bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 p-5 text-white shadow-md hover:scale-[1.02]"
+        data-testid="level-pick-mix"
+      >
+        <h3 className="text-xl font-bold">🎲 ミックス</h3>
+        <p className="mt-1 text-sm opacity-90">いろいろなレベルから ランダム</p>
+      </button>
+    </div>
+  );
+}

--- a/app/sansu-100/components/NumberKeypad.tsx
+++ b/app/sansu-100/components/NumberKeypad.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React, { useCallback, useEffect } from 'react';
+
+interface NumberKeypadProps {
+  value: string;
+  onChange: (v: string) => void;
+  onSkip: () => void;
+  maxLen?: number;
+  disabled?: boolean;
+}
+
+export default function NumberKeypad({
+  value,
+  onChange,
+  onSkip,
+  maxLen = 4,
+  disabled = false,
+}: NumberKeypadProps): React.JSX.Element {
+  const press = useCallback(
+    (k: string) => {
+      if (disabled) return;
+      if (k === 'back') {
+        onChange(value.slice(0, -1));
+      } else if (k === 'skip') {
+        onSkip();
+      } else if (value.length < maxLen) {
+        onChange(value + k);
+      }
+    },
+    [value, disabled, maxLen, onChange, onSkip]
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (disabled) return;
+      if (e.key >= '0' && e.key <= '9') press(e.key);
+      else if (e.key === 'Backspace') press('back');
+      else if (e.key === 'Enter') press('skip');
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [press, disabled]);
+
+  const Btn = ({ k, label, className }: { k: string; label?: string; className?: string }) => (
+    <button
+      type="button"
+      onClick={() => press(k)}
+      disabled={disabled}
+      className={`flex h-16 items-center justify-center rounded-2xl text-2xl font-bold transition-colors disabled:opacity-50 sm:h-20 sm:text-3xl ${
+        className ??
+        'bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600'
+      }`}
+    >
+      {label ?? k}
+    </button>
+  );
+
+  return (
+    <div className="mx-auto grid w-full max-w-sm grid-cols-3 gap-2 sm:gap-3" data-testid="number-keypad">
+      <Btn k="1" />
+      <Btn k="2" />
+      <Btn k="3" />
+      <Btn k="4" />
+      <Btn k="5" />
+      <Btn k="6" />
+      <Btn k="7" />
+      <Btn k="8" />
+      <Btn k="9" />
+      <Btn k="back" label="←" className="bg-amber-200 text-gray-900 hover:bg-amber-300 dark:bg-amber-800 dark:text-gray-100 dark:hover:bg-amber-700" />
+      <Btn k="0" />
+      <Btn
+        k="skip"
+        label="スキップ"
+        className="bg-gray-400 text-base text-white hover:bg-gray-500 dark:bg-gray-600 dark:hover:bg-gray-500 sm:text-lg"
+      />
+    </div>
+  );
+}

--- a/app/sansu-100/components/PinPad.tsx
+++ b/app/sansu-100/components/PinPad.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import React, { useCallback, useEffect } from 'react';
+
+interface PinPadProps {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit?: (value: string) => void;
+  error?: string | null;
+  disabled?: boolean;
+}
+
+export default function PinPad({
+  value,
+  onChange,
+  onSubmit,
+  error,
+  disabled = false,
+}: PinPadProps): React.JSX.Element {
+  const press = useCallback(
+    (digit: string) => {
+      if (disabled) return;
+      if (digit === 'back') {
+        onChange(value.slice(0, -1));
+        return;
+      }
+      if (value.length >= 4) return;
+      const next = value + digit;
+      onChange(next);
+      if (next.length === 4 && onSubmit) {
+        // tiny delay so the user sees the 4th dot before submitting
+        setTimeout(() => onSubmit(next), 80);
+      }
+    },
+    [value, disabled, onChange, onSubmit]
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (disabled) return;
+      if (e.key >= '0' && e.key <= '9') press(e.key);
+      else if (e.key === 'Backspace') press('back');
+      else if (e.key === 'Enter' && value.length === 4 && onSubmit) onSubmit(value);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [press, value.length, onSubmit, disabled]);
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex gap-3" role="status" aria-label="PIN入力">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={`size-6 rounded-full border-2 ${
+              i < value.length
+                ? 'border-blue-600 bg-blue-600'
+                : 'border-gray-400 bg-transparent'
+            }`}
+          />
+        ))}
+      </div>
+      {error ? (
+        <p className="text-sm font-semibold text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      ) : null}
+      <div className="grid grid-cols-3 gap-3" data-testid="pin-pad">
+        {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((d) => (
+          <button
+            key={d}
+            type="button"
+            disabled={disabled}
+            onClick={() => press(d)}
+            className="flex size-16 items-center justify-center rounded-2xl bg-gray-100 text-2xl font-bold text-gray-900 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+          >
+            {d}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={disabled || value.length === 0}
+          onClick={() => press('back')}
+          className="flex size-16 items-center justify-center rounded-2xl bg-gray-100 text-xl text-gray-700 transition-colors hover:bg-gray-200 disabled:opacity-30 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+          aria-label="削除"
+        >
+          ←
+        </button>
+        <button
+          key="0"
+          type="button"
+          disabled={disabled}
+          onClick={() => press('0')}
+          className="flex size-16 items-center justify-center rounded-2xl bg-gray-100 text-2xl font-bold text-gray-900 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+        >
+          0
+        </button>
+        <div className="size-16" />
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/components/ProblemDisplay.tsx
+++ b/app/sansu-100/components/ProblemDisplay.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+
+import type { Problem } from '../lib/types';
+
+const OP_SYMBOL: Record<Problem['op'], string> = {
+  add: '＋',
+  sub: '−',
+  mul: '×',
+  div: '÷',
+};
+
+interface ProblemDisplayProps {
+  problem: Problem;
+  userInput: string;
+  feedback?: 'correct' | 'wrong' | null;
+}
+
+export default function ProblemDisplay({
+  problem,
+  userInput,
+  feedback,
+}: ProblemDisplayProps): React.JSX.Element {
+  // Keep the problem text in a stable color regardless of feedback so the page
+  // doesn't appear to "flash to light mode" on each correct answer. Only the
+  // answer slot reacts.
+  const slotBg =
+    feedback === 'correct'
+      ? 'bg-green-500/20 dark:bg-green-400/25'
+      : feedback === 'wrong'
+        ? 'bg-red-500/20 dark:bg-red-400/25'
+        : 'bg-transparent';
+  const slotBorder =
+    feedback === 'correct'
+      ? 'border-green-600 dark:border-green-400'
+      : feedback === 'wrong'
+        ? 'border-red-600 dark:border-red-400'
+        : 'border-gray-400 dark:border-gray-500';
+  return (
+    <div
+      className="flex items-baseline justify-center gap-3 font-mono text-6xl font-bold text-gray-900 dark:text-gray-100 sm:text-7xl md:text-8xl"
+      data-testid="problem-display"
+    >
+      <span>{problem.a}</span>
+      <span>{OP_SYMBOL[problem.op]}</span>
+      <span>{problem.b}</span>
+      <span>＝</span>
+      <span
+        className={`min-w-[1.5em] rounded-lg border-b-4 px-2 text-center transition-colors duration-150 ${slotBorder} ${slotBg}`}
+      >
+        {userInput || ' '}
+      </span>
+    </div>
+  );
+}

--- a/app/sansu-100/components/ProgressBar.tsx
+++ b/app/sansu-100/components/ProgressBar.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+
+interface ProgressBarProps {
+  current: number;
+  total: number;
+  correctCount?: number;
+}
+
+export default function ProgressBar({
+  current,
+  total,
+  correctCount,
+}: ProgressBarProps): React.JSX.Element {
+  const pct = Math.min(100, (current / total) * 100);
+  return (
+    <div className="space-y-1" data-testid="progress-bar">
+      <div className="flex items-center justify-between text-sm font-semibold text-gray-700 dark:text-gray-300">
+        <span>
+          {current} / {total}
+        </span>
+        {correctCount !== undefined && (
+          <span className="text-green-600 dark:text-green-400">
+            ⭕️ {correctCount}
+          </span>
+        )}
+      </div>
+      <div className="h-3 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          className="h-full bg-gradient-to-r from-blue-500 to-green-500 transition-all duration-200"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/components/RegistrationForm.tsx
+++ b/app/sansu-100/components/RegistrationForm.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { sansuApi } from '../lib/api-client';
+import { AVATARS, THEME_COLORS } from '../lib/avatar';
+import { hashPin } from '../lib/pin-hash';
+import { storage } from '../lib/storage';
+import type { SansuUserPublic } from '../lib/types';
+
+import AvatarPicker from './AvatarPicker';
+import ColorPicker from './ColorPicker';
+import PinPad from './PinPad';
+
+function newUserId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+  return `u_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export default function RegistrationForm(): React.JSX.Element {
+  const router = useRouter();
+  const [step, setStep] = useState<'name' | 'avatar' | 'color' | 'pin'>('name');
+  const [name, setName] = useState('');
+  const [avatar, setAvatar] = useState(AVATARS[2]);
+  const [color, setColor] = useState<string>(THEME_COLORS[1]);
+  const [pin, setPin] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (pinValue: string = pin) => {
+    if (pinValue.length !== 4) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const id = newUserId();
+      const salt = id;
+      const pinHash = await hashPin(pinValue, salt);
+      const now = Date.now();
+      const user: SansuUserPublic = {
+        id,
+        name: name.trim(),
+        avatar,
+        themeColor: color,
+        createdAt: now,
+        totalPoints: 0,
+        earnedBadges: [],
+        bestTimesByLevel: {},
+        currentStreakDays: 0,
+        lastPlayedDate: '',
+        lastPlayedAt: 0,
+        totalSessions: 0,
+      };
+      try {
+        await sansuApi.createUser({
+          name: user.name,
+          avatar: user.avatar,
+          themeColor: user.themeColor,
+          pinHash,
+          pinSalt: salt,
+        });
+      } catch (e) {
+        // backend not reachable — proceed with local-only registration
+        // (sync will retry later)
+        console.warn('Backend registration failed, continuing locally', e);
+      }
+      storage.upsertUser(user);
+      storage.setCurrentUserId(user.id);
+      router.push('/sansu-100');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '登録に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-md space-y-6 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+      {step === 'name' && (
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            なまえを いれてね
+          </h2>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={12}
+            placeholder="ニックネーム（12文字まで）"
+            className="w-full rounded-lg border border-gray-300 bg-white p-3 text-lg text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            data-testid="register-name-input"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            ※ ほんとうの なまえじゃなくても OK だよ
+          </p>
+          <button
+            type="button"
+            disabled={!name.trim()}
+            onClick={() => setStep('avatar')}
+            className="w-full rounded-lg bg-blue-600 px-4 py-3 font-bold text-white hover:bg-blue-700 disabled:bg-gray-400"
+            data-testid="register-name-next"
+          >
+            つぎへ →
+          </button>
+        </div>
+      )}
+
+      {step === 'avatar' && (
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            アバターを えらんでね
+          </h2>
+          <div className="text-center text-6xl">{avatar}</div>
+          <AvatarPicker value={avatar} onChange={setAvatar} />
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => setStep('name')}
+              className="flex-1 rounded-lg bg-gray-200 px-4 py-3 font-bold text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ← もどる
+            </button>
+            <button
+              type="button"
+              onClick={() => setStep('color')}
+              className="flex-1 rounded-lg bg-blue-600 px-4 py-3 font-bold text-white hover:bg-blue-700"
+            >
+              つぎへ →
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 'color' && (
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            すきな いろは？
+          </h2>
+          <ColorPicker value={color} onChange={setColor} />
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => setStep('avatar')}
+              className="flex-1 rounded-lg bg-gray-200 px-4 py-3 font-bold text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ← もどる
+            </button>
+            <button
+              type="button"
+              onClick={() => setStep('pin')}
+              className="flex-1 rounded-lg bg-blue-600 px-4 py-3 font-bold text-white hover:bg-blue-700"
+            >
+              つぎへ →
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 'pin' && (
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            あいことば（4けた）
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            たんじょうびの 月日（MMDD）でも OK だよ。ぜったいに わすれないでね！
+          </p>
+          <PinPad
+            value={pin}
+            onChange={setPin}
+            onSubmit={handleSubmit}
+            error={error}
+            disabled={submitting}
+          />
+          <button
+            type="button"
+            onClick={() => setStep('color')}
+            className="w-full rounded-lg bg-gray-200 px-4 py-2 text-sm text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+          >
+            ← もどる
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/sansu-100/components/SessionTimer.tsx
+++ b/app/sansu-100/components/SessionTimer.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface SessionTimerProps {
+  startedAt: number;
+  stopped?: boolean;
+}
+
+export default function SessionTimer({
+  startedAt,
+  stopped,
+}: SessionTimerProps): React.JSX.Element {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (stopped) return;
+    const id = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(id);
+  }, [stopped]);
+
+  const ms = (stopped ? now : Date.now()) - startedAt;
+  const min = Math.floor(ms / 60_000);
+  const sec = Math.floor((ms % 60_000) / 1000);
+  const tenth = Math.floor((ms % 1000) / 100);
+  return (
+    <div className="font-mono text-2xl font-bold tabular-nums text-gray-900 dark:text-gray-100" data-testid="session-timer">
+      {min}:{String(sec).padStart(2, '0')}.{tenth}
+    </div>
+  );
+}
+
+export function formatDuration(ms: number): string {
+  const min = Math.floor(ms / 60_000);
+  const sec = Math.floor((ms % 60_000) / 1000);
+  const tenth = Math.floor((ms % 1000) / 100);
+  return `${min}:${String(sec).padStart(2, '0')}.${tenth}`;
+}

--- a/app/sansu-100/components/StatsCharts.tsx
+++ b/app/sansu-100/components/StatsCharts.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React from 'react';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { SansuSession } from '../lib/types';
+
+interface StatsChartsProps {
+  sessions: SansuSession[];
+}
+
+const OP_LABELS: Record<string, string> = {
+  add: 'たし算',
+  sub: 'ひき算',
+  mul: 'かけ算',
+  div: 'わり算',
+  mixed: 'ミックス',
+};
+
+export default function StatsCharts({
+  sessions,
+}: StatsChartsProps): React.JSX.Element {
+  if (sessions.length === 0) {
+    return (
+      <p className="text-center text-gray-600 dark:text-gray-400">
+        まだ きろくが ないよ。れんしゅうしてみよう！
+      </p>
+    );
+  }
+
+  // タイム推移（最新50件）
+  const recent = sessions.slice(-50);
+  const timeData = recent.map((s, i) => ({
+    n: i + 1,
+    seconds: Math.round(s.durationMs / 100) / 10,
+    accuracy: Math.round((s.correctCount / s.totalProblems) * 100),
+  }));
+
+  // 演算別集計
+  const opCounts: Record<string, number> = {};
+  for (const s of sessions) {
+    opCounts[s.operation] = (opCounts[s.operation] ?? 0) + 1;
+  }
+  const opData = Object.entries(opCounts).map(([op, count]) => ({
+    name: OP_LABELS[op] ?? op,
+    count,
+  }));
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-gray-100">
+          ⏱️ タイム & 正かい率の すいい
+        </h3>
+        <div className="h-64 rounded-xl bg-white p-2 dark:bg-gray-800">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={timeData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="n" tick={{ fontSize: 12 }} />
+              <YAxis yAxisId="left" tick={{ fontSize: 12 }} />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tick={{ fontSize: 12 }}
+                domain={[0, 100]}
+              />
+              <Tooltip />
+              <Legend />
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="seconds"
+                name="秒"
+                stroke="#3b82f6"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+              />
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="accuracy"
+                name="正解率(%)"
+                stroke="#10b981"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-gray-100">
+          🎯 れんしゅう回数 by 演算
+        </h3>
+        <div className="h-64 rounded-xl bg-white p-2 dark:bg-gray-800">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={opData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+              <YAxis tick={{ fontSize: 12 }} />
+              <Tooltip />
+              <Bar dataKey="count" fill="#8b5cf6" radius={[6, 6, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/sansu-100/components/UserTile.tsx
+++ b/app/sansu-100/components/UserTile.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+
+import { getThemeClasses } from '../lib/avatar';
+import type { SansuUserPublic } from '../lib/types';
+
+interface UserTileProps {
+  user: SansuUserPublic;
+  onSelect: (user: SansuUserPublic) => void;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export default function UserTile({
+  user,
+  onSelect,
+  size = 'md',
+}: UserTileProps): React.JSX.Element {
+  const theme = getThemeClasses(user.themeColor);
+  const sizes = {
+    sm: { wrap: 'p-3', emoji: 'text-4xl', label: 'text-sm' },
+    md: { wrap: 'p-5', emoji: 'text-6xl', label: 'text-lg' },
+    lg: { wrap: 'p-7', emoji: 'text-7xl', label: 'text-xl' },
+  }[size];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(user)}
+      className={`flex flex-col items-center gap-2 rounded-2xl ${theme.bg} ${sizes.wrap} hover: ring-4 ring-transparent transition-all hover:scale-105${theme.ring} hover:ring-offset-2 hover:ring-offset-white dark:hover:ring-offset-gray-900`}
+      data-testid={`user-tile-${user.id}`}
+    >
+      <span className={sizes.emoji}>{user.avatar}</span>
+      <span className={`font-bold ${theme.text} ${sizes.label}`}>
+        {user.name}
+      </span>
+    </button>
+  );
+}

--- a/app/sansu-100/history/page.tsx
+++ b/app/sansu-100/history/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import BadgeShowcase from '../components/BadgeShowcase';
+import { formatDuration } from '../components/SessionTimer';
+import StatsCharts from '../components/StatsCharts';
+import { useSansuUser } from '../hooks/useSansuUser';
+import { storage } from '../lib/storage';
+import type { SansuSession } from '../lib/types';
+
+export default function HistoryPage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, loaded } = useSansuUser();
+  const [sessions, setSessions] = useState<SansuSession[]>([]);
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (!currentUser) {
+      router.replace('/sansu-100');
+      return;
+    }
+    setSessions(storage.getSessions(currentUser.id));
+  }, [loaded, currentUser, router]);
+
+  if (!loaded || !currentUser) return <main className="p-8" />;
+
+  const latest = sessions.slice(-10).reverse();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-8">
+        <Header
+          title={`${currentUser.avatar} ${currentUser.name} のきろく`}
+          description={`累計 ${currentUser.totalSessions}回 / ${currentUser.totalPoints}pt`}
+          showBackButton
+          backHref="/sansu-100"
+          backLabel="ホームにもどる"
+        />
+
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            📊 グラフ
+          </h2>
+          <StatsCharts sessions={sessions} />
+        </section>
+
+        <section className="space-y-3 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            🕒 さいきんの れんしゅう
+          </h2>
+          {latest.length === 0 ? (
+            <p className="text-gray-600 dark:text-gray-400">
+              まだ きろくが ないよ
+            </p>
+          ) : (
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+              {latest.map((s) => (
+                <li
+                  key={s.id}
+                  className="flex items-center justify-between py-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      {new Date(s.completedAt).toLocaleString('ja-JP', {
+                        month: '2-digit',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">
+                      Lv.{s.level} {s.operation}
+                      {s.isDaily ? ' ⭐' : ''}
+                    </span>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-bold text-gray-900 dark:text-gray-100">
+                      {formatDuration(s.durationMs)}
+                    </p>
+                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                      {s.correctCount}/{s.totalProblems} ・ +
+                      {s.pointsEarned}pt
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <BadgeShowcase earned={currentUser.earnedBadges} />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/sansu-100/hooks/useSansuSession.ts
+++ b/app/sansu-100/hooks/useSansuSession.ts
@@ -1,0 +1,130 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { dailyLevel, dailySeed } from '../lib/daily';
+import {
+  generateSet,
+  generateSetSeeded,
+  mulberry32,
+} from '../lib/problem-generator';
+import type {
+  AnsweredProblem,
+  LevelId,
+  Operation,
+  Problem,
+} from '../lib/types';
+
+export type UseSansuSessionOptions = {
+  level: LevelId;
+  operation: Operation;
+  isDaily: boolean;
+  totalProblems?: number;
+};
+
+export type SansuSessionState = {
+  problems: Problem[];
+  currentIndex: number;
+  answered: AnsweredProblem[];
+  startedAt: number;
+  completedAt: number | null;
+  isComplete: boolean;
+  currentProblem: Problem | null;
+};
+
+export function useSansuSession(opts: UseSansuSessionOptions) {
+  const total = opts.totalProblems ?? 100;
+  const problems = useMemo<Problem[]>(() => {
+    if (opts.isDaily) {
+      const seed = dailySeed();
+      const lvl = (opts.level === 'mix' ? dailyLevel() : opts.level) as LevelId;
+      return generateSetSeeded(lvl, total, seed);
+    }
+    const seed = Math.floor(Math.random() * 0x7fffffff);
+    return generateSet(opts.level, total, mulberry32(seed));
+  }, [opts.isDaily, opts.level, total]);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answered, setAnswered] = useState<AnsweredProblem[]>([]);
+  const startedAtRef = useRef<number>(Date.now());
+  const lastAdvanceRef = useRef<number>(startedAtRef.current);
+  const [completedAt, setCompletedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    lastAdvanceRef.current = startedAtRef.current;
+    setCurrentIndex(0);
+    setAnswered([]);
+    setCompletedAt(null);
+  }, [problems]);
+
+  const currentProblem = currentIndex < problems.length
+    ? problems[currentIndex]
+    : null;
+
+  const submitAnswer = useCallback(
+    (userAnswer: number) => {
+      if (!currentProblem) return;
+      const now = Date.now();
+      const timeMs = now - lastAdvanceRef.current;
+      lastAdvanceRef.current = now;
+
+      const ans: AnsweredProblem = {
+        ...currentProblem,
+        userAnswer,
+        isCorrect: userAnswer === currentProblem.answer,
+        timeMs,
+      };
+      setAnswered((prev) => {
+        const next = [...prev, ans];
+        if (next.length >= problems.length) {
+          setCompletedAt(now);
+        }
+        return next;
+      });
+      setCurrentIndex((i) => i + 1);
+      return ans;
+    },
+    [currentProblem, problems.length]
+  );
+
+  /**
+   * DEBUG ONLY: fill all remaining problems with correct answers (or a chosen
+   * accuracy) and immediately mark the session complete.
+   */
+  const debugFinish = useCallback(
+    (opts2: { accuracy?: number; durationMs?: number } = {}) => {
+      const accuracy = opts2.accuracy ?? 1;
+      const startedAt = startedAtRef.current;
+      const targetDuration = opts2.durationMs ?? Math.max(60_000, Date.now() - startedAt);
+      const now = Date.now();
+      // Backdate startedAt so resulting durationMs is realistic
+      startedAtRef.current = now - targetDuration;
+      const filled: AnsweredProblem[] = problems.map((p, idx) => {
+        const wantCorrect = idx / problems.length < accuracy;
+        return {
+          ...p,
+          userAnswer: wantCorrect ? p.answer : p.answer + 1,
+          isCorrect: wantCorrect,
+          timeMs: Math.floor(targetDuration / problems.length),
+        };
+      });
+      setAnswered(filled);
+      setCurrentIndex(problems.length);
+      setCompletedAt(now);
+    },
+    [problems]
+  );
+
+  return {
+    problems,
+    currentIndex,
+    answered,
+    startedAt: startedAtRef.current,
+    completedAt,
+    isComplete: completedAt !== null,
+    currentProblem,
+    submitAnswer,
+    debugFinish,
+  };
+}

--- a/app/sansu-100/hooks/useSansuSync.ts
+++ b/app/sansu-100/hooks/useSansuSync.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { sansuApi } from '../lib/api-client';
+import { storage } from '../lib/storage';
+
+export function useSansuSync(): void {
+  useEffect(() => {
+    const flush = async () => {
+      const pending = storage.getPendingSync();
+      if (pending.length === 0) return;
+      const settled: string[] = [];
+      for (const s of pending) {
+        try {
+          await sansuApi.submitSession(s);
+          settled.push(s.id);
+        } catch {
+          // keep in queue
+        }
+      }
+      if (settled.length > 0) storage.clearPending(settled);
+    };
+
+    // try once on mount
+    flush();
+
+    // and whenever we come back online
+    const onOnline = () => {
+      flush();
+    };
+    window.addEventListener('online', onOnline);
+    return () => window.removeEventListener('online', onOnline);
+  }, []);
+}

--- a/app/sansu-100/hooks/useSansuUser.ts
+++ b/app/sansu-100/hooks/useSansuUser.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { storage } from '../lib/storage';
+import type { SansuUserPublic } from '../lib/types';
+
+export function useSansuUser() {
+  const [currentUser, setCurrentUser] = useState<SansuUserPublic | null>(null);
+  const [recentUsers, setRecentUsers] = useState<SansuUserPublic[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const users = storage.getUsers();
+    setRecentUsers(users);
+    const id = storage.getCurrentUserId();
+    const u = id ? users.find((x) => x.id === id) ?? null : null;
+    setCurrentUser(u);
+    setLoaded(true);
+  }, []);
+
+  const selectUser = useCallback((user: SansuUserPublic | null) => {
+    storage.setCurrentUserId(user?.id ?? null);
+    setCurrentUser(user);
+  }, []);
+
+  const saveUser = useCallback((user: SansuUserPublic) => {
+    storage.upsertUser(user);
+    setRecentUsers(storage.getUsers());
+    setCurrentUser(user);
+    storage.setCurrentUserId(user.id);
+  }, []);
+
+  const updateUser = useCallback(
+    (updater: (u: SansuUserPublic) => SansuUserPublic) => {
+      setCurrentUser((prev) => {
+        if (!prev) return prev;
+        const next = updater(prev);
+        storage.upsertUser(next);
+        setRecentUsers(storage.getUsers());
+        return next;
+      });
+    },
+    []
+  );
+
+  const removeRecentUser = useCallback(
+    (id: string) => {
+      storage.removeUser(id);
+      setRecentUsers(storage.getUsers());
+      if (currentUser?.id === id) {
+        storage.setCurrentUserId(null);
+        setCurrentUser(null);
+      }
+    },
+    [currentUser?.id]
+  );
+
+  const refreshUsers = useCallback(() => {
+    const users = storage.getUsers();
+    setRecentUsers(users);
+    const id = storage.getCurrentUserId();
+    const u = id ? users.find((x) => x.id === id) ?? null : null;
+    setCurrentUser(u);
+  }, []);
+
+  return {
+    currentUser,
+    recentUsers,
+    loaded,
+    selectUser,
+    saveUser,
+    updateUser,
+    removeRecentUser,
+    refreshUsers,
+  };
+}

--- a/app/sansu-100/lib/__tests__/badges.test.ts
+++ b/app/sansu-100/lib/__tests__/badges.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateBadges,
+  calculateStreakDays,
+  calculatePoints,
+  type BadgeEvalContext,
+} from '../badges';
+import { BADGE_CATALOG } from '../badge-catalog';
+import type { SansuSession, SansuUserPublic } from '../types';
+
+function mkUser(overrides: Partial<SansuUserPublic> = {}): SansuUserPublic {
+  return {
+    id: 'u1',
+    name: 'tester',
+    avatar: '🦊',
+    themeColor: 'blue',
+    createdAt: Date.now(),
+    totalPoints: 0,
+    earnedBadges: [],
+    bestTimesByLevel: {},
+    currentStreakDays: 0,
+    lastPlayedDate: '2026-05-25',
+    lastPlayedAt: Date.now(),
+    totalSessions: 0,
+    ...overrides,
+  };
+}
+
+function mkSession(overrides: Partial<SansuSession> = {}): SansuSession {
+  return {
+    id: 's1',
+    userId: 'u1',
+    userName: 'tester',
+    level: 1,
+    operation: 'add',
+    isDaily: false,
+    startedAt: 0,
+    completedAt: 100_000,
+    durationMs: 100_000,
+    totalProblems: 100,
+    correctCount: 90,
+    pointsEarned: 0,
+    newBadges: [],
+    ...overrides,
+  };
+}
+
+function mkCtx(overrides: Partial<BadgeEvalContext> = {}): BadgeEvalContext {
+  return {
+    user: mkUser(),
+    session: mkSession(),
+    allSessions: [mkSession()],
+    playedAt: new Date('2026-05-25T12:00:00'),
+    ...overrides,
+  };
+}
+
+describe('badges - sessions count', () => {
+  it('awards sessions_1 on first session', () => {
+    const newly = evaluateBadges(mkCtx());
+    expect(newly).toContain('sessions_1');
+  });
+
+  it('awards sessions_10 at exactly 10', () => {
+    const sessions = Array.from({ length: 10 }, () => mkSession());
+    const newly = evaluateBadges(
+      mkCtx({ allSessions: sessions, session: sessions[9] })
+    );
+    expect(newly).toContain('sessions_10');
+  });
+
+  it('does not award sessions_10 with 9 sessions', () => {
+    const sessions = Array.from({ length: 9 }, () => mkSession());
+    const newly = evaluateBadges(mkCtx({ allSessions: sessions }));
+    expect(newly).not.toContain('sessions_10');
+  });
+
+  it('does not re-award already-earned badges', () => {
+    const newly = evaluateBadges(
+      mkCtx({ user: mkUser({ earnedBadges: ['sessions_1'] }) })
+    );
+    expect(newly).not.toContain('sessions_1');
+  });
+});
+
+describe('badges - perfect', () => {
+  it('awards perfect_first on 100/100', () => {
+    const s = mkSession({ correctCount: 100 });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).toContain('perfect_first');
+  });
+
+  it('does not award perfect_first on 99/100', () => {
+    const newly = evaluateBadges(mkCtx());
+    expect(newly).not.toContain('perfect_first');
+  });
+
+  it('awards perfect_streak_3 on 3 consecutive perfects', () => {
+    const perfects = Array.from({ length: 3 }, () =>
+      mkSession({ correctCount: 100 })
+    );
+    const newly = evaluateBadges(
+      mkCtx({ session: perfects[2], allSessions: perfects })
+    );
+    expect(newly).toContain('perfect_streak_3');
+  });
+
+  it('does not award perfect_streak_3 if last was not perfect', () => {
+    const sessions = [
+      mkSession({ correctCount: 100 }),
+      mkSession({ correctCount: 100 }),
+      mkSession({ correctCount: 99 }),
+    ];
+    const newly = evaluateBadges(
+      mkCtx({ session: sessions[2], allSessions: sessions })
+    );
+    expect(newly).not.toContain('perfect_streak_3');
+  });
+});
+
+describe('badges - speed', () => {
+  it('awards speed_3min for perfect under 3min', () => {
+    const s = mkSession({ correctCount: 100, durationMs: 2 * 60_000 });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).toContain('speed_3min');
+    expect(newly).toContain('speed_5min');
+  });
+
+  it('does not award speed_30sec for slower runs', () => {
+    const s = mkSession({ correctCount: 100, durationMs: 31_000 });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).not.toContain('speed_30sec');
+    expect(newly).toContain('speed_60sec');
+  });
+
+  it('does not award speed badges if not perfect', () => {
+    const s = mkSession({ correctCount: 99, durationMs: 30_000 });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).not.toContain('speed_30sec');
+  });
+});
+
+describe('badges - streak', () => {
+  it('awards streak_7 when currentStreakDays is 7', () => {
+    const newly = evaluateBadges(
+      mkCtx({ user: mkUser({ currentStreakDays: 7 }) })
+    );
+    expect(newly).toContain('streak_7');
+    expect(newly).toContain('streak_3');
+  });
+
+  it('does not award streak_7 at 6 days', () => {
+    const newly = evaluateBadges(
+      mkCtx({ user: mkUser({ currentStreakDays: 6 }) })
+    );
+    expect(newly).not.toContain('streak_7');
+  });
+});
+
+describe('badges - master', () => {
+  it('awards master_add_basic when Lv1 and Lv2 cleared perfectly', () => {
+    const sessions = [
+      mkSession({ level: 1, correctCount: 100 }),
+      mkSession({ level: 2, correctCount: 100 }),
+    ];
+    const newly = evaluateBadges(
+      mkCtx({ session: sessions[1], allSessions: sessions })
+    );
+    expect(newly).toContain('master_add_basic');
+  });
+
+  it('master_mul_basic requires Level 5 perfect clear', () => {
+    const s = mkSession({ level: 5, correctCount: 100, operation: 'mul' });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).toContain('master_mul_basic');
+  });
+});
+
+describe('badges - timing', () => {
+  it('awards early_bird if played at 7am', () => {
+    const newly = evaluateBadges(
+      mkCtx({ playedAt: new Date('2026-05-25T07:30:00') })
+    );
+    expect(newly).toContain('early_bird');
+  });
+
+  it('does not award early_bird at noon', () => {
+    const newly = evaluateBadges(
+      mkCtx({ playedAt: new Date('2026-05-25T12:00:00') })
+    );
+    expect(newly).not.toContain('early_bird');
+  });
+
+  it('night_owl at 21:00', () => {
+    const newly = evaluateBadges(
+      mkCtx({ playedAt: new Date('2026-05-25T21:00:00') })
+    );
+    expect(newly).toContain('night_owl');
+  });
+
+  it('late_night at 1am', () => {
+    const newly = evaluateBadges(
+      mkCtx({ playedAt: new Date('2026-05-25T01:00:00') })
+    );
+    expect(newly).toContain('late_night');
+  });
+});
+
+describe('badges - daily', () => {
+  it('awards daily_first on daily session', () => {
+    const s = mkSession({ isDaily: true });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).toContain('daily_first');
+  });
+
+  it('does not award daily_first on regular session', () => {
+    const newly = evaluateBadges(mkCtx());
+    expect(newly).not.toContain('daily_first');
+  });
+});
+
+describe('badges - special', () => {
+  it('awards mix_master on perfect mix', () => {
+    const s = mkSession({ level: 'mix', correctCount: 100 });
+    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
+    expect(newly).toContain('mix_master');
+  });
+
+  it('awards new_year_play on Jan 1', () => {
+    const newly = evaluateBadges(
+      mkCtx({ playedAt: new Date('2026-01-01T10:00:00') })
+    );
+    expect(newly).toContain('new_year_play');
+  });
+
+  it('awards birthday_play matching MM-DD', () => {
+    const newly = evaluateBadges(
+      mkCtx({
+        playedAt: new Date('2026-03-15T10:00:00'),
+        birthdayMMDD: '03-15',
+      })
+    );
+    expect(newly).toContain('birthday_play');
+  });
+
+  it('awards comeback after 7+ day gap', () => {
+    const prev = mkSession({ completedAt: 1000 });
+    const now = mkSession({
+      completedAt: 1000 + 8 * 24 * 60 * 60 * 1000,
+    });
+    const newly = evaluateBadges(
+      mkCtx({ session: now, allSessions: [prev, now] })
+    );
+    expect(newly).toContain('comeback');
+  });
+});
+
+describe('badges - meta', () => {
+  it('badge_collector_25 with 25 badges', () => {
+    const badges = Array.from({ length: 25 }, (_, i) => `badge_${i}`);
+    const newly = evaluateBadges(
+      mkCtx({ user: mkUser({ earnedBadges: badges }) })
+    );
+    expect(newly).toContain('badge_collector_25');
+  });
+
+  it('badge_collector_all when all but it earned', () => {
+    const allButMeta = BADGE_CATALOG.filter(
+      (b) => b.id !== 'badge_collector_all'
+    ).map((b) => b.id);
+    const newly = evaluateBadges(
+      mkCtx({ user: mkUser({ earnedBadges: allButMeta }) })
+    );
+    expect(newly).toContain('badge_collector_all');
+  });
+});
+
+describe('calculateStreakDays', () => {
+  it('returns 0 with no sessions today', () => {
+    expect(calculateStreakDays([], new Date('2026-05-25T12:00:00'))).toBe(0);
+  });
+
+  it('returns 1 when only today played', () => {
+    const sessions = [
+      mkSession({ completedAt: new Date('2026-05-25T10:00:00').getTime() }),
+    ];
+    expect(
+      calculateStreakDays(sessions, new Date('2026-05-25T12:00:00'))
+    ).toBe(1);
+  });
+
+  it('returns 3 for 3 consecutive days', () => {
+    const sessions = [
+      mkSession({ completedAt: new Date('2026-05-23T10:00:00').getTime() }),
+      mkSession({ completedAt: new Date('2026-05-24T10:00:00').getTime() }),
+      mkSession({ completedAt: new Date('2026-05-25T10:00:00').getTime() }),
+    ];
+    expect(
+      calculateStreakDays(sessions, new Date('2026-05-25T12:00:00'))
+    ).toBe(3);
+  });
+
+  it('breaks streak on gap', () => {
+    const sessions = [
+      mkSession({ completedAt: new Date('2026-05-23T10:00:00').getTime() }),
+      mkSession({ completedAt: new Date('2026-05-25T10:00:00').getTime() }),
+    ];
+    expect(
+      calculateStreakDays(sessions, new Date('2026-05-25T12:00:00'))
+    ).toBe(1);
+  });
+});
+
+describe('calculatePoints', () => {
+  it('basic calculation', () => {
+    const s = mkSession({ correctCount: 100, level: 1, durationMs: 60_000 });
+    const pts = calculatePoints(s);
+    // 100 * (1 + 0.5) = 150, +50 (3min) +30 (perfect) = 230
+    expect(pts).toBe(230);
+  });
+
+  it('daily bonus +50', () => {
+    const s = mkSession({
+      correctCount: 100,
+      level: 1,
+      durationMs: 60_000,
+      isDaily: true,
+    });
+    expect(calculatePoints(s)).toBe(280);
+  });
+
+  it('no perfect bonus on miss', () => {
+    const s = mkSession({ correctCount: 90, level: 1, durationMs: 60_000 });
+    // 90 * 1.5 = 135, +50 = 185 (no perfect, no daily)
+    expect(calculatePoints(s)).toBe(185);
+  });
+});

--- a/app/sansu-100/lib/__tests__/daily.test.ts
+++ b/app/sansu-100/lib/__tests__/daily.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { todayKey, dailySeed, dailyLevel } from '../daily';
+import { generateSetSeeded } from '../problem-generator';
+
+describe('daily challenge', () => {
+  it('todayKey produces YYYY-MM-DD', () => {
+    expect(todayKey(new Date('2026-05-25T10:00:00'))).toBe('2026-05-25');
+  });
+
+  it('same date produces same seed', () => {
+    const d1 = new Date('2026-05-25T01:00:00');
+    const d2 = new Date('2026-05-25T23:00:00');
+    expect(dailySeed(d1)).toBe(dailySeed(d2));
+  });
+
+  it('different dates produce different seeds', () => {
+    expect(dailySeed(new Date('2026-05-25'))).not.toBe(
+      dailySeed(new Date('2026-05-26'))
+    );
+  });
+
+  it('daily problem set is reproducible', () => {
+    const seed = dailySeed(new Date('2026-05-25'));
+    const level = dailyLevel(new Date('2026-05-25'));
+    const a = generateSetSeeded(level as 1, 100, seed);
+    const b = generateSetSeeded(level as 1, 100, seed);
+    expect(a).toEqual(b);
+  });
+
+  it('dailyLevel returns a valid level number 1-11', () => {
+    for (let d = 0; d < 30; d++) {
+      const date = new Date(2026, 0, 1 + d);
+      const lvl = dailyLevel(date);
+      expect(lvl).toBeGreaterThanOrEqual(1);
+      expect(lvl).toBeLessThanOrEqual(11);
+    }
+  });
+});

--- a/app/sansu-100/lib/__tests__/pin-hash.test.ts
+++ b/app/sansu-100/lib/__tests__/pin-hash.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { hashPin, verifyPin } from '../pin-hash';
+
+describe('pin-hash', () => {
+  it('produces deterministic hash for same pin and salt', async () => {
+    const a = await hashPin('1234', 'salt-a');
+    const b = await hashPin('1234', 'salt-a');
+    expect(a).toBe(b);
+  });
+
+  it('produces different hash for different salt', async () => {
+    const a = await hashPin('1234', 'salt-a');
+    const b = await hashPin('1234', 'salt-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different hash for different pin', async () => {
+    const a = await hashPin('1234', 'salt');
+    const b = await hashPin('5678', 'salt');
+    expect(a).not.toBe(b);
+  });
+
+  it('rejects non-4-digit pins', async () => {
+    await expect(hashPin('123', 'salt')).rejects.toThrow();
+    await expect(hashPin('12345', 'salt')).rejects.toThrow();
+    await expect(hashPin('abcd', 'salt')).rejects.toThrow();
+  });
+
+  it('verifyPin returns true for correct pin', async () => {
+    const hash = await hashPin('1234', 'salt');
+    expect(await verifyPin('1234', 'salt', hash)).toBe(true);
+  });
+
+  it('verifyPin returns false for wrong pin', async () => {
+    const hash = await hashPin('1234', 'salt');
+    expect(await verifyPin('9999', 'salt', hash)).toBe(false);
+  });
+
+  it('hex output is 64 chars (SHA-256)', async () => {
+    const hash = await hashPin('1234', 'salt');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/app/sansu-100/lib/__tests__/problem-generator.test.ts
+++ b/app/sansu-100/lib/__tests__/problem-generator.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateSet,
+  generateSetSeeded,
+  hashStringToSeed,
+  mulberry32,
+} from '../problem-generator';
+import { LEVELS, getLevel } from '../levels';
+import type { LevelId } from '../types';
+
+describe('problem-generator', () => {
+  it('generates the requested number of problems per level', () => {
+    for (const level of LEVELS) {
+      const rng = mulberry32(42);
+      const set = generateSet(level.id, 100, rng);
+      expect(set).toHaveLength(100);
+    }
+  });
+
+  it('Level 1: addition without carry, answer 0-9', () => {
+    const set = generateSetSeeded(1, 200, 1);
+    for (const p of set) {
+      expect(p.op).toBe('add');
+      expect(p.a + p.b).toBe(p.answer);
+      expect(p.answer).toBeLessThanOrEqual(9);
+      expect((p.a % 10) + (p.b % 10)).toBeLessThan(10);
+    }
+  });
+
+  it('Level 2: addition with carry, answer 10-18', () => {
+    const set = generateSetSeeded(2, 200, 2);
+    for (const p of set) {
+      expect(p.op).toBe('add');
+      expect(p.answer).toBeGreaterThanOrEqual(10);
+      expect(p.answer).toBeLessThanOrEqual(18);
+    }
+  });
+
+  it('Level 3: subtraction non-negative, no borrow', () => {
+    const set = generateSetSeeded(3, 200, 3);
+    for (const p of set) {
+      expect(p.op).toBe('sub');
+      expect(p.answer).toBeGreaterThanOrEqual(0);
+      expect(p.a - p.b).toBe(p.answer);
+    }
+  });
+
+  it('Level 4: subtraction with borrow, non-negative', () => {
+    const set = generateSetSeeded(4, 200, 4);
+    for (const p of set) {
+      expect(p.op).toBe('sub');
+      expect(p.answer).toBeGreaterThanOrEqual(0);
+      expect(p.a).toBeGreaterThanOrEqual(10);
+      expect(p.a).toBeLessThanOrEqual(18);
+    }
+  });
+
+  it('Level 5: multiplication 1-9 × 1-9 (九九)', () => {
+    const set = generateSetSeeded(5, 200, 5);
+    for (const p of set) {
+      expect(p.op).toBe('mul');
+      expect(p.a).toBeGreaterThanOrEqual(1);
+      expect(p.a).toBeLessThanOrEqual(9);
+      expect(p.b).toBeGreaterThanOrEqual(1);
+      expect(p.b).toBeLessThanOrEqual(9);
+      expect(p.a * p.b).toBe(p.answer);
+    }
+  });
+
+  it('Level 6: division with no remainder', () => {
+    const set = generateSetSeeded(6, 200, 6);
+    for (const p of set) {
+      expect(p.op).toBe('div');
+      expect(p.a % p.b).toBe(0);
+      expect(p.answer).toBe(p.a / p.b);
+    }
+  });
+
+  it('Level 7: 2-digit + 1-digit addition', () => {
+    const set = generateSetSeeded(7, 200, 7);
+    for (const p of set) {
+      expect(p.op).toBe('add');
+      expect(p.a).toBeGreaterThanOrEqual(10);
+      expect(p.a).toBeLessThanOrEqual(99);
+      expect(p.b).toBeGreaterThanOrEqual(1);
+      expect(p.b).toBeLessThanOrEqual(9);
+    }
+  });
+
+  it('Level 8: 2-digit + 2-digit', () => {
+    const set = generateSetSeeded(8, 200, 8);
+    for (const p of set) {
+      expect(p.a).toBeGreaterThanOrEqual(10);
+      expect(p.b).toBeGreaterThanOrEqual(10);
+    }
+  });
+
+  it('Level 9: 2-digit - 2-digit, non-negative', () => {
+    const set = generateSetSeeded(9, 200, 9);
+    for (const p of set) {
+      expect(p.op).toBe('sub');
+      expect(p.answer).toBeGreaterThanOrEqual(0);
+      expect(p.a).toBeGreaterThanOrEqual(p.b);
+    }
+  });
+
+  it('Level 10: 2-digit × 1-digit', () => {
+    const set = generateSetSeeded(10, 200, 10);
+    for (const p of set) {
+      expect(p.op).toBe('mul');
+      expect(p.a).toBeGreaterThanOrEqual(10);
+      expect(p.b).toBeGreaterThanOrEqual(2);
+      expect(p.b).toBeLessThanOrEqual(9);
+    }
+  });
+
+  it('Level 11: 2-digit ÷ 1-digit with remainder allowed', () => {
+    const set = generateSetSeeded(11, 200, 11);
+    for (const p of set) {
+      expect(p.op).toBe('div');
+      expect(p.answer).toBe(Math.floor(p.a / p.b));
+    }
+  });
+
+  it('mix level pulls from multiple levels', () => {
+    const set = generateSetSeeded('mix' as LevelId, 200, 12);
+    const ops = new Set(set.map((p) => p.op));
+    expect(ops.size).toBeGreaterThan(1);
+  });
+
+  it('seeded RNG is deterministic', () => {
+    const a = generateSetSeeded(5, 100, 999);
+    const b = generateSetSeeded(5, 100, 999);
+    expect(a).toEqual(b);
+  });
+
+  it('different seeds produce different sets', () => {
+    const a = generateSetSeeded(5, 100, 1);
+    const b = generateSetSeeded(5, 100, 2);
+    expect(a).not.toEqual(b);
+  });
+
+  it('hashStringToSeed produces deterministic seed', () => {
+    expect(hashStringToSeed('hello')).toBe(hashStringToSeed('hello'));
+    expect(hashStringToSeed('hello')).not.toBe(hashStringToSeed('world'));
+  });
+
+  it('all LEVELS are well-defined', () => {
+    for (const level of LEVELS) {
+      expect(getLevel(level.id)).toBe(level);
+      expect(level.rangeA[0]).toBeLessThanOrEqual(level.rangeA[1]);
+      expect(level.rangeB[0]).toBeLessThanOrEqual(level.rangeB[1]);
+    }
+  });
+});

--- a/app/sansu-100/lib/api-client.ts
+++ b/app/sansu-100/lib/api-client.ts
@@ -1,0 +1,129 @@
+import type { SansuSession, SansuUserPublic } from './types';
+
+const BASE = '/api/sansu';
+
+export type CreateUserPayload = {
+  name: string;
+  avatar: string;
+  themeColor: string;
+  pinHash: string;
+  pinSalt: string;
+};
+
+function devAdminHeader(): Record<string, string> {
+  if (typeof window === 'undefined' || window.location.hostname !== 'localhost')
+    return {};
+  const principal = btoa(
+    JSON.stringify({
+      userId: 'admin-local',
+      userRoles: ['authenticated', 'anonymous'],
+      identityProvider: 'aad',
+      userDetails: 'admin@localhost',
+    })
+  );
+  return { 'x-ms-client-principal': principal };
+}
+
+async function jsonFetch<T>(
+  url: string,
+  init?: RequestInit,
+  extraHeaders?: Record<string, string>
+): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+      ...(extraHeaders ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+export const sansuApi = {
+  async createUser(payload: CreateUserPayload): Promise<SansuUserPublic> {
+    return jsonFetch<SansuUserPublic>(`${BASE}/users`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+  async findUser(name: string): Promise<SansuUserPublic | null> {
+    try {
+      return await jsonFetch<SansuUserPublic>(
+        `${BASE}/users?name=${encodeURIComponent(name)}`
+      );
+    } catch (e) {
+      if (e instanceof Error && /HTTP 404/.test(e.message)) return null;
+      throw e;
+    }
+  },
+  async getUser(userId: string): Promise<SansuUserPublic | null> {
+    try {
+      return await jsonFetch<SansuUserPublic>(
+        `${BASE}/users?userId=${encodeURIComponent(userId)}`
+      );
+    } catch (e) {
+      if (e instanceof Error && /HTTP 404/.test(e.message)) return null;
+      throw e;
+    }
+  },
+  async verifyPin(
+    userId: string,
+    pinHash: string
+  ): Promise<{ ok: boolean; user?: SansuUserPublic }> {
+    return jsonFetch<{ ok: boolean; user?: SansuUserPublic }>(
+      `${BASE}/users/verify`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId, pinHash }),
+      }
+    );
+  },
+  async submitSession(session: SansuSession): Promise<{ ok: true }> {
+    return jsonFetch<{ ok: true }>(`${BASE}/sessions`, {
+      method: 'POST',
+      body: JSON.stringify(session),
+    });
+  },
+  async getSessions(userId: string): Promise<SansuSession[]> {
+    return jsonFetch<SansuSession[]>(
+      `${BASE}/sessions?userId=${encodeURIComponent(userId)}`
+    );
+  },
+};
+
+export type AdminUserSummary = SansuUserPublic & {
+  totalSessions: number;
+};
+
+export const sansuAdminApi = {
+  async listUsers(): Promise<AdminUserSummary[]> {
+    return jsonFetch<AdminUserSummary[]>(
+      `${BASE}/admin/users`,
+      undefined,
+      devAdminHeader()
+    );
+  },
+  async resetPin(
+    userId: string,
+    pinHash: string,
+    pinSalt: string
+  ): Promise<{ ok: true }> {
+    return jsonFetch<{ ok: true }>(
+      `${BASE}/admin/users/${encodeURIComponent(userId)}/pin`,
+      { method: 'PATCH', body: JSON.stringify({ pinHash, pinSalt }) },
+      devAdminHeader()
+    );
+  },
+  async getSummary(): Promise<{
+    totalUsers: number;
+    totalSessions: number;
+    sessionsByDate: Record<string, number>;
+  }> {
+    return jsonFetch(`${BASE}/admin/summary`, undefined, devAdminHeader());
+  },
+};

--- a/app/sansu-100/lib/avatar.ts
+++ b/app/sansu-100/lib/avatar.ts
@@ -1,0 +1,65 @@
+import type { ThemeColor } from './types';
+
+export const AVATARS: readonly string[] = [
+  '🐶', '🐱', '🦊', '🐼', '🦁', '🐯',
+  '🐰', '🐻', '🐧', '🐸', '🦄', '🐙',
+  '🐳', '🦖', '🐝', '🦋', '🌟', '⚡',
+  '🔥', '🍎', '🍓', '🍕', '🎮', '⚽',
+];
+
+export const THEME_COLORS: readonly ThemeColor[] = [
+  'pink',
+  'blue',
+  'green',
+  'yellow',
+  'purple',
+  'orange',
+];
+
+export const THEME_COLOR_CLASSES: Record<
+  ThemeColor,
+  { bg: string; ring: string; text: string; gradient: string }
+> = {
+  pink: {
+    bg: 'bg-pink-100 dark:bg-pink-900/40',
+    ring: 'ring-pink-400',
+    text: 'text-pink-700 dark:text-pink-200',
+    gradient: 'from-pink-400 to-pink-600',
+  },
+  blue: {
+    bg: 'bg-blue-100 dark:bg-blue-900/40',
+    ring: 'ring-blue-400',
+    text: 'text-blue-700 dark:text-blue-200',
+    gradient: 'from-blue-400 to-blue-600',
+  },
+  green: {
+    bg: 'bg-green-100 dark:bg-green-900/40',
+    ring: 'ring-green-400',
+    text: 'text-green-700 dark:text-green-200',
+    gradient: 'from-green-400 to-green-600',
+  },
+  yellow: {
+    bg: 'bg-yellow-100 dark:bg-yellow-900/40',
+    ring: 'ring-yellow-400',
+    text: 'text-yellow-700 dark:text-yellow-200',
+    gradient: 'from-yellow-400 to-yellow-600',
+  },
+  purple: {
+    bg: 'bg-purple-100 dark:bg-purple-900/40',
+    ring: 'ring-purple-400',
+    text: 'text-purple-700 dark:text-purple-200',
+    gradient: 'from-purple-400 to-purple-600',
+  },
+  orange: {
+    bg: 'bg-orange-100 dark:bg-orange-900/40',
+    ring: 'ring-orange-400',
+    text: 'text-orange-700 dark:text-orange-200',
+    gradient: 'from-orange-400 to-orange-600',
+  },
+};
+
+export function getThemeClasses(color: string) {
+  return (
+    THEME_COLOR_CLASSES[color as ThemeColor] ?? THEME_COLOR_CLASSES.blue
+  );
+}

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -1,0 +1,107 @@
+export type BadgeTier = 'bronze' | 'silver' | 'gold' | 'rainbow';
+export type BadgeRarity = 'common' | 'rare' | 'epic' | 'legendary';
+export type BadgeCategory =
+  | 'sessions'
+  | 'perfect'
+  | 'speed'
+  | 'streak'
+  | 'master'
+  | 'timing'
+  | 'daily'
+  | 'special'
+  | 'meta';
+
+export type BadgeDef = {
+  id: string;
+  category: BadgeCategory;
+  name: string;
+  description: string;
+  icon: string;
+  tier: BadgeTier;
+  rarity: BadgeRarity;
+  hint?: string;
+};
+
+export const BADGE_CATALOG: readonly BadgeDef[] = [
+  // 練習回数系
+  { id: 'sessions_1', category: 'sessions', name: 'はじめの一歩', description: 'はじめての100マスをクリア！', icon: '👣', tier: 'bronze', rarity: 'common' },
+  { id: 'sessions_5', category: 'sessions', name: '5回チャレンジャー', description: '5回練習したよ', icon: '🌱', tier: 'bronze', rarity: 'common' },
+  { id: 'sessions_10', category: 'sessions', name: 'トレーニー', description: '10回練習したよ', icon: '🌿', tier: 'bronze', rarity: 'common' },
+  { id: 'sessions_30', category: 'sessions', name: 'ひと月マスター', description: '30回練習したよ', icon: '🌳', tier: 'silver', rarity: 'common' },
+  { id: 'sessions_50', category: 'sessions', name: 'ハーフセンチュリー', description: '50回練習したよ', icon: '🏃', tier: 'silver', rarity: 'rare' },
+  { id: 'sessions_100', category: 'sessions', name: 'センチュリー', description: '100回練習したよ', icon: '💯', tier: 'gold', rarity: 'rare' },
+  { id: 'sessions_200', category: 'sessions', name: 'ダブルセンチュリー', description: '200回練習したよ', icon: '🏆', tier: 'gold', rarity: 'epic' },
+  { id: 'sessions_500', category: 'sessions', name: '五百本ノック', description: '500回練習したよ', icon: '⚔️', tier: 'gold', rarity: 'epic' },
+  { id: 'sessions_1000', category: 'sessions', name: '千本桜', description: '1000回練習したよ！', icon: '🌸', tier: 'rainbow', rarity: 'legendary' },
+
+  // パーフェクト系
+  { id: 'perfect_first', category: 'perfect', name: '初パーフェクト', description: '全問正解だ！', icon: '💎', tier: 'silver', rarity: 'rare' },
+  { id: 'perfect_5', category: 'perfect', name: 'パーフェクト5', description: 'パーフェクト5回', icon: '✨', tier: 'silver', rarity: 'rare' },
+  { id: 'perfect_10', category: 'perfect', name: 'パーフェクト10', description: 'パーフェクト10回', icon: '🌟', tier: 'gold', rarity: 'epic' },
+  { id: 'perfect_50', category: 'perfect', name: 'パーフェクト職人', description: 'パーフェクト50回', icon: '👑', tier: 'rainbow', rarity: 'legendary' },
+  { id: 'perfect_streak_3', category: 'perfect', name: '3連パーフェクト', description: '3回連続パーフェクト', icon: '🎯', tier: 'gold', rarity: 'epic' },
+
+  // スピード系
+  { id: 'speed_5min', category: 'speed', name: '5分切り', description: '5分以内でクリア', icon: '⏱️', tier: 'bronze', rarity: 'common' },
+  { id: 'speed_3min', category: 'speed', name: '3分切り', description: '3分以内でクリア', icon: '⚡', tier: 'silver', rarity: 'rare' },
+  { id: 'speed_2min', category: 'speed', name: '2分切り', description: '2分以内でクリア', icon: '🚀', tier: 'gold', rarity: 'epic' },
+  { id: 'speed_90sec', category: 'speed', name: '90秒切り', description: '90秒以内でクリア', icon: '💨', tier: 'gold', rarity: 'epic' },
+  { id: 'speed_60sec', category: 'speed', name: '1分切り', description: '60秒以内でクリア', icon: '🔥', tier: 'rainbow', rarity: 'legendary' },
+  { id: 'speed_30sec', category: 'speed', name: '究極の30秒', description: '30秒以内でクリア', icon: '⚡', tier: 'rainbow', rarity: 'legendary' },
+
+  // 連続日数系
+  { id: 'streak_3', category: 'streak', name: '三日坊主そつぎょう', description: '3日連続練習', icon: '🔥', tier: 'bronze', rarity: 'common' },
+  { id: 'streak_7', category: 'streak', name: '一週間つづいた', description: '7日連続練習', icon: '🔥', tier: 'silver', rarity: 'rare' },
+  { id: 'streak_14', category: 'streak', name: '二週間つづいた', description: '14日連続練習', icon: '🔥', tier: 'silver', rarity: 'rare' },
+  { id: 'streak_30', category: 'streak', name: 'ひと月つづいた', description: '30日連続練習', icon: '🔥', tier: 'gold', rarity: 'epic' },
+  { id: 'streak_60', category: 'streak', name: '二ヶ月つづいた', description: '60日連続練習', icon: '🔥', tier: 'gold', rarity: 'epic' },
+  { id: 'streak_100', category: 'streak', name: '100日継続', description: '100日連続練習！', icon: '🔥', tier: 'rainbow', rarity: 'legendary' },
+
+  // 演算マスター系
+  { id: 'master_add_basic', category: 'master', name: 'たし算マスター（初級）', description: 'たし算Lv1-4を全てクリア', icon: '➕', tier: 'silver', rarity: 'rare' },
+  { id: 'master_add_full', category: 'master', name: 'たし算マスター', description: 'たし算の全レベルを制覇', icon: '🟢', tier: 'gold', rarity: 'epic' },
+  { id: 'master_sub_basic', category: 'master', name: 'ひき算マスター（初級）', description: 'ひき算Lv1-2をクリア', icon: '➖', tier: 'silver', rarity: 'rare' },
+  { id: 'master_sub_full', category: 'master', name: 'ひき算マスター', description: 'ひき算の全レベルを制覇', icon: '🟡', tier: 'gold', rarity: 'epic' },
+  { id: 'master_mul_basic', category: 'master', name: '九九マスター', description: '九九（Lv5）をクリア', icon: '✖️', tier: 'silver', rarity: 'rare' },
+  { id: 'master_mul_full', category: 'master', name: 'かけ算マスター', description: 'かけ算の全レベルを制覇', icon: '🔴', tier: 'gold', rarity: 'epic' },
+  { id: 'master_div_basic', category: 'master', name: 'わり算マスター（初級）', description: 'わり算Lv1をクリア', icon: '➗', tier: 'silver', rarity: 'rare' },
+  { id: 'master_div_full', category: 'master', name: 'わり算マスター', description: 'わり算の全レベルを制覇', icon: '🟣', tier: 'gold', rarity: 'epic' },
+
+  // 時間帯系
+  { id: 'early_bird', category: 'timing', name: 'はやおき！', description: '朝6-9時に練習', icon: '🌅', tier: 'bronze', rarity: 'common' },
+  { id: 'night_owl', category: 'timing', name: 'よふかし', description: '夜20-22時に練習', icon: '🌙', tier: 'bronze', rarity: 'common' },
+  { id: 'weekend_warrior', category: 'timing', name: '週末王者', description: '土日両方練習', icon: '🎽', tier: 'silver', rarity: 'rare' },
+
+  // デイリーチャレンジ系
+  { id: 'daily_first', category: 'daily', name: 'デイリーデビュー', description: 'デイリーチャレンジ初参加', icon: '📅', tier: 'bronze', rarity: 'common' },
+  { id: 'daily_7', category: 'daily', name: 'デイリー7連', description: 'デイリー7日連続', icon: '📆', tier: 'silver', rarity: 'rare' },
+  { id: 'daily_30', category: 'daily', name: 'デイリー30連', description: 'デイリー30日連続', icon: '🗓️', tier: 'gold', rarity: 'epic' },
+  { id: 'daily_100', category: 'daily', name: 'デイリー100連', description: 'デイリー100日連続！', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
+
+  // 特殊・面白系
+  { id: 'comeback', category: 'special', name: 'おかえり！', description: '7日空けて復帰', icon: '🌈', tier: 'silver', rarity: 'rare' },
+  { id: 'mix_master', category: 'special', name: 'ミックスマスター', description: '混合モードをクリア', icon: '🎲', tier: 'silver', rarity: 'rare' },
+  { id: 'birthday_play', category: 'special', name: 'たんじょうび練習', description: '誕生日に練習', icon: '🎂', tier: 'gold', rarity: 'epic' },
+  { id: 'new_year_play', category: 'special', name: '元日チャレンジ', description: '元日に練習', icon: '🎍', tier: 'gold', rarity: 'epic' },
+  { id: 'late_night', category: 'special', name: 'ナイトオウル', description: '深夜0-3時に練習', icon: '🦉', tier: 'silver', rarity: 'rare' },
+
+  // メタバッジ
+  { id: 'badge_collector_25', category: 'meta', name: 'バッジハンター', description: 'バッジを25個集めた', icon: '🎖️', tier: 'gold', rarity: 'epic' },
+  { id: 'badge_collector_all', category: 'meta', name: 'コンプリート！', description: '全バッジを集めた', icon: '🏆', tier: 'rainbow', rarity: 'legendary' },
+] as const;
+
+export const BADGES_BY_ID: Record<string, BadgeDef> = Object.fromEntries(
+  BADGE_CATALOG.map((b) => [b.id, b])
+);
+
+export function getBadgeDef(id: string): BadgeDef | undefined {
+  return BADGES_BY_ID[id];
+}
+
+export const TIER_COLORS: Record<BadgeTier, string> = {
+  bronze: 'from-amber-700 to-amber-500',
+  silver: 'from-slate-400 to-slate-200',
+  gold: 'from-yellow-500 to-yellow-300',
+  rainbow:
+    'from-pink-500 via-yellow-400 via-green-400 via-blue-500 to-purple-500',
+};

--- a/app/sansu-100/lib/badges.ts
+++ b/app/sansu-100/lib/badges.ts
@@ -1,0 +1,214 @@
+import { BADGE_CATALOG } from './badge-catalog';
+import type { SansuSession, SansuUserPublic } from './types';
+
+export type BadgeEvalContext = {
+  user: SansuUserPublic;
+  session: SansuSession;
+  /** All past sessions including the just-completed one (newest last) */
+  allSessions: SansuSession[];
+  /** Date in user's local timezone */
+  playedAt: Date;
+  /** YYYY-MM-DD of birthday if known (MM-DD comparison) */
+  birthdayMMDD?: string;
+};
+
+type Rule = (ctx: BadgeEvalContext) => boolean;
+
+const LEVELS_ADD = [1, 2, 7, 8];
+const LEVELS_SUB = [3, 4, 9];
+const LEVELS_MUL = [5, 10];
+const LEVELS_DIV = [6, 11];
+
+function levelsCleared(
+  sessions: SansuSession[],
+  levels: number[]
+): Set<number> {
+  const cleared = new Set<number>();
+  for (const s of sessions) {
+    if (
+      typeof s.level === 'number' &&
+      levels.includes(s.level) &&
+      s.correctCount === s.totalProblems
+    ) {
+      cleared.add(s.level);
+    }
+  }
+  return cleared;
+}
+
+function isPerfect(s: SansuSession): boolean {
+  return s.correctCount === s.totalProblems;
+}
+
+function consecutivePerfectTail(sessions: SansuSession[], n: number): boolean {
+  if (sessions.length < n) return false;
+  return sessions.slice(-n).every(isPerfect);
+}
+
+function dateToMMDD(date: Date): string {
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${mm}-${dd}`;
+}
+
+function dateToYMD(date: Date): string {
+  return `${date.getFullYear()}-${dateToMMDD(date)}`;
+}
+
+function uniqueDatesInLast(sessions: SansuSession[], days: number): Set<string> {
+  const set = new Set<string>();
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  for (const s of sessions) {
+    if (s.completedAt >= cutoff) {
+      set.add(dateToYMD(new Date(s.completedAt)));
+    }
+  }
+  return set;
+}
+
+const RULES: Record<string, Rule> = {
+  sessions_1: ({ allSessions }) => allSessions.length >= 1,
+  sessions_5: ({ allSessions }) => allSessions.length >= 5,
+  sessions_10: ({ allSessions }) => allSessions.length >= 10,
+  sessions_30: ({ allSessions }) => allSessions.length >= 30,
+  sessions_50: ({ allSessions }) => allSessions.length >= 50,
+  sessions_100: ({ allSessions }) => allSessions.length >= 100,
+  sessions_200: ({ allSessions }) => allSessions.length >= 200,
+  sessions_500: ({ allSessions }) => allSessions.length >= 500,
+  sessions_1000: ({ allSessions }) => allSessions.length >= 1000,
+
+  perfect_first: ({ session }) => isPerfect(session),
+  perfect_5: ({ allSessions }) => allSessions.filter(isPerfect).length >= 5,
+  perfect_10: ({ allSessions }) => allSessions.filter(isPerfect).length >= 10,
+  perfect_50: ({ allSessions }) => allSessions.filter(isPerfect).length >= 50,
+  perfect_streak_3: ({ allSessions }) =>
+    consecutivePerfectTail(allSessions, 3),
+
+  speed_5min: ({ session }) =>
+    isPerfect(session) && session.durationMs <= 5 * 60_000,
+  speed_3min: ({ session }) =>
+    isPerfect(session) && session.durationMs <= 3 * 60_000,
+  speed_2min: ({ session }) =>
+    isPerfect(session) && session.durationMs <= 2 * 60_000,
+  speed_90sec: ({ session }) =>
+    isPerfect(session) && session.durationMs <= 90_000,
+  speed_60sec: ({ session }) =>
+    isPerfect(session) && session.durationMs <= 60_000,
+  speed_30sec: ({ session }) =>
+    isPerfect(session) && session.durationMs <= 30_000,
+
+  streak_3: ({ user }) => user.currentStreakDays >= 3,
+  streak_7: ({ user }) => user.currentStreakDays >= 7,
+  streak_14: ({ user }) => user.currentStreakDays >= 14,
+  streak_30: ({ user }) => user.currentStreakDays >= 30,
+  streak_60: ({ user }) => user.currentStreakDays >= 60,
+  streak_100: ({ user }) => user.currentStreakDays >= 100,
+
+  master_add_basic: ({ allSessions }) =>
+    levelsCleared(allSessions, [1, 2]).size === 2,
+  master_add_full: ({ allSessions }) =>
+    levelsCleared(allSessions, LEVELS_ADD).size === LEVELS_ADD.length,
+  master_sub_basic: ({ allSessions }) =>
+    levelsCleared(allSessions, [3, 4]).size === 2,
+  master_sub_full: ({ allSessions }) =>
+    levelsCleared(allSessions, LEVELS_SUB).size === LEVELS_SUB.length,
+  master_mul_basic: ({ allSessions }) =>
+    levelsCleared(allSessions, [5]).size === 1,
+  master_mul_full: ({ allSessions }) =>
+    levelsCleared(allSessions, LEVELS_MUL).size === LEVELS_MUL.length,
+  master_div_basic: ({ allSessions }) =>
+    levelsCleared(allSessions, [6]).size === 1,
+  master_div_full: ({ allSessions }) =>
+    levelsCleared(allSessions, LEVELS_DIV).size === LEVELS_DIV.length,
+
+  early_bird: ({ playedAt }) => {
+    const h = playedAt.getHours();
+    return h >= 6 && h < 9;
+  },
+  night_owl: ({ playedAt }) => {
+    const h = playedAt.getHours();
+    return h >= 20 && h < 22;
+  },
+  weekend_warrior: ({ allSessions }) => {
+    const last14 = uniqueDatesInLast(allSessions, 14);
+    let sawSat = false;
+    let sawSun = false;
+    for (const ymd of last14) {
+      const d = new Date(ymd + 'T12:00:00');
+      if (d.getDay() === 6) sawSat = true;
+      if (d.getDay() === 0) sawSun = true;
+    }
+    return sawSat && sawSun;
+  },
+
+  daily_first: ({ session }) => session.isDaily,
+  daily_7: ({ user, session }) => session.isDaily && user.currentStreakDays >= 7,
+  daily_30: ({ user, session }) =>
+    session.isDaily && user.currentStreakDays >= 30,
+  daily_100: ({ user, session }) =>
+    session.isDaily && user.currentStreakDays >= 100,
+
+  comeback: ({ allSessions, session }) => {
+    if (allSessions.length < 2) return false;
+    const prev = allSessions[allSessions.length - 2];
+    return session.completedAt - prev.completedAt >= 7 * 24 * 60 * 60 * 1000;
+  },
+  mix_master: ({ session }) => session.level === 'mix' && isPerfect(session),
+  birthday_play: ({ playedAt, birthdayMMDD }) =>
+    !!birthdayMMDD && dateToMMDD(playedAt) === birthdayMMDD,
+  new_year_play: ({ playedAt }) => dateToMMDD(playedAt) === '01-01',
+  late_night: ({ playedAt }) => {
+    const h = playedAt.getHours();
+    return h >= 0 && h < 3;
+  },
+
+  badge_collector_25: ({ user }) => user.earnedBadges.length >= 25,
+  badge_collector_all: ({ user }) =>
+    user.earnedBadges.length >= BADGE_CATALOG.length - 1,
+};
+
+export function evaluateBadges(ctx: BadgeEvalContext): string[] {
+  const earned = new Set(ctx.user.earnedBadges);
+  const newly: string[] = [];
+  for (const def of BADGE_CATALOG) {
+    if (earned.has(def.id)) continue;
+    const rule = RULES[def.id];
+    if (rule && rule(ctx)) {
+      newly.push(def.id);
+    }
+  }
+  return newly;
+}
+
+/**
+ * Calculate streak days based on session history and today's session date.
+ * Returns the number of consecutive days (including today) ending at the given date.
+ */
+export function calculateStreakDays(
+  sessions: SansuSession[],
+  asOfDate: Date
+): number {
+  const dates = new Set<string>();
+  for (const s of sessions) {
+    dates.add(dateToYMD(new Date(s.completedAt)));
+  }
+  let count = 0;
+  const cursor = new Date(asOfDate);
+  cursor.setHours(12, 0, 0, 0);
+  while (dates.has(dateToYMD(cursor))) {
+    count++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return count;
+}
+
+export function calculatePoints(session: SansuSession): number {
+  let pts = session.correctCount;
+  const levelNum = typeof session.level === 'number' ? session.level : 6;
+  pts = Math.round(pts * (1 + levelNum * 0.5));
+  if (session.durationMs <= 3 * 60_000) pts += 50;
+  else if (session.durationMs <= 5 * 60_000) pts += 20;
+  if (session.correctCount === session.totalProblems) pts += 30;
+  if (session.isDaily) pts += 50;
+  return pts;
+}

--- a/app/sansu-100/lib/daily.ts
+++ b/app/sansu-100/lib/daily.ts
@@ -1,0 +1,27 @@
+import { hashStringToSeed } from './problem-generator';
+
+export function todayKey(d: Date = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Daily challenge seed derived from date only — same problems for all users on the same day.
+ */
+export function dailySeed(d: Date = new Date()): number {
+  return hashStringToSeed(`daily-${todayKey(d)}`);
+}
+
+/**
+ * Pick a level for today's challenge based on date — rotates through a curated list.
+ */
+export function dailyLevel(d: Date = new Date()): number {
+  const rotation = [1, 2, 3, 4, 5, 6, 5, 7, 8, 9, 5, 10, 11];
+  const dayOfYear = Math.floor(
+    (d.getTime() - new Date(d.getFullYear(), 0, 0).getTime()) /
+      (24 * 60 * 60 * 1000)
+  );
+  return rotation[dayOfYear % rotation.length];
+}

--- a/app/sansu-100/lib/dev-seed.ts
+++ b/app/sansu-100/lib/dev-seed.ts
@@ -1,0 +1,60 @@
+import { sansuApi } from './api-client';
+import { hashPin } from './pin-hash';
+import { storage } from './storage';
+import type { SansuUserPublic } from './types';
+
+const SEED_KEY = 'sansu-100:dev-seeded';
+
+const SEED_USERS = [
+  { name: 'たろう', pin: '1111', avatar: '🐶', themeColor: 'blue' },
+  { name: 'はなこ', pin: '2222', avatar: '🌸', themeColor: 'pink' },
+  { name: 'けんた', pin: '3333', avatar: '🦊', themeColor: 'green' },
+];
+
+/** Returns true if users were newly seeded (localStorage was updated). */
+export async function seedDevUsers(): Promise<boolean> {
+  if (sessionStorage.getItem(SEED_KEY)) return false;
+
+  const created: SansuUserPublic[] = [];
+  for (const u of SEED_USERS) {
+    // skip if already registered on server
+    const existing = await sansuApi.findUser(u.name).catch(() => null);
+    if (existing) {
+      storage.upsertUser(existing);
+      created.push(existing);
+      continue;
+    }
+    // generate a fresh UUID as id/salt
+    const id = crypto.randomUUID();
+    const pinHash = await hashPin(u.pin, id);
+    const user = await sansuApi
+      .createUser({
+        name: u.name,
+        avatar: u.avatar,
+        themeColor: u.themeColor,
+        pinHash,
+        pinSalt: id,
+      })
+      .catch((e) => {
+        console.warn('[dev-seed] failed to create', u.name, e);
+        return null;
+      });
+    if (user) {
+      storage.upsertUser(user);
+      created.push(user);
+    }
+  }
+
+  if (created.length > 0) {
+    // auto-select the first user so the home screen is immediately useful
+    storage.setCurrentUserId(created[0].id);
+    console.info(
+      '[dev-seed] seeded users:',
+      created.map((u) => `${u.avatar}${u.name}`).join(', '),
+      '| PINs: 1111 / 2222 / 3333'
+    );
+  }
+
+  sessionStorage.setItem(SEED_KEY, '1');
+  return created.length > 0;
+}

--- a/app/sansu-100/lib/levels.ts
+++ b/app/sansu-100/lib/levels.ts
@@ -1,0 +1,133 @@
+import type { LevelId, Operation } from './types';
+
+export type LevelDef = {
+  id: Exclude<LevelId, 'mix'>;
+  operation: Exclude<Operation, 'mixed'>;
+  label: string;
+  description: string;
+  rangeA: [number, number];
+  rangeB: [number, number];
+  constraints?: {
+    noCarry?: boolean;
+    withCarry?: boolean;
+    noBorrow?: boolean;
+    withBorrow?: boolean;
+    nonNegativeResult?: boolean;
+    integerResult?: boolean;
+    allowRemainder?: boolean;
+  };
+};
+
+export const LEVELS: readonly LevelDef[] = [
+  {
+    id: 1,
+    operation: 'add',
+    label: 'たし算 Lv.1',
+    description: '1けた＋1けた（くりあがりなし）',
+    rangeA: [0, 9],
+    rangeB: [0, 9],
+    constraints: { noCarry: true },
+  },
+  {
+    id: 2,
+    operation: 'add',
+    label: 'たし算 Lv.2',
+    description: '1けた＋1けた（くりあがりあり）',
+    rangeA: [1, 9],
+    rangeB: [1, 9],
+    constraints: { withCarry: true },
+  },
+  {
+    id: 3,
+    operation: 'sub',
+    label: 'ひき算 Lv.1',
+    description: '1けた−1けた（くりさがりなし）',
+    rangeA: [0, 9],
+    rangeB: [0, 9],
+    constraints: { nonNegativeResult: true, noBorrow: true },
+  },
+  {
+    id: 4,
+    operation: 'sub',
+    label: 'ひき算 Lv.2',
+    description: '2けた−1けた（くりさがりあり）',
+    rangeA: [10, 18],
+    rangeB: [1, 9],
+    constraints: { nonNegativeResult: true, withBorrow: true },
+  },
+  {
+    id: 5,
+    operation: 'mul',
+    label: 'かけ算（九九）',
+    description: '1×1〜9×9',
+    rangeA: [1, 9],
+    rangeB: [1, 9],
+  },
+  {
+    id: 6,
+    operation: 'div',
+    label: 'わり算 Lv.1',
+    description: '九九の逆算（あまりなし）',
+    rangeA: [1, 81],
+    rangeB: [1, 9],
+    constraints: { integerResult: true, allowRemainder: false },
+  },
+  {
+    id: 7,
+    operation: 'add',
+    label: 'たし算 Lv.3',
+    description: '2けた＋1けた',
+    rangeA: [10, 99],
+    rangeB: [1, 9],
+  },
+  {
+    id: 8,
+    operation: 'add',
+    label: 'たし算 Lv.4',
+    description: '2けた＋2けた',
+    rangeA: [10, 99],
+    rangeB: [10, 99],
+  },
+  {
+    id: 9,
+    operation: 'sub',
+    label: 'ひき算 Lv.3',
+    description: '2けた−2けた',
+    rangeA: [10, 99],
+    rangeB: [10, 99],
+    constraints: { nonNegativeResult: true },
+  },
+  {
+    id: 10,
+    operation: 'mul',
+    label: 'かけ算 Lv.2',
+    description: '2けた×1けた',
+    rangeA: [10, 99],
+    rangeB: [2, 9],
+  },
+  {
+    id: 11,
+    operation: 'div',
+    label: 'わり算 Lv.2',
+    description: '2けた÷1けた（あまりあり）',
+    rangeA: [10, 99],
+    rangeB: [2, 9],
+    constraints: { integerResult: true, allowRemainder: true },
+  },
+] as const;
+
+export function getLevel(id: Exclude<LevelId, 'mix'>): LevelDef {
+  const level = LEVELS.find((l) => l.id === id);
+  if (!level) throw new Error(`Unknown level: ${id}`);
+  return level;
+}
+
+export const LEVELS_BY_OPERATION: Record<
+  Exclude<Operation, 'mixed'>,
+  LevelDef[]
+> = {
+  add: LEVELS.filter((l) => l.operation === 'add'),
+  sub: LEVELS.filter((l) => l.operation === 'sub'),
+  mul: LEVELS.filter((l) => l.operation === 'mul'),
+  div: LEVELS.filter((l) => l.operation === 'div'),
+};

--- a/app/sansu-100/lib/pin-hash.ts
+++ b/app/sansu-100/lib/pin-hash.ts
@@ -1,0 +1,27 @@
+export async function hashPin(pin: string, salt: string): Promise<string> {
+  if (!/^\d{4}$/.test(pin)) {
+    throw new Error('PIN must be exactly 4 digits');
+  }
+  const encoder = new TextEncoder();
+  const data = encoder.encode(`${salt}:${pin}`);
+  const hashBuf = await crypto.subtle.digest('SHA-256', data);
+  const bytes = new Uint8Array(hashBuf);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function verifyPin(
+  pin: string,
+  salt: string,
+  expectedHash: string
+): Promise<boolean> {
+  const actual = await hashPin(pin, salt);
+  // constant-time-ish comparison
+  if (actual.length !== expectedHash.length) return false;
+  let diff = 0;
+  for (let i = 0; i < actual.length; i++) {
+    diff |= actual.charCodeAt(i) ^ expectedHash.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/app/sansu-100/lib/problem-generator.ts
+++ b/app/sansu-100/lib/problem-generator.ts
@@ -1,0 +1,106 @@
+import { LEVELS, getLevel, type LevelDef } from './levels';
+import type { LevelId, Problem } from './types';
+
+export type Rng = () => number;
+
+export function mulberry32(seed: number): Rng {
+  let t = seed >>> 0;
+  return function () {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = t;
+    r = Math.imul(r ^ (r >>> 15), r | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function hashStringToSeed(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function randInt(rng: Rng, min: number, max: number): number {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+function digitsCarry(a: number, b: number): boolean {
+  return a % 10 + b % 10 >= 10;
+}
+
+function digitsBorrow(a: number, b: number): boolean {
+  return a % 10 < b % 10;
+}
+
+export function generateOne(level: LevelDef, rng: Rng): Problem {
+  const { operation, rangeA, rangeB, constraints } = level;
+
+  for (let attempt = 0; attempt < 200; attempt++) {
+    let a = randInt(rng, rangeA[0], rangeA[1]);
+    let b = randInt(rng, rangeB[0], rangeB[1]);
+
+    if (operation === 'add') {
+      if (constraints?.noCarry && digitsCarry(a, b)) continue;
+      if (constraints?.withCarry && !digitsCarry(a, b)) continue;
+      return { a, b, op: 'add', answer: a + b };
+    }
+
+    if (operation === 'sub') {
+      // ensure non-negative
+      if (a < b) [a, b] = [b, a];
+      if (constraints?.nonNegativeResult && a < b) continue;
+      if (constraints?.noBorrow && digitsBorrow(a, b)) continue;
+      if (constraints?.withBorrow && !digitsBorrow(a, b)) continue;
+      return { a, b, op: 'sub', answer: a - b };
+    }
+
+    if (operation === 'mul') {
+      return { a, b, op: 'mul', answer: a * b };
+    }
+
+    if (operation === 'div') {
+      if (constraints?.allowRemainder === false) {
+        // generate as b * q form for clean integer division
+        const q = randInt(rng, 1, 9);
+        const divisor = randInt(rng, rangeB[0], rangeB[1]);
+        const dividend = divisor * q;
+        if (dividend < rangeA[0] || dividend > rangeA[1]) continue;
+        return { a: dividend, b: divisor, op: 'div', answer: q };
+      }
+      // with remainder: answer is the integer quotient
+      if (b === 0) continue;
+      return { a, b, op: 'div', answer: Math.floor(a / b) };
+    }
+  }
+
+  throw new Error(
+    `Failed to generate problem for level ${level.id} within attempts`
+  );
+}
+
+export function generateSet(
+  levelId: LevelId,
+  count: number,
+  rng: Rng
+): Problem[] {
+  if (levelId === 'mix') {
+    const all = LEVELS.slice();
+    return Array.from({ length: count }, () => {
+      const idx = Math.floor(rng() * all.length);
+      return generateOne(all[idx], rng);
+    });
+  }
+  const level = getLevel(levelId);
+  return Array.from({ length: count }, () => generateOne(level, rng));
+}
+
+export function generateSetSeeded(
+  levelId: LevelId,
+  count: number,
+  seed: number
+): Problem[] {
+  return generateSet(levelId, count, mulberry32(seed));
+}

--- a/app/sansu-100/lib/session-result.ts
+++ b/app/sansu-100/lib/session-result.ts
@@ -1,0 +1,98 @@
+import { calculatePoints, calculateStreakDays, evaluateBadges } from './badges';
+import type { AnsweredProblem, LevelId, Operation, SansuSession, SansuUserPublic } from './types';
+
+export type FinishSessionInput = {
+  user: SansuUserPublic;
+  level: LevelId;
+  operation: Operation;
+  isDaily: boolean;
+  startedAt: number;
+  completedAt: number;
+  problems: AnsweredProblem[];
+  pastSessions: SansuSession[];
+};
+
+export type FinishSessionResult = {
+  session: SansuSession;
+  updatedUser: SansuUserPublic;
+  newBadges: string[];
+  pointsEarned: number;
+};
+
+export function finishSession(input: FinishSessionInput): FinishSessionResult {
+  const {
+    user,
+    level,
+    operation,
+    isDaily,
+    startedAt,
+    completedAt,
+    problems,
+    pastSessions,
+  } = input;
+
+  const correctCount = problems.filter((p) => p.isCorrect).length;
+  const durationMs = completedAt - startedAt;
+
+  const sessionId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `s_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+
+  const baseSession: SansuSession = {
+    id: sessionId,
+    userId: user.id,
+    userName: user.name,
+    level,
+    operation,
+    isDaily,
+    startedAt,
+    completedAt,
+    durationMs,
+    totalProblems: problems.length,
+    correctCount,
+    pointsEarned: 0,
+    newBadges: [],
+  };
+
+  const pointsEarned = calculatePoints(baseSession);
+  const session: SansuSession = { ...baseSession, pointsEarned };
+
+  const allSessions = [...pastSessions, session];
+  const streak = calculateStreakDays(allSessions, new Date(completedAt));
+
+  const bestKey = `lv${level}:${operation}`;
+  const prevBest = user.bestTimesByLevel[bestKey];
+  const isPerfect = correctCount === problems.length;
+  const newBest =
+    isPerfect && (!prevBest || durationMs < prevBest) ? durationMs : prevBest;
+
+  const intermediateUser: SansuUserPublic = {
+    ...user,
+    currentStreakDays: streak,
+    lastPlayedDate: new Date(completedAt).toISOString().slice(0, 10),
+    lastPlayedAt: completedAt,
+    totalSessions: user.totalSessions + 1,
+    bestTimesByLevel: {
+      ...user.bestTimesByLevel,
+      ...(newBest !== undefined ? { [bestKey]: newBest } : {}),
+    },
+  };
+
+  const newBadges = evaluateBadges({
+    user: intermediateUser,
+    session,
+    allSessions,
+    playedAt: new Date(completedAt),
+  });
+
+  session.newBadges = newBadges;
+
+  const updatedUser: SansuUserPublic = {
+    ...intermediateUser,
+    earnedBadges: [...intermediateUser.earnedBadges, ...newBadges],
+    totalPoints: intermediateUser.totalPoints + pointsEarned,
+  };
+
+  return { session, updatedUser, newBadges, pointsEarned };
+}

--- a/app/sansu-100/lib/sound-presets.ts
+++ b/app/sansu-100/lib/sound-presets.ts
@@ -1,0 +1,54 @@
+let audioCtx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  if (!audioCtx) {
+    const Ctor =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!Ctor) return null;
+    audioCtx = new Ctor();
+  }
+  return audioCtx;
+}
+
+function playTone(
+  freq: number,
+  durationMs: number,
+  delayMs = 0,
+  type: OscillatorType = 'sine',
+  volume = 0.2
+) {
+  const ctx = getCtx();
+  if (!ctx) return;
+  const start = ctx.currentTime + delayMs / 1000;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, start);
+  gain.gain.setValueAtTime(0, start);
+  gain.gain.linearRampToValueAtTime(volume, start + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + durationMs / 1000);
+  osc.connect(gain).connect(ctx.destination);
+  osc.start(start);
+  osc.stop(start + durationMs / 1000);
+}
+
+export const sound = {
+  correct() {
+    playTone(880, 120, 0, 'triangle', 0.15);
+  },
+  wrong() {
+    playTone(200, 200, 0, 'sawtooth', 0.15);
+  },
+  fanfare() {
+    // simple fanfare: C E G C
+    [
+      [523.25, 0],
+      [659.25, 120],
+      [783.99, 240],
+      [1046.5, 360],
+    ].forEach(([f, d]) => playTone(f, 250, d, 'triangle', 0.18));
+  },
+};

--- a/app/sansu-100/lib/storage.ts
+++ b/app/sansu-100/lib/storage.ts
@@ -1,0 +1,104 @@
+import type { SansuSession, SansuUserPublic } from './types';
+
+const KEY_CURRENT = 'sansu-100:current-user';
+const KEY_USERS = 'sansu-100:users';
+const KEY_SESSIONS = (userId: string) => `sansu-100:sessions:${userId}`;
+const KEY_SETTINGS = 'sansu-100:settings';
+const KEY_PENDING = 'sansu-100:pending-sync';
+
+export type SansuSettings = {
+  soundOn: boolean;
+  keypadMode: 'on-screen' | 'keyboard' | 'auto';
+};
+
+const DEFAULT_SETTINGS: SansuSettings = {
+  soundOn: true,
+  keypadMode: 'auto',
+};
+
+function safeGet<T>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeSet(key: string, value: unknown): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // quota exceeded — silently drop
+  }
+}
+
+export const storage = {
+  getCurrentUserId(): string | null {
+    return safeGet<string | null>(KEY_CURRENT, null);
+  },
+  setCurrentUserId(id: string | null): void {
+    if (id === null) {
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(KEY_CURRENT);
+      }
+      return;
+    }
+    safeSet(KEY_CURRENT, id);
+  },
+
+  getUsers(): SansuUserPublic[] {
+    return safeGet<SansuUserPublic[]>(KEY_USERS, []);
+  },
+  setUsers(users: SansuUserPublic[]): void {
+    safeSet(KEY_USERS, users);
+  },
+  upsertUser(user: SansuUserPublic): void {
+    const users = storage.getUsers();
+    const idx = users.findIndex((u) => u.id === user.id);
+    if (idx >= 0) users[idx] = user;
+    else users.push(user);
+    storage.setUsers(users);
+  },
+  removeUser(id: string): void {
+    const users = storage.getUsers().filter((u) => u.id !== id);
+    storage.setUsers(users);
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(KEY_SESSIONS(id));
+    }
+  },
+
+  getSessions(userId: string): SansuSession[] {
+    return safeGet<SansuSession[]>(KEY_SESSIONS(userId), []);
+  },
+  appendSession(session: SansuSession): void {
+    const list = storage.getSessions(session.userId);
+    list.push(session);
+    // keep last 200 to bound localStorage usage
+    const trimmed = list.slice(-200);
+    safeSet(KEY_SESSIONS(session.userId), trimmed);
+  },
+
+  getSettings(): SansuSettings {
+    return safeGet<SansuSettings>(KEY_SETTINGS, DEFAULT_SETTINGS);
+  },
+  setSettings(s: SansuSettings): void {
+    safeSet(KEY_SETTINGS, s);
+  },
+
+  getPendingSync(): SansuSession[] {
+    return safeGet<SansuSession[]>(KEY_PENDING, []);
+  },
+  pushPending(session: SansuSession): void {
+    const list = storage.getPendingSync();
+    list.push(session);
+    safeSet(KEY_PENDING, list);
+  },
+  clearPending(ids: string[]): void {
+    const list = storage.getPendingSync().filter((s) => !ids.includes(s.id));
+    safeSet(KEY_PENDING, list);
+  },
+};

--- a/app/sansu-100/lib/types.ts
+++ b/app/sansu-100/lib/types.ts
@@ -1,0 +1,74 @@
+export type Operation = 'add' | 'sub' | 'mul' | 'div' | 'mixed';
+
+export type LevelId =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 'mix';
+
+export type Problem = {
+  a: number;
+  b: number;
+  op: Exclude<Operation, 'mixed'>;
+  answer: number;
+};
+
+export type AnsweredProblem = Problem & {
+  userAnswer: number;
+  isCorrect: boolean;
+  timeMs: number;
+};
+
+export type SansuUserPublic = {
+  id: string;
+  name: string;
+  avatar: string;
+  themeColor: string;
+  createdAt: number;
+  totalPoints: number;
+  earnedBadges: string[];
+  bestTimesByLevel: Record<string, number>;
+  currentStreakDays: number;
+  lastPlayedDate: string;
+  lastPlayedAt: number;
+  totalSessions: number;
+  pinResetAt?: number;
+  pinResetBy?: string;
+};
+
+export type SansuUserServer = SansuUserPublic & {
+  pinHash: string;
+  pinSalt: string;
+};
+
+export type SansuSession = {
+  id: string;
+  userId: string;
+  userName: string;
+  level: LevelId;
+  operation: Operation;
+  isDaily: boolean;
+  startedAt: number;
+  completedAt: number;
+  durationMs: number;
+  totalProblems: number;
+  correctCount: number;
+  pointsEarned: number;
+  newBadges: string[];
+};
+
+export type ThemeColor =
+  | 'pink'
+  | 'blue'
+  | 'green'
+  | 'yellow'
+  | 'purple'
+  | 'orange';

--- a/app/sansu-100/login/page.tsx
+++ b/app/sansu-100/login/page.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import PinPad from '../components/PinPad';
+import { useSansuUser } from '../hooks/useSansuUser';
+import { sansuApi } from '../lib/api-client';
+import { hashPin } from '../lib/pin-hash';
+import type { SansuUserPublic } from '../lib/types';
+
+export default function LoginPage(): React.JSX.Element {
+  const router = useRouter();
+  const { saveUser } = useSansuUser();
+  const [name, setName] = useState('');
+  const [foundUser, setFoundUser] = useState<SansuUserPublic | null>(null);
+  const [pin, setPin] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSearch = async () => {
+    if (!name.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const u = await sansuApi.findUser(name.trim());
+      if (!u) {
+        setError('みつからなかったよ');
+      } else {
+        setFoundUser(u);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'エラー');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerify = async (pinValue: string = pin) => {
+    if (!foundUser || pinValue.length !== 4) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const hash = await hashPin(pinValue, foundUser.id);
+      const res = await sansuApi.verifyPin(foundUser.id, hash);
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        router.push('/sansu-100');
+      } else {
+        setError('あいことばが ちがうみたい');
+        setPin('');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'エラー');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-6 px-4 py-8">
+        <Header
+          title="べつの たんまつで つくった"
+          description="なまえで さがしてみよう"
+          showBackButton
+          backHref="/sansu-100"
+          backLabel="ホームにもどる"
+        />
+
+        {!foundUser ? (
+          <div className="space-y-4 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
+              なまえ
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white p-3 text-gray-900 focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            />
+            {error ? <p className="text-sm text-red-600 dark:text-red-400">{error}</p> : null}
+            <button
+              type="button"
+              onClick={handleSearch}
+              disabled={loading || !name.trim()}
+              className="w-full rounded-lg bg-blue-600 px-4 py-3 font-bold text-white hover:bg-blue-700 disabled:bg-gray-400"
+            >
+              {loading ? 'さがしてる...' : 'さがす'}
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <div className="flex flex-col items-center gap-2">
+              <span className="text-6xl">{foundUser.avatar}</span>
+              <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+                {foundUser.name}
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                これで あってる？
+              </p>
+            </div>
+            <PinPad
+              value={pin}
+              onChange={setPin}
+              onSubmit={handleVerify}
+              error={error}
+              disabled={loading}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setFoundUser(null);
+                setPin('');
+                setError(null);
+              }}
+              className="w-full rounded-lg bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ← べつの なまえを いれる
+            </button>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../components/header';
+import ThemeToggle from '../components/theme-toggle';
+
+import PinPad from './components/PinPad';
+import UserTile from './components/UserTile';
+import { useSansuSync } from './hooks/useSansuSync';
+import { useSansuUser } from './hooks/useSansuUser';
+import { sansuApi } from './lib/api-client';
+import { dailyLevel, todayKey } from './lib/daily';
+import { hashPin } from './lib/pin-hash';
+import type { SansuUserPublic } from './lib/types';
+
+const IS_DEV = process.env.NODE_ENV !== 'production';
+
+export default function SansuHome(): React.JSX.Element {
+  useSansuSync();
+  const router = useRouter();
+  const { recentUsers, currentUser, selectUser, saveUser, loaded, refreshUsers } =
+    useSansuUser();
+  const seedDone = useRef(false);
+  const [selectingUser, setSelectingUser] = useState<SansuUserPublic | null>(
+    null
+  );
+  const [pin, setPin] = useState('');
+  const [pinError, setPinError] = useState<string | null>(null);
+  const [failedAttempts, setFailedAttempts] = useState(0);
+
+  // Auto-seed test users in dev mode on first mount
+  useEffect(() => {
+    if (!IS_DEV || seedDone.current) return;
+    seedDone.current = true;
+    import('./lib/dev-seed').then(({ seedDevUsers }) =>
+      seedDevUsers().then((seeded) => {
+        if (seeded) refreshUsers();
+      }).catch(console.warn)
+    );
+  }, [refreshUsers]);
+
+  const handleSelect = (user: SansuUserPublic) => {
+    setSelectingUser(user);
+    setPin('');
+    setPinError(null);
+  };
+
+  const handleVerifyPin = async (pinValue: string = pin) => {
+    if (!selectingUser || pinValue.length !== 4) return;
+    if (failedAttempts >= 3) {
+      setPinError('3回まちがえたよ。すこし まってからもういちど ためしてね');
+      return;
+    }
+    setPinError(null);
+    try {
+      const hash = await hashPin(pinValue, selectingUser.id);
+      const result = await sansuApi
+        .verifyPin(selectingUser.id, hash)
+        .catch(() => ({ ok: false }) as { ok: false });
+      if (result.ok) {
+        if ('user' in result && result.user) {
+          saveUser(result.user);
+        } else {
+          selectUser(selectingUser);
+        }
+        setSelectingUser(null);
+      } else {
+        setFailedAttempts((n) => n + 1);
+        setPinError('あいことばが ちがうみたい');
+        setPin('');
+      }
+    } catch (e) {
+      setPinError(e instanceof Error ? e.message : 'エラーが おきたよ');
+    }
+  };
+
+  const goPlay = () => {
+    if (currentUser) router.push('/sansu-100/play');
+  };
+  const goDaily = () => {
+    if (currentUser) router.push('/sansu-100/play?daily=1');
+  };
+
+  if (!loaded) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-3xl space-y-8 px-4 py-8">
+        <Header
+          title="100マス計算"
+          description="毎日 100問。じぶんの ベストを ぬりかえよう！"
+          showBackButton
+        />
+
+        {currentUser ? (
+          <section className="space-y-6 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <div className="flex items-center gap-4">
+              <span className="text-6xl">{currentUser.avatar}</span>
+              <div>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  こんにちは
+                </p>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                  {currentUser.name}
+                </h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  これまで {currentUser.totalSessions}回 / バッジ{' '}
+                  {currentUser.earnedBadges.length}
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={goDaily}
+                className="rounded-xl bg-gradient-to-br from-yellow-500 to-orange-500 p-4 text-lg font-bold text-white shadow-md hover:from-yellow-600 hover:to-orange-600"
+                data-testid="daily-challenge-btn"
+              >
+                ⭐ きょうのチャレンジ
+                <p className="mt-1 text-xs font-normal opacity-90">
+                  {todayKey()}・Lv.{dailyLevel()}
+                </p>
+              </button>
+              <button
+                type="button"
+                onClick={goPlay}
+                className="rounded-xl bg-blue-600 p-4 text-lg font-bold text-white shadow-md hover:bg-blue-700"
+                data-testid="play-btn"
+              >
+                ▶︎ じぶんで えらんで れんしゅう
+              </button>
+            </div>
+            <div className="flex gap-3">
+              <Link
+                href="/sansu-100/history"
+                className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-center font-semibold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                📈 きろくをみる
+              </Link>
+              <button
+                type="button"
+                onClick={() => selectUser(null)}
+                className="rounded-lg bg-gray-200 px-4 py-2 text-center font-semibold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                👋 おわる
+              </button>
+            </div>
+          </section>
+        ) : (
+          <section className="space-y-6 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+              だれが あそぶ？
+            </h2>
+            {recentUsers.length === 0 ? (
+              <p className="text-center text-gray-600 dark:text-gray-400">
+                まだ だれも とうろくしていないよ
+              </p>
+            ) : (
+              <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
+                {recentUsers.map((u) => (
+                  <UserTile key={u.id} user={u} onSelect={handleSelect} />
+                ))}
+              </div>
+            )}
+            <div className="flex flex-col gap-2 border-t border-gray-200 pt-4 dark:border-gray-700 sm:flex-row">
+              <Link
+                href="/sansu-100/register"
+                className="flex-1 rounded-lg bg-blue-600 px-4 py-3 text-center font-bold text-white hover:bg-blue-700"
+                data-testid="register-link"
+              >
+                ＋ あたらしく とうろく
+              </Link>
+              <Link
+                href="/sansu-100/login"
+                className="flex-1 rounded-lg bg-gray-200 px-4 py-3 text-center font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                べつの たんまつで つくったよ
+              </Link>
+            </div>
+          </section>
+        )}
+
+        {selectingUser ? (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            onClick={() => setSelectingUser(null)}
+          >
+            <div
+              className="w-full max-w-sm space-y-4 rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex flex-col items-center gap-2">
+                <span className="text-6xl">{selectingUser.avatar}</span>
+                <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+                  {selectingUser.name} の あいことば
+                </h3>
+              </div>
+              <PinPad
+                value={pin}
+                onChange={setPin}
+                onSubmit={handleVerifyPin}
+                error={pinError}
+              />
+              <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+                わからない時は おうちの人に きいてね
+              </p>
+              <button
+                type="button"
+                onClick={() => setSelectingUser(null)}
+                className="w-full rounded-lg bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                やめる
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import React, { Suspense, useCallback, useEffect, useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import LevelPicker from '../components/LevelPicker';
+import NumberKeypad from '../components/NumberKeypad';
+import ProblemDisplay from '../components/ProblemDisplay';
+import ProgressBar from '../components/ProgressBar';
+import SessionTimer from '../components/SessionTimer';
+import { useSansuSession } from '../hooks/useSansuSession';
+import { useSansuUser } from '../hooks/useSansuUser';
+import { sansuApi } from '../lib/api-client';
+import { dailyLevel } from '../lib/daily';
+import { finishSession } from '../lib/session-result';
+import { storage } from '../lib/storage';
+import type { LevelId, Operation } from '../lib/types';
+
+function PlayInner(): React.JSX.Element {
+  const router = useRouter();
+  const params = useSearchParams();
+  const isDaily = params.get('daily') === '1';
+  const debugMode =
+    params.get('debug') === '1' || process.env.NODE_ENV !== 'production';
+  const { currentUser, updateUser, loaded } = useSansuUser();
+  const [pick, setPick] = useState<{
+    level: LevelId;
+    operation: Operation;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (!currentUser) router.replace('/sansu-100');
+  }, [loaded, currentUser, router]);
+
+  useEffect(() => {
+    if (isDaily && !pick) {
+      const lv = dailyLevel() as Exclude<LevelId, 'mix'>;
+      setPick({ level: lv, operation: opOf(lv) });
+    }
+  }, [isDaily, pick]);
+
+  if (!loaded || !currentUser) return <main className="p-8" />;
+
+  if (!pick) {
+    return (
+      <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+        <div className="absolute right-4 top-4">
+          <ThemeToggle />
+        </div>
+        <div className="container mx-auto max-w-3xl space-y-6 px-4 py-8">
+          <Header
+            title="どの れんしゅう？"
+            description="レベルを えらんでね"
+            showBackButton
+            backHref="/sansu-100"
+            backLabel="ホームにもどる"
+          />
+          <LevelPicker
+            onPick={(level, operation) => setPick({ level, operation })}
+          />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <PlaySession
+      user={currentUser}
+      pick={pick}
+      isDaily={isDaily}
+      onFinishUpdate={updateUser}
+      debugMode={debugMode}
+    />
+  );
+}
+
+function opOf(lv: Exclude<LevelId, 'mix'>): Operation {
+  if ([1, 2, 7, 8].includes(lv)) return 'add';
+  if ([3, 4, 9].includes(lv)) return 'sub';
+  if ([5, 10].includes(lv)) return 'mul';
+  return 'div';
+}
+
+interface PlaySessionProps {
+  user: ReturnType<typeof useSansuUser>['currentUser'];
+  pick: { level: LevelId; operation: Operation };
+  isDaily: boolean;
+  onFinishUpdate: (
+    updater: (u: NonNullable<ReturnType<typeof useSansuUser>['currentUser']>) => NonNullable<ReturnType<typeof useSansuUser>['currentUser']>
+  ) => void;
+  debugMode?: boolean;
+}
+
+function PlaySession({
+  user,
+  pick,
+  isDaily,
+  onFinishUpdate,
+  debugMode,
+}: PlaySessionProps): React.JSX.Element {
+  const router = useRouter();
+  const session = useSansuSession({
+    level: pick.level,
+    operation: pick.operation,
+    isDaily,
+  });
+  const [input, setInput] = useState('');
+  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
+  const [finalized, setFinalized] = useState(false);
+  const [showRetire, setShowRetire] = useState(false);
+
+  const judge = useCallback(
+    (value: string, isSkip = false) => {
+      if (!session.currentProblem) return;
+      const n = Number.parseInt(value, 10);
+      if (Number.isNaN(n) && !isSkip) return;
+      const answer = session.currentProblem.answer;
+      const isCorrect = !isSkip && n === answer;
+      setFeedback(isCorrect ? 'correct' : 'wrong');
+      setTimeout(
+        () => {
+          session.submitAnswer(isSkip ? -1 : n);
+          setInput('');
+          setFeedback(null);
+        },
+        isCorrect ? 200 : 500
+      );
+    },
+    [session]
+  );
+
+  // Auto-judge when input matches the answer
+  const handleInputChange = useCallback(
+    (v: string) => {
+      setInput(v);
+      if (!session.currentProblem || feedback) return;
+      const n = Number.parseInt(v, 10);
+      if (!Number.isNaN(n) && n === session.currentProblem.answer) {
+        judge(v, false);
+      }
+    },
+    [session.currentProblem, feedback, judge]
+  );
+
+  const handleSkip = useCallback(() => {
+    if (feedback) return;
+    judge(input, true);
+  }, [feedback, input, judge]);
+
+  useEffect(() => {
+    if (!session.isComplete || finalized || !user) return;
+    setFinalized(true);
+    const result = finishSession({
+      user,
+      level: pick.level,
+      operation: pick.operation,
+      isDaily,
+      startedAt: session.startedAt,
+      completedAt: session.completedAt ?? Date.now(),
+      problems: session.answered,
+      pastSessions: storage.getSessions(user.id),
+    });
+
+    storage.appendSession(result.session);
+    storage.pushPending(result.session);
+    onFinishUpdate(() => result.updatedUser);
+
+    sansuApi
+      .submitSession(result.session)
+      .then(() => storage.clearPending([result.session.id]))
+      .catch(() => {
+        // remain in pending queue for later sync
+      });
+
+    sessionStorage.setItem(
+      'sansu-100:last-result',
+      JSON.stringify({
+        session: result.session,
+        newBadges: result.newBadges,
+        pointsEarned: result.pointsEarned,
+        bestKey: `lv${pick.level}:${pick.operation}`,
+        previousBest:
+          user.bestTimesByLevel[`lv${pick.level}:${pick.operation}`] ?? null,
+      })
+    );
+    router.replace('/sansu-100/result');
+  }, [
+    session.isComplete,
+    finalized,
+    user,
+    pick.level,
+    pick.operation,
+    isDaily,
+    session.startedAt,
+    session.completedAt,
+    session.answered,
+    onFinishUpdate,
+    router,
+  ]);
+
+  if (!user) return <main className="p-8" />;
+
+  const correctCount = session.answered.filter((a) => a.isCorrect).length;
+
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto flex w-full max-w-2xl flex-1 flex-col gap-4 p-4">
+        <header className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowRetire(true)}
+              className="rounded-lg bg-gray-200 px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-red-100 hover:text-red-700 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-red-900/40 dark:hover:text-red-400"
+              aria-label="リタイヤ"
+            >
+              ✕ やめる
+            </button>
+          </div>
+          <SessionTimer
+            startedAt={session.startedAt}
+            stopped={session.isComplete}
+          />
+          <ThemeToggle />
+        </header>
+
+        {showRetire ? (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            onClick={() => setShowRetire(false)}
+          >
+            <div
+              className="w-full max-w-xs space-y-4 rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="text-center text-lg font-bold text-gray-900 dark:text-gray-100">
+                れんしゅうを やめる？
+              </p>
+              <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+                {session.currentIndex}問め まで の きろくは のこらないよ
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  onClick={() => router.replace('/sansu-100')}
+                  className="rounded-xl bg-red-500 py-3 font-bold text-white hover:bg-red-600"
+                >
+                  やめる
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowRetire(false)}
+                  className="rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200"
+                >
+                  つづける
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <ProgressBar
+          current={session.currentIndex}
+          total={session.problems.length}
+          correctCount={correctCount}
+        />
+
+        <div className="flex flex-1 items-center justify-center">
+          {session.currentProblem ? <ProblemDisplay
+              problem={session.currentProblem}
+              userInput={input}
+              feedback={feedback}
+            /> : null}
+        </div>
+
+        <NumberKeypad
+          value={input}
+          onChange={handleInputChange}
+          onSkip={handleSkip}
+          disabled={feedback !== null || session.isComplete}
+        />
+
+        {debugMode ? (
+          <div className="mt-2 flex flex-wrap items-center gap-2 rounded-lg border-2 border-dashed border-amber-400 bg-amber-50 p-2 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-100">
+            <span className="font-bold">🐛 DEBUG</span>
+            <button
+              type="button"
+              onClick={() => session.debugFinish({ accuracy: 1, durationMs: 25_000 })}
+              className="rounded bg-amber-600 px-2 py-1 font-semibold text-white hover:bg-amber-700"
+              data-testid="debug-finish-perfect"
+            >
+              一気に100問パーフェクト（25秒）
+            </button>
+            <button
+              type="button"
+              onClick={() => session.debugFinish({ accuracy: 0.9, durationMs: 90_000 })}
+              className="rounded bg-amber-500 px-2 py-1 font-semibold text-white hover:bg-amber-600"
+              data-testid="debug-finish-90"
+            >
+              90%正解 (1分30秒)
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                session.debugFinish({ accuracy: 1, durationMs: 25_000 + Math.random() * 60_000 })
+              }
+              className="rounded bg-amber-400 px-2 py-1 font-semibold text-amber-900 hover:bg-amber-500"
+              data-testid="debug-finish-random"
+            >
+              完走（ランダムタイム）
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+export default function PlayPage(): React.JSX.Element {
+  return (
+    <Suspense fallback={<main className="p-8" />}>
+      <PlayInner />
+    </Suspense>
+  );
+}

--- a/app/sansu-100/register/page.tsx
+++ b/app/sansu-100/register/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import RegistrationForm from '../components/RegistrationForm';
+
+export default function RegisterPage(): React.JSX.Element {
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-8">
+        <Header
+          title="あたらしく とうろく"
+          description="なまえ・アバター・あいことばを えらんでね"
+          showBackButton
+          backHref="/sansu-100"
+          backLabel="ホームにもどる"
+        />
+        <RegistrationForm />
+      </div>
+    </main>
+  );
+}

--- a/app/sansu-100/result/page.tsx
+++ b/app/sansu-100/result/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../components/header';
+import ThemeToggle from '../../components/theme-toggle';
+import BadgeUnlockOverlay from '../components/BadgeUnlockOverlay';
+import { formatDuration } from '../components/SessionTimer';
+import { useSansuUser } from '../hooks/useSansuUser';
+import type { SansuSession } from '../lib/types';
+
+type LastResult = {
+  session: SansuSession;
+  newBadges: string[];
+  pointsEarned: number;
+  bestKey: string;
+  previousBest: number | null;
+};
+
+export default function ResultPage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser } = useSansuUser();
+  const [result, setResult] = useState<LastResult | null>(null);
+  const [showOverlay, setShowOverlay] = useState(false);
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem('sansu-100:last-result');
+    if (!raw) {
+      router.replace('/sansu-100');
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw) as LastResult;
+      setResult(parsed);
+      if (parsed.newBadges.length > 0) {
+        setShowOverlay(true);
+      }
+    } catch {
+      router.replace('/sansu-100');
+    }
+  }, [router]);
+
+  if (!result || !currentUser) return <main className="p-8" />;
+
+  const { session, newBadges, pointsEarned, previousBest } = result;
+  const accuracy = Math.round(
+    (session.correctCount / session.totalProblems) * 100
+  );
+  const isPerfect = session.correctCount === session.totalProblems;
+  const newBestUpdated =
+    isPerfect && (previousBest === null || session.durationMs < previousBest);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <Header
+          title={isPerfect ? '🎉 パーフェクト！' : 'おつかれさま！'}
+          description={`Lv.${session.level} ${session.operation}`}
+          showBackButton
+          backHref="/sansu-100"
+          backLabel="ホームにもどる"
+        />
+
+        <section className="space-y-6 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <Stat label="タイム" value={formatDuration(session.durationMs)} highlight={newBestUpdated} />
+            <Stat label="せいかい" value={`${session.correctCount}/${session.totalProblems}`} />
+            <Stat label="せいかい率" value={`${accuracy}%`} />
+            <Stat label="ポイント" value={`+${pointsEarned}`} highlight />
+          </div>
+
+          {newBestUpdated ? (
+            <div className="rounded-xl bg-gradient-to-r from-yellow-400 to-orange-500 px-4 py-3 text-center font-bold text-white shadow">
+              🏆 じぶんの ベストを ぬりかえたよ！
+              {previousBest !== null && (
+                <span className="ml-2 text-sm font-normal opacity-90">
+                  まえの ベスト: {formatDuration(previousBest)}
+                </span>
+              )}
+            </div>
+          ) : null}
+
+          {newBadges.length > 0 ? (
+            <div className="rounded-xl bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 p-1">
+              <div className="rounded-[10px] bg-white px-4 py-3 dark:bg-gray-800">
+                <p className="font-bold text-gray-900 dark:text-gray-100">
+                  ✨ あたらしい バッジ × {newBadges.length}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setShowOverlay(true)}
+                  className="mt-2 rounded-lg bg-purple-600 px-4 py-1 text-sm font-bold text-white hover:bg-purple-700"
+                >
+                  もういちど みる
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => router.replace('/sansu-100/play')}
+              className="flex-1 rounded-lg bg-blue-600 px-4 py-3 font-bold text-white hover:bg-blue-700"
+            >
+              🔁 もう1かい
+            </button>
+            <Link
+              href="/sansu-100/history"
+              className="flex-1 rounded-lg bg-gray-200 px-4 py-3 text-center font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              📈 きろくをみる
+            </Link>
+            <Link
+              href="/sansu-100"
+              className="flex-1 rounded-lg bg-gray-200 px-4 py-3 text-center font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              🏠 ホーム
+            </Link>
+          </div>
+        </section>
+      </div>
+
+      {showOverlay && newBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={newBadges}
+          onDone={() => setShowOverlay(false)}
+        />
+      ) : null}
+    </main>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-xl p-3 text-center ${
+        highlight
+          ? 'bg-yellow-100 dark:bg-yellow-900/30'
+          : 'bg-gray-100 dark:bg-gray-700'
+      }`}
+    >
+      <p className="text-xs text-gray-600 dark:text-gray-400">{label}</p>
+      <p className="text-xl font-bold text-gray-900 dark:text-gray-100">
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "canvas": "^3.1.0",
+        "canvas-confetti": "^1.9.4",
+        "framer-motion": "^12.40.0",
         "highlight.js": "^11.11.1",
         "next": "^15.5.10",
         "next-pwa": "^5.6.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "zod": "^3.24.4"
@@ -22,9 +25,14 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@tailwindcss/typography": "^0.5.16",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.0.1",
         "concurrently": "^8.2.2",
         "cross-env": "^10.0.0",
@@ -42,15 +50,24 @@
         "eslint-plugin-tailwindcss": "^3.18.2",
         "eslint-plugin-unicorn": "^48.0.1",
         "husky": "^9.1.7",
+        "jsdom": "^29.1.1",
         "lint-staged": "^16.1.2",
         "postcss": "^8",
         "prettier": "^3.6.2",
         "tailwindcss": "^3.3.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=18.18.0 || >=20.0.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -76,6 +93,57 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1492,22 +1560,175 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.4",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1515,9 +1736,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1659,6 +1880,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2194,7 +2433,6 @@
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -2250,9 +2488,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2279,9 +2517,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.10.tgz",
-      "integrity": "sha512-plg+9A/KoZcTS26fe15LHg+QxReTazrIOoKKUC3Uz4leGGeNPgLHdevVraAAOX0snnUs3WkRx3eUQpj9mreG6A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2325,9 +2563,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
-      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2341,9 +2579,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
-      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -2357,9 +2595,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
-      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -2373,9 +2611,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
-      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -2389,9 +2627,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
-      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -2405,9 +2643,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
-      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -2421,9 +2659,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
-      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -2437,9 +2675,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
-      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -2494,25 +2732,34 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2520,6 +2767,325 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -2614,6 +3180,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2665,16 +3243,206 @@
         "node": ">=4"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
-      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2684,6 +3452,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -2708,9 +3483,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -2776,11 +3551,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.22.tgz",
-      "integrity": "sha512-/G+IxWxma6V3E+pqK1tSl2Fo1kl41pK1yeCyDsgkF9WlVAme4j5ISYM2zR11bgLFJGLN5sVK40T4RJNuiZbEjA==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -2828,6 +3604,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3363,6 +4145,175 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -3548,19 +4499,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3895,6 +4833,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4091,16 +5039,14 @@
       ],
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/big.js": {
@@ -4154,9 +5100,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4173,11 +5119,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "caniuse-lite": "^1.0.30001716",
+        "electron-to-chromium": "^1.5.149",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4305,9 +5250,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001770",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "version": "1.0.30001717",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
+      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4338,6 +5283,16 @@
         "node": "^18.12.0 || >= 20.9.0"
       }
     },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -4346,6 +5301,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4695,6 +5660,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4847,6 +5821,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4865,12 +5860,147 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4956,6 +6086,19 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -5219,6 +6362,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5237,8 +6388,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -5256,9 +6406,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.151",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.151.tgz",
+      "integrity": "sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5286,17 +6436,30 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.2.0"
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -5437,9 +6600,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "license": "MIT",
       "peer": true
     },
@@ -5499,6 +6662,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -6457,7 +7630,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -6477,6 +7649,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -6759,6 +7941,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -6955,22 +8164,22 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7236,6 +8445,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7295,6 +8517,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -7375,6 +8607,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -7776,6 +9017,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7964,13 +9212,15 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8048,9 +9298,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8058,6 +9308,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -8206,6 +9507,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -8347,17 +9909,13 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -8387,9 +9945,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lodash.castarray": {
@@ -8564,6 +10122,17 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.25.9",
@@ -8824,9 +10393,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -8877,6 +10446,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9552,11 +11128,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -9565,6 +11140,21 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -9598,9 +11188,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -9652,12 +11242,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.10.tgz",
-      "integrity": "sha512-r0X65PNwyDDyOrWNKpQoZvOatw7BcsTPRKdwEqtc9cj3wv7mbBIk9tKed4klRaFXJdX0rugpuMTHslDrAU1bBg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.10",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -9670,14 +11260,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.7",
-        "@next/swc-darwin-x64": "15.5.7",
-        "@next/swc-linux-arm64-gnu": "15.5.7",
-        "@next/swc-linux-arm64-musl": "15.5.7",
-        "@next/swc-linux-x64-gnu": "15.5.7",
-        "@next/swc-linux-x64-musl": "15.5.7",
-        "@next/swc-win32-arm64-msvc": "15.5.7",
-        "@next/swc-win32-x64-msvc": "15.5.7",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -9778,9 +11368,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
@@ -9951,6 +11541,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10056,13 +11657,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10120,6 +11714,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10159,17 +11766,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
+        "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10184,6 +11790,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10191,10 +11804,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -10267,13 +11879,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -10286,9 +11898,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10302,6 +11914,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10332,9 +11945,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -10350,10 +11963,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -10544,6 +12158,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10653,7 +12316,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -10681,6 +12343,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -10770,6 +12455,65 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/refa": {
@@ -11018,6 +12762,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -11141,6 +12891,40 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
     "node_modules/rollup": {
@@ -11321,6 +13105,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11590,6 +13387,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11702,9 +13506,10 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11785,6 +13590,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -11822,7 +13641,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -11841,7 +13659,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11856,7 +13673,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11865,15 +13681,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12039,7 +13853,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12052,7 +13865,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -12187,6 +13999,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
@@ -12225,23 +14044,19 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -12312,9 +14127,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
+      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -12432,15 +14247,38 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12450,11 +14288,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -12477,6 +14318,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
+      "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.0"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.0.tgz",
+      "integrity": "sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12487,6 +14358,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -12712,10 +14609,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -12925,9 +14833,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12961,6 +14869,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -13007,10 +14924,256 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13021,38 +15184,47 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack": {
-      "version": "5.105.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "version": "5.99.8",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.8.tgz",
+      "integrity": "sha512-lQ3CPiSTpfOnrEGeXDwoq5hIGzSjmwD72GdfVzF7CQAI7t47rJG9eDWvcEkEn3CUQymAElVvDg3YNTlCYj+qUQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
+        "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.19.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
+        "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.3"
+        "schema-utils": "^4.3.2",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.11",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -13071,9 +15243,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -13081,9 +15253,9 @@
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13118,9 +15290,9 @@
       "peer": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13135,6 +15307,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -13235,6 +15432,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -13594,7 +15808,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -13613,7 +15826,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -13631,7 +15843,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13641,7 +15852,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13656,15 +15866,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13679,7 +15887,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -13692,6 +15899,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "test:e2e:no-auth": "WITH_API=true npx playwright test --config=playwright.config.no-auth.ts",
     "test:e2e:no-auth:headed": "WITH_API=true npx playwright test --config=playwright.config.no-auth.ts --headed",
     "dev:with-api": "npm run build:api && swa start http://localhost:3000 --api-location api --run \"npm run dev\"",
+    "sansu:stop": "pkill -f 'azurite' 2>/dev/null; pkill -f 'swa start' 2>/dev/null; pkill -f 'func start' 2>/dev/null; lsof -ti:4280,7071,3000,10000,10001,10002 | xargs kill -9 2>/dev/null; sleep 1; echo 'stopped.'",
+    "sansu:dev": "npm run sansu:stop && mkdir -p /tmp/azurite-sansu && (azurite --location /tmp/azurite-sansu --loose > /tmp/azurite.log 2>&1 &) && sleep 1 && npm run build:api && swa start http://localhost:3000 --api-location api --run \"npm run dev\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -29,12 +33,15 @@
   },
   "dependencies": {
     "canvas": "^3.1.0",
+    "canvas-confetti": "^1.9.4",
+    "framer-motion": "^12.40.0",
     "highlight.js": "^11.11.1",
     "next": "^15.5.10",
     "next-pwa": "^5.6.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "zod": "^3.24.4"
@@ -42,9 +49,14 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.0.1",
     "concurrently": "^8.2.2",
     "cross-env": "^10.0.0",
@@ -62,11 +74,13 @@
     "eslint-plugin-tailwindcss": "^3.18.2",
     "eslint-plugin-unicorn": "^48.0.1",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "lint-staged": "^16.1.2",
     "postcss": "^8",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=18.18.0 || >=20.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,11 @@
     "node_modules",
     "api/**",
     "frontend/**",
-    "tmp/**"
+    "tmp/**",
+    "vitest.config.ts",
+    "vitest.setup.ts",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['app/**/*.test.{ts,tsx}'],
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './app'),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/vitest';
+
+if (typeof globalThis.crypto === 'undefined') {
+  // jsdom v22+ provides crypto; this is a safety net
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { webcrypto } = require('node:crypto');
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto });
+}


### PR DESCRIPTION
## Summary

- 11段階レベル（たし算・ひき算・かけ算・わり算）の100問逐次セッション
- 名前 + PIN(4桁) + アバター によるユーザー識別（軽量認証、PINはSHA-256でハッシュ化）
- Azure Table Storage (Azurite) へのセッション記録・マルチ端末同期
- 49種類以上のバッジと獲得演出（canvas-confetti + Framer Motion）
- 練習履歴グラフ（recharts）・デイリーチャレンジ（日付シードで再現可能）
- `/sansu-100/admin999` 管理画面（ユーザー一覧・PIN再設定・アバター確認）
- 正解と一致した瞬間に自動判定・スキップボタンで次へ進む入力UX
- dev環境自動シードユーザー（たろう/はなこ/けんた、PIN: 1111/2222/3333）

## 新規ルート

| URL | 説明 |
|-----|------|
| `/sansu-100` | ユーザー選択・ホーム |
| `/sansu-100/register` | 新規ユーザー登録 |
| `/sansu-100/login` | 別端末からログイン |
| `/sansu-100/play` | 練習セッション |
| `/sansu-100/result` | 結果・バッジ獲得演出 |
| `/sansu-100/history` | 履歴グラフ・バッジ一覧 |
| `/sansu-100/admin999` | 管理画面（URL難読化） |
| `/authenticated/sansu-100-admin` | 管理画面（Azure AD保護版） |

## 新規 API（Azure Functions）

- `POST/GET /api/sansu/users` — ユーザー作成・検索
- `POST /api/sansu/users/verify` — PIN検証
- `POST/GET /api/sansu/sessions` — セッション記録
- `GET /api/sansu/admin/summary` — 集計（要認証）
- `GET /api/sansu/admin/users` — ユーザー一覧（要認証）
- `PATCH /api/sansu/admin/users/:id/pin` — PIN再設定（要認証）

## ローカル起動

```bash
npm run sansu:dev   # Azurite + SWA + Next.js + Functions を一括起動
```

## Test plan

- [ ] `npm run sansu:dev` で http://localhost:4280/sansu-100 が開く
- [ ] 自動シードユーザー（たろう PIN:1111）でログインできる
- [ ] 練習セッションで答えが一致した瞬間に自動進行する
- [ ] スキップボタンで不正解扱いで次へ進む
- [ ] セッション完了後、結果画面でバッジ演出が出る
- [ ] `/sansu-100/admin999` でユーザー一覧・PIN再設定ができる

🤖 Generated with [Claude Code](https://claude.com/claude-code)