### PR TITLE
fix: 100マス計算 UX改善（PIN確定ボタン・デイリー削除・リタイヤ保存）

### DIFF
--- a/app/sansu-100/components/PinPad.tsx
+++ b/app/sansu-100/components/PinPad.tsx
@@ -8,6 +8,7 @@ interface PinPadProps {
   onSubmit?: (value: string) => void;
   error?: string | null;
   disabled?: boolean;
+  confirmLabel?: string;
 }
 
 export default function PinPad({
@@ -16,6 +17,7 @@ export default function PinPad({
   onSubmit,
   error,
   disabled = false,
+  confirmLabel = 'OK！',
 }: PinPadProps): React.JSX.Element {
   const press = useCallback(
     (digit: string) => {
@@ -25,26 +27,28 @@ export default function PinPad({
         return;
       }
       if (value.length >= 4) return;
-      const next = value + digit;
-      onChange(next);
-      if (next.length === 4 && onSubmit) {
-        // tiny delay so the user sees the 4th dot before submitting
-        setTimeout(() => onSubmit(next), 80);
-      }
+      onChange(value + digit);
     },
-    [value, disabled, onChange, onSubmit]
+    [value, disabled, onChange]
   );
+
+  const handleConfirm = useCallback(() => {
+    if (disabled || value.length !== 4 || !onSubmit) return;
+    onSubmit(value);
+  }, [value, disabled, onSubmit]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (disabled) return;
       if (e.key >= '0' && e.key <= '9') press(e.key);
       else if (e.key === 'Backspace') press('back');
-      else if (e.key === 'Enter' && value.length === 4 && onSubmit) onSubmit(value);
+      else if (e.key === 'Enter') handleConfirm();
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [press, value.length, onSubmit, disabled]);
+  }, [press, handleConfirm, disabled]);
+
+  const canConfirm = value.length === 4 && !disabled && !!onSubmit;
 
   return (
     <div className="flex flex-col items-center gap-4">
@@ -52,7 +56,7 @@ export default function PinPad({
         {[0, 1, 2, 3].map((i) => (
           <div
             key={i}
-            className={`size-6 rounded-full border-2 ${
+            className={`size-6 rounded-full border-2 transition-colors ${
               i < value.length
                 ? 'border-blue-600 bg-blue-600'
                 : 'border-gray-400 bg-transparent'
@@ -97,6 +101,21 @@ export default function PinPad({
         </button>
         <div className="size-16" />
       </div>
+
+      {onSubmit ? (
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!canConfirm}
+          className={`w-full rounded-xl py-3 text-lg font-bold transition-all ${
+            canConfirm
+              ? 'bg-blue-600 text-white shadow-md hover:bg-blue-700'
+              : 'bg-gray-200 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+          }`}
+        >
+          {disabled ? 'たしかめてるよ...' : confirmLabel}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/app/sansu-100/components/RegistrationForm.tsx
+++ b/app/sansu-100/components/RegistrationForm.tsx
@@ -176,6 +176,7 @@ export default function RegistrationForm(): React.JSX.Element {
             onSubmit={handleSubmit}
             error={error}
             disabled={submitting}
+            confirmLabel="これでとうろく！"
           />
           <button
             type="button"

--- a/app/sansu-100/history/page.tsx
+++ b/app/sansu-100/history/page.tsx
@@ -65,7 +65,7 @@ export default function HistoryPage(): React.JSX.Element {
               {latest.map((s) => (
                 <li
                   key={s.id}
-                  className="flex items-center justify-between py-2"
+                  className={`flex items-center justify-between py-2 ${s.isRetired ? 'opacity-70' : ''}`}
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-sm text-gray-500 dark:text-gray-400">
@@ -76,14 +76,22 @@ export default function HistoryPage(): React.JSX.Element {
                         minute: '2-digit',
                       })}
                     </span>
-                    <span className="font-semibold text-gray-900 dark:text-gray-100">
-                      Lv.{s.level} {s.operation}
-                      {s.isDaily ? ' ⭐' : ''}
-                    </span>
+                    <div>
+                      <span className="font-semibold text-gray-900 dark:text-gray-100">
+                        Lv.{s.level} {s.operation}
+                      </span>
+                      {s.isRetired ? (
+                        <span className="ml-1 rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400">
+                          ⏸ 途中
+                        </span>
+                      ) : null}
+                    </div>
                   </div>
                   <div className="text-right">
                     <p className="font-bold text-gray-900 dark:text-gray-100">
-                      {formatDuration(s.durationMs)}
+                      {s.isRetired
+                        ? `${s.totalProblems}/100問`
+                        : formatDuration(s.durationMs)}
                     </p>
                     <p className="text-xs text-gray-600 dark:text-gray-400">
                       {s.correctCount}/{s.totalProblems} ・ +

--- a/app/sansu-100/lib/session-result.ts
+++ b/app/sansu-100/lib/session-result.ts
@@ -6,6 +6,7 @@ export type FinishSessionInput = {
   level: LevelId;
   operation: Operation;
   isDaily: boolean;
+  isRetired?: boolean;
   startedAt: number;
   completedAt: number;
   problems: AnsweredProblem[];
@@ -25,6 +26,7 @@ export function finishSession(input: FinishSessionInput): FinishSessionResult {
     level,
     operation,
     isDaily,
+    isRetired = false,
     startedAt,
     completedAt,
     problems,
@@ -46,6 +48,7 @@ export function finishSession(input: FinishSessionInput): FinishSessionResult {
     level,
     operation,
     isDaily,
+    ...(isRetired ? { isRetired: true } : {}),
     startedAt,
     completedAt,
     durationMs,

--- a/app/sansu-100/lib/types.ts
+++ b/app/sansu-100/lib/types.ts
@@ -56,6 +56,7 @@ export type SansuSession = {
   level: LevelId;
   operation: Operation;
   isDaily: boolean;
+  isRetired?: boolean;
   startedAt: number;
   completedAt: number;
   durationMs: number;

--- a/app/sansu-100/login/page.tsx
+++ b/app/sansu-100/login/page.tsx
@@ -40,12 +40,19 @@ export default function LoginPage(): React.JSX.Element {
   };
 
   const handleVerify = async (pinValue: string = pin) => {
-    if (!foundUser || pinValue.length !== 4) return;
+    if (!foundUser || pinValue.length !== 4 || loading) return;
     setLoading(true);
     setError(null);
     try {
       const hash = await hashPin(pinValue, foundUser.id);
-      const res = await sansuApi.verifyPin(foundUser.id, hash);
+      let res: { ok: boolean; user?: SansuUserPublic };
+      try {
+        res = await sansuApi.verifyPin(foundUser.id, hash);
+      } catch {
+        setError('サーバーに つながらなかったよ。もういちど ためしてね');
+        setPin('');
+        return;
+      }
       if (res.ok && res.user) {
         saveUser(res.user);
         router.push('/sansu-100');
@@ -112,6 +119,7 @@ export default function LoginPage(): React.JSX.Element {
               onSubmit={handleVerify}
               error={error}
               disabled={loading}
+              confirmLabel="これでOK！"
             />
             <button
               type="button"

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -13,7 +13,6 @@ import UserTile from './components/UserTile';
 import { useSansuSync } from './hooks/useSansuSync';
 import { useSansuUser } from './hooks/useSansuUser';
 import { sansuApi } from './lib/api-client';
-import { dailyLevel, todayKey } from './lib/daily';
 import { hashPin } from './lib/pin-hash';
 import type { SansuUserPublic } from './lib/types';
 
@@ -30,6 +29,7 @@ export default function SansuHome(): React.JSX.Element {
   );
   const [pin, setPin] = useState('');
   const [pinError, setPinError] = useState<string | null>(null);
+  const [verifyingPin, setVerifyingPin] = useState(false);
   const [failedAttempts, setFailedAttempts] = useState(0);
 
   // Auto-seed test users in dev mode on first mount
@@ -47,20 +47,27 @@ export default function SansuHome(): React.JSX.Element {
     setSelectingUser(user);
     setPin('');
     setPinError(null);
+    setFailedAttempts(0);
   };
 
   const handleVerifyPin = async (pinValue: string = pin) => {
-    if (!selectingUser || pinValue.length !== 4) return;
+    if (!selectingUser || pinValue.length !== 4 || verifyingPin) return;
     if (failedAttempts >= 3) {
       setPinError('3回まちがえたよ。すこし まってからもういちど ためしてね');
       return;
     }
     setPinError(null);
+    setVerifyingPin(true);
     try {
       const hash = await hashPin(pinValue, selectingUser.id);
-      const result = await sansuApi
-        .verifyPin(selectingUser.id, hash)
-        .catch(() => ({ ok: false }) as { ok: false });
+      let result: { ok: boolean; user?: SansuUserPublic };
+      try {
+        result = await sansuApi.verifyPin(selectingUser.id, hash);
+      } catch {
+        setPinError('サーバーに つながらなかったよ。もういちど ためしてね');
+        setPin('');
+        return;
+      }
       if (result.ok) {
         if ('user' in result && result.user) {
           saveUser(result.user);
@@ -75,14 +82,9 @@ export default function SansuHome(): React.JSX.Element {
       }
     } catch (e) {
       setPinError(e instanceof Error ? e.message : 'エラーが おきたよ');
+    } finally {
+      setVerifyingPin(false);
     }
-  };
-
-  const goPlay = () => {
-    if (currentUser) router.push('/sansu-100/play');
-  };
-  const goDaily = () => {
-    if (currentUser) router.push('/sansu-100/play?daily=1');
   };
 
   if (!loaded) return <main className="p-8" />;
@@ -95,7 +97,7 @@ export default function SansuHome(): React.JSX.Element {
       <div className="container mx-auto max-w-3xl space-y-8 px-4 py-8">
         <Header
           title="100マス計算"
-          description="毎日 100問。じぶんの ベストを ぬりかえよう！"
+          description="じぶんの ベストを ぬりかえよう！"
           showBackButton
         />
 
@@ -116,27 +118,14 @@ export default function SansuHome(): React.JSX.Element {
                 </p>
               </div>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                onClick={goDaily}
-                className="rounded-xl bg-gradient-to-br from-yellow-500 to-orange-500 p-4 text-lg font-bold text-white shadow-md hover:from-yellow-600 hover:to-orange-600"
-                data-testid="daily-challenge-btn"
-              >
-                ⭐ きょうのチャレンジ
-                <p className="mt-1 text-xs font-normal opacity-90">
-                  {todayKey()}・Lv.{dailyLevel()}
-                </p>
-              </button>
-              <button
-                type="button"
-                onClick={goPlay}
-                className="rounded-xl bg-blue-600 p-4 text-lg font-bold text-white shadow-md hover:bg-blue-700"
-                data-testid="play-btn"
-              >
-                ▶︎ じぶんで えらんで れんしゅう
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={() => router.push('/sansu-100/play')}
+              className="w-full rounded-xl bg-blue-600 p-5 text-xl font-bold text-white shadow-md hover:bg-blue-700"
+              data-testid="play-btn"
+            >
+              ▶︎ れんしゅう スタート！
+            </button>
             <div className="flex gap-3">
               <Link
                 href="/sansu-100/history"
@@ -190,7 +179,7 @@ export default function SansuHome(): React.JSX.Element {
         {selectingUser ? (
           <div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-            onClick={() => setSelectingUser(null)}
+            onClick={() => !verifyingPin && setSelectingUser(null)}
           >
             <div
               className="w-full max-w-sm space-y-4 rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800"
@@ -207,6 +196,8 @@ export default function SansuHome(): React.JSX.Element {
                 onChange={setPin}
                 onSubmit={handleVerifyPin}
                 error={pinError}
+                disabled={verifyingPin}
+                confirmLabel="これでOK！"
               />
               <p className="text-center text-xs text-gray-500 dark:text-gray-400">
                 わからない時は おうちの人に きいてね
@@ -214,7 +205,8 @@ export default function SansuHome(): React.JSX.Element {
               <button
                 type="button"
                 onClick={() => setSelectingUser(null)}
-                className="w-full rounded-lg bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                disabled={verifyingPin}
+                className="w-full rounded-lg bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 disabled:opacity-50 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
               >
                 やめる
               </button>

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -112,6 +112,7 @@ function PlaySession({
   const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
   const [finalized, setFinalized] = useState(false);
   const [showRetire, setShowRetire] = useState(false);
+  const [retiring, setRetiring] = useState(false);
 
   const judge = useCallback(
     (value: string, isSkip = false) => {
@@ -245,10 +246,37 @@ function PlaySession({
               <div className="grid grid-cols-2 gap-3">
                 <button
                   type="button"
-                  onClick={() => router.replace('/sansu-100')}
-                  className="rounded-xl bg-red-500 py-3 font-bold text-white hover:bg-red-600"
+                  disabled={retiring}
+                  onClick={async () => {
+                    if (finalized || retiring) return;
+                    if (session.answered.length > 0 && user) {
+                      setRetiring(true);
+                      const now = Date.now();
+                      const result = finishSession({
+                        user,
+                        level: pick.level,
+                        operation: pick.operation,
+                        isDaily: false,
+                        isRetired: true,
+                        startedAt: session.startedAt,
+                        completedAt: now,
+                        problems: session.answered,
+                        pastSessions: storage.getSessions(user.id),
+                      });
+                      setFinalized(true);
+                      storage.appendSession(result.session);
+                      storage.pushPending(result.session);
+                      onFinishUpdate(() => result.updatedUser);
+                      sansuApi
+                        .submitSession(result.session)
+                        .then(() => storage.clearPending([result.session.id]))
+                        .catch(() => {});
+                    }
+                    router.replace('/sansu-100');
+                  }}
+                  className="rounded-xl bg-red-500 py-3 font-bold text-white hover:bg-red-600 disabled:opacity-60"
                 >
-                  やめる
+                  {retiring ? 'きろく中...' : 'やめる'}
                 </button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

100マス計算アプリ（#43 でマージ済み）の UX 改善。

- **PIN確定ボタン追加**: 4桁自動送信を廃止。入力後に「これでOK！」ボタンを押して送信（登録・ログイン共通）
- **デイリーチャレンジ削除**: 「きょうのチャレンジ」を削除、「▶︎ れんしゅう スタート！」1ボタンに統一
- **リタイヤ時の部分保存**: 途中終了でも解いた問題をセッション保存（`isRetired: true`）
- **履歴表示**: リタイヤセッションを「⏸ 途中 N/100問」として表示
- **エラーメッセージ改善**: PIN検証でネットワークエラーと間違いPINを別メッセージで区別、検証中は「たしかめてるよ...」表示

## Changes

- `PinPad.tsx`: 自動送信廃止 → 確定ボタン追加（`confirmLabel` prop）
- `RegistrationForm.tsx`: 「これでとうろく！」ラベル
- `page.tsx` (home): デイリー削除、PIN検証ローディング・エラー分離
- `login/page.tsx`: 同様のエラー分離
- `play/page.tsx`: リタイヤ時に `finishSession` でセッション保存
- `history/page.tsx`: `isRetired` セッションを「⏸ 途中」表示
- `lib/types.ts` / `lib/session-result.ts`: `isRetired` フラグ追加

## Test plan

- [x] localhost:4280 でビルド・起動・ブラウザ操作確認
- [x] デイリーチャレンジボタン非表示
- [x] 4桁未満は確定ボタン無効 / 4桁で有効化
- [x] PIN「1111」でログイン成功
- [x] プレイ→完走→result 遷移
- [x] プレイ途中リタイヤ→履歴に「⏸ 途中 4/100問」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)