### PR TITLE
fix: 100マス計算 プレイ画面をスマホで全表示できるよう縮小

### DIFF
--- a/app/sansu-100/components/NumberKeypad.tsx
+++ b/app/sansu-100/components/NumberKeypad.tsx
@@ -47,7 +47,7 @@ export default function NumberKeypad({
       type="button"
       onClick={() => press(k)}
       disabled={disabled}
-      className={`flex h-16 items-center justify-center rounded-2xl text-2xl font-bold transition-colors disabled:opacity-50 sm:h-20 sm:text-3xl ${
+      className={`flex h-12 items-center justify-center rounded-2xl text-xl font-bold transition-colors disabled:opacity-50 sm:h-20 sm:text-3xl ${
         className ??
         'bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600'
       }`}
@@ -72,7 +72,7 @@ export default function NumberKeypad({
       <Btn
         k="skip"
         label="スキップ"
-        className="bg-gray-400 text-base text-white hover:bg-gray-500 dark:bg-gray-600 dark:hover:bg-gray-500 sm:text-lg"
+        className="bg-gray-400 text-sm text-white hover:bg-gray-500 dark:bg-gray-600 dark:hover:bg-gray-500 sm:text-lg"
       />
     </div>
   );

--- a/app/sansu-100/components/ProblemDisplay.tsx
+++ b/app/sansu-100/components/ProblemDisplay.tsx
@@ -39,7 +39,7 @@ export default function ProblemDisplay({
         : 'border-gray-400 dark:border-gray-500';
   return (
     <div
-      className="flex items-baseline justify-center gap-3 font-mono text-6xl font-bold text-gray-900 dark:text-gray-100 sm:text-7xl md:text-8xl"
+      className="flex items-baseline justify-center gap-2 font-mono text-5xl font-bold text-gray-900 dark:text-gray-100 sm:gap-3 sm:text-7xl md:text-8xl"
       data-testid="problem-display"
     >
       <span>{problem.a}</span>

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -208,8 +208,8 @@ function PlaySession({
   const correctCount = session.answered.filter((a) => a.isCorrect).length;
 
   return (
-    <main className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
-      <div className="container mx-auto flex w-full max-w-2xl flex-1 flex-col gap-4 p-4">
+    <main className="flex min-h-svh flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto flex w-full max-w-2xl flex-1 flex-col gap-3 p-3 sm:gap-4 sm:p-4">
         <header className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <button
@@ -241,7 +241,7 @@ function PlaySession({
                 れんしゅうを やめる？
               </p>
               <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-                {session.currentIndex}問め まで の きろくは のこらないよ
+                ここまでの {session.currentIndex}問は きろくに のこるよ
               </p>
               <div className="grid grid-cols-2 gap-3">
                 <button


### PR DESCRIPTION
## Summary

スマホ（iPhone等）で計算プレイ画面のキーパッド下部（←/0/スキップ）がブラウザ下バーの裏に隠れて**全部表示されない**問題を修正。

## 原因

1. `min-h-screen`(100vh) がモバイルブラウザのツールバー領域を含んでしまい、下部がツールバーの裏に隠れる
2. 問題表示(text-6xl)・キーパッド(h-16)がモバイルには大きすぎる

## Changes

- `play/page.tsx`: `min-h-screen` → `min-h-svh`（小ビューポート基準でツールバー分を考慮）／gap・paddingをモバイルで縮小
- `ProblemDisplay.tsx`: `text-6xl` → `text-5xl`（モバイル）、gap縮小
- `NumberKeypad.tsx`: ボタン `h-16`→`h-12`・`text-2xl`→`text-xl`（モバイル）、スキップ文字 `text-sm`
- リタイヤ確認の文言を実態（部分保存する）に合わせて修正

## Test plan

- [x] Playwright で iPhone SE/12/14ProMax 相当の可視領域（375×553 / 390×664 / 430×730）を検証
- [x] 全ビューポートでキーパッド全体（スキップボタン含む）がはみ出さず収まることを確認（overflow: false）
- [x] スクリーンショットで目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)