### PR TITLE
fix: 100マス計算 リタイヤ重複防止・デイリーバッジ削除・リタイヤ非集計化

### DIFF
--- a/app/sansu-100/components/BadgeShowcase.tsx
+++ b/app/sansu-100/components/BadgeShowcase.tsx
@@ -15,7 +15,6 @@ const CATEGORY_LABELS: Record<BadgeDef['category'], string> = {
   streak: '🔥 れんぞく日数',
   master: '🎓 演算マスター',
   timing: '🕐 じかんたい',
-  daily: '📅 デイリー',
   special: '✨ とくべつ',
   meta: '🏆 メタ',
 };

--- a/app/sansu-100/lib/__tests__/badges.test.ts
+++ b/app/sansu-100/lib/__tests__/badges.test.ts
@@ -206,19 +206,6 @@ describe('badges - timing', () => {
   });
 });
 
-describe('badges - daily', () => {
-  it('awards daily_first on daily session', () => {
-    const s = mkSession({ isDaily: true });
-    const newly = evaluateBadges(mkCtx({ session: s, allSessions: [s] }));
-    expect(newly).toContain('daily_first');
-  });
-
-  it('does not award daily_first on regular session', () => {
-    const newly = evaluateBadges(mkCtx());
-    expect(newly).not.toContain('daily_first');
-  });
-});
-
 describe('badges - special', () => {
   it('awards mix_master on perfect mix', () => {
     const s = mkSession({ level: 'mix', correctCount: 100 });

--- a/app/sansu-100/lib/__tests__/session-result.test.ts
+++ b/app/sansu-100/lib/__tests__/session-result.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { finishSession } from '../session-result';
+import type { AnsweredProblem, SansuUserPublic } from '../types';
+
+function mkUser(over: Partial<SansuUserPublic> = {}): SansuUserPublic {
+  return {
+    id: 'u1',
+    name: 'てすと',
+    avatar: '🦊',
+    themeColor: 'blue',
+    createdAt: 0,
+    totalPoints: 0,
+    earnedBadges: [],
+    bestTimesByLevel: {},
+    currentStreakDays: 0,
+    lastPlayedDate: '',
+    lastPlayedAt: 0,
+    totalSessions: 0,
+    ...over,
+  };
+}
+
+function mkProblems(n: number, allCorrect = true): AnsweredProblem[] {
+  return Array.from({ length: n }, (_, i) => ({
+    a: 1,
+    b: 1,
+    op: 'add' as const,
+    answer: 2,
+    userAnswer: allCorrect ? 2 : 0,
+    isCorrect: allCorrect,
+    timeMs: 1000,
+  }));
+}
+
+const base = {
+  level: 1 as const,
+  operation: 'add' as const,
+  isDaily: false,
+  startedAt: 0,
+  completedAt: 25_000,
+  pastSessions: [],
+};
+
+describe('finishSession - 通常完走', () => {
+  it('回数・ポイント・バッジを加算する', () => {
+    const user = mkUser();
+    const r = finishSession({ ...base, user, problems: mkProblems(100) });
+    expect(r.updatedUser.totalSessions).toBe(1);
+    expect(r.pointsEarned).toBeGreaterThan(0);
+    expect(r.updatedUser.totalPoints).toBe(r.pointsEarned);
+    expect(r.newBadges).toContain('sessions_1');
+  });
+});
+
+describe('finishSession - リタイヤ(isRetired) は集計に加えない', () => {
+  it('totalSessions / totalPoints / バッジ を増やさない', () => {
+    const user = mkUser();
+    const r = finishSession({
+      ...base,
+      user,
+      isRetired: true,
+      problems: mkProblems(3),
+    });
+    expect(r.updatedUser.totalSessions).toBe(0);
+    expect(r.pointsEarned).toBe(0);
+    expect(r.updatedUser.totalPoints).toBe(0);
+    expect(r.newBadges).toEqual([]);
+    expect(r.updatedUser.earnedBadges).toEqual([]);
+  });
+
+  it('全問正解でリタイヤしてもベストタイムを更新しない', () => {
+    const user = mkUser();
+    const r = finishSession({
+      ...base,
+      user,
+      isRetired: true,
+      problems: mkProblems(3, true),
+    });
+    expect(r.updatedUser.bestTimesByLevel['lv1:add']).toBeUndefined();
+  });
+
+  it('セッション自体は記録として残り isRetired を持つ', () => {
+    const user = mkUser();
+    const r = finishSession({
+      ...base,
+      user,
+      isRetired: true,
+      problems: mkProblems(3),
+    });
+    expect(r.session.isRetired).toBe(true);
+    expect(r.session.totalProblems).toBe(3);
+    expect(r.updatedUser.lastPlayedAt).toBe(25_000);
+  });
+});

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -7,7 +7,6 @@ export type BadgeCategory =
   | 'streak'
   | 'master'
   | 'timing'
-  | 'daily'
   | 'special'
   | 'meta';
 
@@ -71,12 +70,6 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'early_bird', category: 'timing', name: 'はやおき！', description: '朝6-9時に練習', icon: '🌅', tier: 'bronze', rarity: 'common' },
   { id: 'night_owl', category: 'timing', name: 'よふかし', description: '夜20-22時に練習', icon: '🌙', tier: 'bronze', rarity: 'common' },
   { id: 'weekend_warrior', category: 'timing', name: '週末王者', description: '土日両方練習', icon: '🎽', tier: 'silver', rarity: 'rare' },
-
-  // デイリーチャレンジ系
-  { id: 'daily_first', category: 'daily', name: 'デイリーデビュー', description: 'デイリーチャレンジ初参加', icon: '📅', tier: 'bronze', rarity: 'common' },
-  { id: 'daily_7', category: 'daily', name: 'デイリー7連', description: 'デイリー7日連続', icon: '📆', tier: 'silver', rarity: 'rare' },
-  { id: 'daily_30', category: 'daily', name: 'デイリー30連', description: 'デイリー30日連続', icon: '🗓️', tier: 'gold', rarity: 'epic' },
-  { id: 'daily_100', category: 'daily', name: 'デイリー100連', description: 'デイリー100日連続！', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 
   // 特殊・面白系
   { id: 'comeback', category: 'special', name: 'おかえり！', description: '7日空けて復帰', icon: '🌈', tier: 'silver', rarity: 'rare' },

--- a/app/sansu-100/lib/badges.ts
+++ b/app/sansu-100/lib/badges.ts
@@ -141,13 +141,6 @@ const RULES: Record<string, Rule> = {
     return sawSat && sawSun;
   },
 
-  daily_first: ({ session }) => session.isDaily,
-  daily_7: ({ user, session }) => session.isDaily && user.currentStreakDays >= 7,
-  daily_30: ({ user, session }) =>
-    session.isDaily && user.currentStreakDays >= 30,
-  daily_100: ({ user, session }) =>
-    session.isDaily && user.currentStreakDays >= 100,
-
   comeback: ({ allSessions, session }) => {
     if (allSessions.length < 2) return false;
     const prev = allSessions[allSessions.length - 2];

--- a/app/sansu-100/lib/session-result.ts
+++ b/app/sansu-100/lib/session-result.ts
@@ -58,7 +58,12 @@ export function finishSession(input: FinishSessionInput): FinishSessionResult {
     newBadges: [],
   };
 
-  const pointsEarned = calculatePoints(baseSession);
+  // リタイヤ（途中終了）は履歴には残すが、回数・ポイント・バッジ・ベストタイムの
+  // 集計には加えない（記録の水増し防止）。lastPlayedAt と streak は「練習した事実」
+  // として更新する。
+  const isCountable = !isRetired;
+
+  const pointsEarned = isCountable ? calculatePoints(baseSession) : 0;
   const session: SansuSession = { ...baseSession, pointsEarned };
 
   const allSessions = [...pastSessions, session];
@@ -68,26 +73,30 @@ export function finishSession(input: FinishSessionInput): FinishSessionResult {
   const prevBest = user.bestTimesByLevel[bestKey];
   const isPerfect = correctCount === problems.length;
   const newBest =
-    isPerfect && (!prevBest || durationMs < prevBest) ? durationMs : prevBest;
+    isCountable && isPerfect && (!prevBest || durationMs < prevBest)
+      ? durationMs
+      : prevBest;
 
   const intermediateUser: SansuUserPublic = {
     ...user,
     currentStreakDays: streak,
     lastPlayedDate: new Date(completedAt).toISOString().slice(0, 10),
     lastPlayedAt: completedAt,
-    totalSessions: user.totalSessions + 1,
+    totalSessions: isCountable ? user.totalSessions + 1 : user.totalSessions,
     bestTimesByLevel: {
       ...user.bestTimesByLevel,
       ...(newBest !== undefined ? { [bestKey]: newBest } : {}),
     },
   };
 
-  const newBadges = evaluateBadges({
-    user: intermediateUser,
-    session,
-    allSessions,
-    playedAt: new Date(completedAt),
-  });
+  const newBadges = isCountable
+    ? evaluateBadges({
+        user: intermediateUser,
+        session,
+        allSessions,
+        playedAt: new Date(completedAt),
+      })
+    : [];
 
   session.newBadges = newBadges;
 

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -110,9 +110,11 @@ function PlaySession({
   });
   const [input, setInput] = useState('');
   const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
-  const [finalized, setFinalized] = useState(false);
   const [showRetire, setShowRetire] = useState(false);
   const [retiring, setRetiring] = useState(false);
+  // 同期ガード: 完走/リタイヤの finishSession が二重起動（連打や再レンダ）しないよう、
+  // state より先に効く ref で1回だけ確定させる。
+  const finalizingRef = useRef(false);
 
   const judge = useCallback(
     (value: string, isSkip = false) => {
@@ -153,8 +155,8 @@ function PlaySession({
   }, [feedback, input, judge]);
 
   useEffect(() => {
-    if (!session.isComplete || finalized || !user) return;
-    setFinalized(true);
+    if (!session.isComplete || finalizingRef.current || !user) return;
+    finalizingRef.current = true;
     const result = finishSession({
       user,
       level: pick.level,
@@ -191,7 +193,6 @@ function PlaySession({
     router.replace('/sansu-100/result');
   }, [
     session.isComplete,
-    finalized,
     user,
     pick.level,
     pick.operation,
@@ -247,9 +248,10 @@ function PlaySession({
                 <button
                   type="button"
                   disabled={retiring}
-                  onClick={async () => {
-                    if (finalized || retiring) return;
+                  onClick={() => {
+                    if (finalizingRef.current) return;
                     if (session.answered.length > 0 && user) {
+                      finalizingRef.current = true;
                       setRetiring(true);
                       const now = Date.now();
                       const result = finishSession({
@@ -263,7 +265,6 @@ function PlaySession({
                         problems: session.answered,
                         pastSessions: storage.getSessions(user.id),
                       });
-                      setFinalized(true);
                       storage.appendSession(result.session);
                       storage.pushPending(result.session);
                       onFinishUpdate(() => result.updatedUser);


### PR DESCRIPTION
UXレビュー（[docs/sansu-100-ux-review.md](docs/sansu-100-ux-review.md) / [#51](https://github.com/xiaotiantakumi/SwaSnapContent/pull/51)）で**要対応**とした3点を修正。B2・B3 は対応不要のため対象外。

## 変更点

### B1: リタイヤ確定の連打で重複セッションが生成される
- 原因: `retiring`/`finalized` の非同期 state ガードが、同期的な2連打を防げず `finishSession()` が2回走っていた。
- 修正: 完走/リタイヤ両方の確定を同期 `ref`（`finalizingRef`）で1回だけに。不要になった `finalized` state を削除。

### U2: 削除済みデイリー機能のバッジが取得不能のまま残存
- `daily_first/7/30/100` をカタログ・判定ルール・バッジ一覧の分類（`daily`）から除去。
- 関連: `badge-catalog.ts` / `badges.ts` / `BadgeShowcase.tsx`。

### U3: リタイヤ（数問）でもセッション1回＋バッジ獲得扱い（記録水増し）
- リタイヤ（`isRetired`）は履歴に「途中」として残しつつ、**回数・ポイント・バッジ・ベストタイムの集計には加えない**。
- 副次バグも解消: 全問正解でリタイヤすると `isPerfect` 判定で100問ベストタイムを汚染していた問題を `isCountable` ガードで修正。
- `lastPlayedAt`/streak は「練習した事実」として更新（管理画面での活動把握のため）。

## テスト
- `session-result.test.ts` を追加し、リタイヤ非集計（回数/ポイント/バッジ/ベスト非更新・セッション自体は記録）を回帰テストで固定。
- デイリーバッジのテストを削除。
- **全65件パス / `tsc --noEmit` クリーン / `npm run build` 成功。**

## セルフレビュー（ai-mix: review=議長Claude / effort特大）
- B1: 完走useEffectとリタイヤonClickが同一refを共有し競合・連打を確実に1回化。answered=0時はref未設定で素通り（無害）。✅
- U3: `streak`/`lastPlayedAt` はリタイヤでも更新する設計（その日練習した事実）。回数・バッジは増えないため水増しは防げている。履歴行のptは0表示になる（非集計と整合）。✅
- U2: 残存参照なし（grep確認）。`badge_collector_all` の母数は自動的に追従。✅
- 備考（本PR対象外）: `daily.ts`/`daily.test.ts` と `isDaily`/`mix` 系は到達しないデッドパスとして残存。別PRで掃除候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)