### PR TITLE
ci: PRクローズ時にSWAステージング環境を自動削除

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
+++ b/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
@@ -53,3 +53,15 @@ jobs:
           production_branch: 'main'
           pull_request_id: ${{ github.event.pull_request.number }}
           ###### End of Repository/Build Configurations ######
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_FIELD_00CC2DA00 }}
+          action: 'close'


### PR DESCRIPTION
## Summary

PR をマージ/クローズしても Azure SWA のプレビュー（ステージング）環境が削除されず溜まり、上限（3個）に達してデプロイが `BadRequest: This Static Web App already has the maximum number of staging environments` で失敗していた問題を恒久対策。

## 原因

ワークフローに **標準の `close_pull_request_job`（`action: 'close'`）が欠落**していた。これが無いと `pull_request: closed` イベントで該当ステージング環境が削除されず、PRごとに溜まり続ける（PR #43 の時点から欠落していた）。

## Changes

- `.github/workflows/azure-static-web-apps-*.yml` に `close_pull_request_job` を追加
  - `github.event.action == 'closed'` 時に `Azure/static-web-apps-deploy@v1` を `action: 'close'` で実行し、当該PRのステージング環境を自動削除

## 効果

- 今後 PR をマージ/クローズすると、その都度プレビュー環境が自動削除され、上限に達しなくなる
- 既に溜まっていた 43/46/47 は手動削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)