### PR TITLE
ci: closeジョブにOIDC認証を追加（ステージング環境を確実に削除）

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
+++ b/.github/workflows/azure-static-web-apps-black-field-00cc2da00.yml
@@ -58,10 +58,24 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - name: Install OIDC Client from Core Package
+        run: npm install @actions/core@1.6.0 @actions/http-client
+      - name: Get Id Token
+        uses: actions/github-script@v6
+        id: idtoken
+        with:
+          script: |
+            const coredemo = require('@actions/core')
+            return await coredemo.getIDToken()
+          result-encoding: string
       - name: Close Pull Request
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_FIELD_00CC2DA00 }}
           action: 'close'
+          github_id_token: ${{ steps.idtoken.outputs.result }}


### PR DESCRIPTION
## Summary

前PR #49 で追加した `close_pull_request_job` が「**No matching static site found**」で失敗し、ステージング環境が削除されない問題を修正。

## 原因

この SWA は **OIDC（Identity token）認証構成**。ビルドジョブは `github_id_token`（OIDC）で認証しているが、close ジョブは `azure_static_web_apps_api_token` のみだったため、デプロイ先サイトを特定できず失敗していた。

## Changes

close ジョブにビルドジョブと同じ OIDC 認証を付与:
- `permissions: id-token: write / contents: read`
- `Install OIDC Client` + `Get Id Token` ステップ
- close アクションに `github_id_token` を渡す

公式ドキュメント（Identity token 構成）に準拠。

## Test plan

- [x] env 48/49 の残骸を削除し、ステージング枠を解放
- [ ] この PR をマージ → close ジョブ（OIDC）が env を自動削除することを確認（マージ後に検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)