### PR TITLE
fix: 100マス計算の1回を100問→30問にする

### DIFF
--- a/app/sansu-100/history/page.tsx
+++ b/app/sansu-100/history/page.tsx
@@ -90,7 +90,7 @@ export default function HistoryPage(): React.JSX.Element {
                   <div className="text-right">
                     <p className="font-bold text-gray-900 dark:text-gray-100">
                       {s.isRetired
-                        ? `${s.totalProblems}/100問`
+                        ? `${s.totalProblems}問`
                         : formatDuration(s.durationMs)}
                     </p>
                     <p className="text-xs text-gray-600 dark:text-gray-400">

--- a/app/sansu-100/hooks/useSansuSession.ts
+++ b/app/sansu-100/hooks/useSansuSession.ts
@@ -15,6 +15,10 @@ import type {
   Problem,
 } from '../lib/types';
 
+// 1回の練習で出す問題数。アプリ名は「100マス計算」だが、100問は子どもにきついので
+// 1回あたり 30問にする（totalProblems で個別に上書きも可能）。
+export const DEFAULT_PROBLEM_COUNT = 30;
+
 export type UseSansuSessionOptions = {
   level: LevelId;
   operation: Operation;
@@ -33,7 +37,7 @@ export type SansuSessionState = {
 };
 
 export function useSansuSession(opts: UseSansuSessionOptions) {
-  const total = opts.totalProblems ?? 100;
+  const total = opts.totalProblems ?? DEFAULT_PROBLEM_COUNT;
   const problems = useMemo<Problem[]>(() => {
     if (opts.isDaily) {
       const seed = dailySeed();

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -343,7 +343,7 @@ function PlaySession({
               className="rounded bg-amber-600 px-2 py-1 font-semibold text-white hover:bg-amber-700"
               data-testid="debug-finish-perfect"
             >
-              一気に100問パーフェクト（25秒）
+              一気に30問パーフェクト（25秒）
             </button>
             <button
               type="button"


### PR DESCRIPTION
100問は子どもにきついため、1回の練習の既定問題数を **30問** に変更。

## 変更
- `useSansuSession` に `DEFAULT_PROBLEM_COUNT = 30` を定義し既定を 30 に（`totalProblems` で個別上書きは可能）
- デバッグボタンの「一気に100問」表記を「30問」に
- 履歴のリタイヤ表示は誤った `/100` を外し回答数のみ表示（旧100問/新30問の両方で正しく出る）
- アプリ名「100マス計算」は据え置き、コイン/バッジは問題数非依存のため影響なし

## 検証
- iPhone実機相当(Playwright): レベル選択→完走で `totalProblems=30` を確認、console error 0
- lint・ビルド緑 / テスト155件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)