### PR TITLE
feat(sansu-100): ミニゲームに「あそびかた」表示＋キャラづくりの未保存確認ダイアログ

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -8,6 +8,8 @@ interface HeaderProps {
   showBackButton?: boolean;
   backHref?: string;
   backLabel?: string;
+  // 指定すると戻るは Link ではなくこのハンドラを呼ぶ（未保存確認などに使う）
+  onBackClick?: () => void;
 }
 
 export default function Header({
@@ -16,19 +18,29 @@ export default function Header({
   showBackButton = false,
   backHref = '/',
   backLabel,
+  onBackClick,
 }: HeaderProps = {}): React.JSX.Element {
   const label = backLabel ?? (backHref === '/' ? 'アプリ選択に戻る' : 'もどる');
+  const backClass =
+    'inline-flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300';
   return (
     <header className="w-full max-w-3xl">
       {showBackButton ? (
         <div className="mb-4">
-          <Link
-            href={backHref}
-            className="inline-flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-            data-testid="back-to-home"
-          >
-            ← {label}
-          </Link>
+          {onBackClick ? (
+            <button
+              type="button"
+              onClick={onBackClick}
+              className={backClass}
+              data-testid="back-to-home"
+            >
+              ← {label}
+            </button>
+          ) : (
+            <Link href={backHref} className={backClass} data-testid="back-to-home">
+              ← {label}
+            </Link>
+          )}
         </div>
       ) : null}
       

--- a/app/sansu-100/avatar/page.tsx
+++ b/app/sansu-100/avatar/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import Header from '../../components/header';
@@ -63,9 +62,14 @@ export default function AvatarBuilderPage(): React.JSX.Element {
   const [activeKey, setActiveKey] = useState<keyof AvatarConfig>('top');
   const [busy, setBusy] = useState(false);
   const [saved, setSaved] = useState(false);
+  // 未保存のまま離脱しようとした行き先（確認ダイアログを出す）
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
 
   const config: AvatarConfig =
     draft ?? normalizeAvatarConfig(currentUser?.avatarConfig);
+
+  // 変更があってまだ保存していない＝離脱時に確認する
+  const dirty = draft !== null && !saved;
 
   const owned = useMemo(() => currentUser?.ownedItems ?? [], [currentUser]);
 
@@ -73,6 +77,18 @@ export default function AvatarBuilderPage(): React.JSX.Element {
     () => (currentUser ? { ...currentUser, avatarConfig: config } : null),
     [currentUser, config]
   );
+
+  // タブを閉じる/リロード/外部遷移のときはブラウザ標準の確認を出す
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (dirty) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [dirty]);
 
   // カテゴリごとの選べる値（無料＋所持している有料）
   const optionsFor = (cat: Cat): string[] => {
@@ -101,7 +117,7 @@ export default function AvatarBuilderPage(): React.JSX.Element {
     if (storage.getSettings().soundOn) sound.correct();
   };
 
-  const save = async () => {
+  const save = async (): Promise<boolean> => {
     setBusy(true);
     try {
       const res = await sansuApi.setAvatarConfig(currentUser.id, config);
@@ -109,12 +125,32 @@ export default function AvatarBuilderPage(): React.JSX.Element {
         saveUser(res.user);
         setSaved(true);
         if (storage.getSettings().soundOn) sound.fanfare();
+        return true;
       }
+      return false;
     } catch {
       // 通信不可時は黙って失敗（あとで再保存できる）
+      return false;
     } finally {
       setBusy(false);
     }
+  };
+
+  // 未保存があれば確認ダイアログ、なければそのまま移動
+  const requestNavigate = (href: string) => {
+    if (dirty) setPendingHref(href);
+    else router.push(href);
+  };
+  const navSaveAndGo = async () => {
+    const href = pendingHref;
+    const ok = await save();
+    setPendingHref(null);
+    if (ok && href) router.push(href);
+  };
+  const navDiscardAndGo = () => {
+    const href = pendingHref;
+    setPendingHref(null);
+    if (href) router.push(href);
   };
 
   const activeCat = CATEGORIES.find((c) => c.key === activeKey) ?? CATEGORIES[0];
@@ -132,6 +168,7 @@ export default function AvatarBuilderPage(): React.JSX.Element {
           showBackButton
           backHref="/sansu-100"
           backLabel="ホームにもどる"
+          onBackClick={() => requestNavigate('/sansu-100')}
         />
 
         <section className="flex flex-col items-center gap-2 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
@@ -208,12 +245,13 @@ export default function AvatarBuilderPage(): React.JSX.Element {
           )}
 
           {activeCat.paid ? (
-            <Link
-              href="/sansu-100/shop"
-              className="block rounded-xl bg-yellow-100 py-2.5 text-center text-sm font-bold text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-200"
+            <button
+              type="button"
+              onClick={() => requestNavigate('/sansu-100/shop')}
+              className="block w-full rounded-xl bg-yellow-100 py-2.5 text-center text-sm font-bold text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-200"
             >
               🛍️ ショップで {activeCat.label} を かう
-            </Link>
+            </button>
           ) : null}
         </section>
 
@@ -227,6 +265,49 @@ export default function AvatarBuilderPage(): React.JSX.Element {
           {busy ? 'ほぞんちゅう…' : saved ? '✅ ほぞんしたよ！' : '💾 このキャラにする'}
         </button>
       </div>
+
+      {pendingHref !== null ? (
+        <div
+          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          data-testid="avatar-unsaved-dialog"
+        >
+          <div className="w-full max-w-xs space-y-3 rounded-2xl bg-white p-6 text-center shadow-xl dark:bg-gray-800">
+            <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
+              ほぞんして いない へんこうが あるよ
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              このまま いくと、きせかえが きえちゃうよ。どうする？
+            </p>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={navSaveAndGo}
+              className="w-full rounded-xl bg-green-600 py-3 font-bold text-white hover:bg-green-700 disabled:opacity-60"
+              data-testid="unsaved-save-go"
+            >
+              💾 ほぞんして いく
+            </button>
+            <button
+              type="button"
+              onClick={navDiscardAndGo}
+              className="w-full rounded-xl bg-gray-200 py-3 font-bold text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              data-testid="unsaved-discard-go"
+            >
+              ほぞんせずに いく
+            </button>
+            <button
+              type="button"
+              onClick={() => setPendingHref(null)}
+              className="w-full py-1 text-sm font-semibold text-blue-600 dark:text-blue-300"
+              data-testid="unsaved-cancel"
+            >
+              キャンセル（ここに のこる）
+            </button>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/app/sansu-100/components/HowToPlay.tsx
+++ b/app/sansu-100/components/HowToPlay.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// ミニゲームの「あそびかた」を intro 画面に出す共通ブロック。
+export default function HowToPlay({
+  steps,
+}: {
+  steps: readonly string[];
+}): React.JSX.Element {
+  return (
+    <div className="rounded-xl bg-blue-50 p-4 text-left dark:bg-blue-900/20">
+      <p className="mb-2 text-sm font-bold text-blue-800 dark:text-blue-200">
+        📖 あそびかた
+      </p>
+      <ol className="list-decimal space-y-1 pl-5 text-sm text-gray-700 dark:text-gray-200">
+        {steps.map((s, i) => (
+          <li key={i}>{s}</li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -5,6 +5,7 @@ export type MinigameMeta = {
   name: string;
   emoji: string;
   desc: string;
+  howTo: readonly string[]; // あそびかた（操作と目的）。各ゲームの intro で表示する
   available: boolean; // 実装済みで遊べるか（ゲームを作るたびに true にする）
 };
 
@@ -15,6 +16,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'スネーク',
     emoji: '🐍',
     desc: 'りんごを たべて のびよう',
+    howTo: [
+      'やじるしキー か スワイプ（下のボタン）で ヘビを うごかす',
+      'りんご🍎を たべると ながく なって スコアアップ',
+      'かべと じぶんの からだに あたると おわり',
+    ],
     available: true,
   },
   {
@@ -22,6 +28,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'よけよけランナー',
     emoji: '🏃',
     desc: 'ジャンプで よけよう',
+    howTo: [
+      'がめんを タップ（か スペースキー）で ジャンプ',
+      'まえから くる じゃまものを ジャンプで よけよう',
+      'よけるほど スコアが ふえるよ',
+    ],
     available: true,
   },
   {
@@ -29,6 +40,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'もぐらたたき',
     emoji: '🔨',
     desc: '🐹を タップ！💣は だめ',
+    howTo: [
+      'でてきた もぐら🐹を タップ！',
+      'ばくだん💣を タップすると おわり',
+      'じかんない に たくさん たたこう',
+    ],
     available: true,
   },
   {
@@ -36,6 +52,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'ブロックくずし',
     emoji: '🧱',
     desc: 'パドルで ボールを はねかえそう',
+    howTo: [
+      'がめんを さわって（か やじるし）で パドルを よこに うごかす',
+      'ボールを はねかえして ブロックを ぜんぶ けそう',
+      'ぜんぶ けすと つぎの レベルへ。ボールを おとすと おわり',
+    ],
     available: true,
   },
   {
@@ -43,6 +64,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'おちものよけ',
     emoji: '👻',
     desc: '👻を よけよう',
+    howTo: [
+      '◀▶ボタン（か スワイプ・やじるし）で ひだり・みぎに うごく',
+      'うえから おちてくる 👻に あたらないように よけよう',
+      'ながく よけるほど スコアアップ',
+    ],
     available: true,
   },
   {
@@ -50,6 +76,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'しんけいすいじゃく',
     emoji: '🧠',
     desc: 'おなじ えを さがそう',
+    howTo: [
+      'カードを 2まい タップして めくる',
+      'おなじ えが でたら そろう！ちがったら また うらむき',
+      'ぜんぶ そろえると カードが ふえて つぎの レベルへ',
+    ],
     available: true,
   },
   {
@@ -57,6 +88,11 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'めいろ',
     emoji: '🗺️',
     desc: '🏁を めざそう',
+    howTo: [
+      'やじるし か スワイプ（下のボタン）で すすむ',
+      'ゴール🏁を めざそう',
+      'クリアするほど めいろが おおきく なるよ',
+    ],
     available: true,
   },
   {
@@ -64,6 +100,24 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     name: 'ぱたぱた',
     emoji: '🐤',
     desc: 'タップで すき間を くぐろう',
+    howTo: [
+      'がめんを タップ（か スペースキー）で はばたく',
+      'つちかんの すき間を くぐろう',
+      'つちかんや 地めんに ぶつかると おわり',
+    ],
     available: true,
   },
 ];
+
+const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(
+  MINIGAMES.map((m) => [m.id, m])
+);
+
+export function getMinigame(id: MinigameId): MinigameMeta | undefined {
+  return BY_ID[id];
+}
+
+/** あそびかたの手順（未定義なら空配列）。 */
+export function minigameHowTo(id: MinigameId): readonly string[] {
+  return BY_ID[id]?.howTo ?? [];
+}

--- a/app/sansu-100/minigame/breakout/page.tsx
+++ b/app/sansu-100/minigame/breakout/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import BreakoutGame from '../../games/BreakoutGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -114,6 +116,7 @@ export default function BreakoutPage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🧱</p>
+            <HowToPlay steps={minigameHowTo('breakout')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/falling/page.tsx
+++ b/app/sansu-100/minigame/falling/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import FallingGame from '../../games/FallingGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -112,6 +114,7 @@ export default function FallingPage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">👻</p>
+            <HowToPlay steps={minigameHowTo('falling')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/flappy/page.tsx
+++ b/app/sansu-100/minigame/flappy/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import FlappyGame from '../../games/FlappyGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -117,6 +119,7 @@ export default function FlappyPage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🐤</p>
+            <HowToPlay steps={minigameHowTo('flappy')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/maze/page.tsx
+++ b/app/sansu-100/minigame/maze/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import MazeGame from '../../games/MazeGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -115,6 +117,7 @@ export default function MazePage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🗺️</p>
+            <HowToPlay steps={minigameHowTo('maze')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/memory/page.tsx
+++ b/app/sansu-100/minigame/memory/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import MemoryGame from '../../games/MemoryGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -115,6 +117,7 @@ export default function MemoryPage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🧠</p>
+            <HowToPlay steps={minigameHowTo('memory')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/runner/page.tsx
+++ b/app/sansu-100/minigame/runner/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import RunnerGame from '../../games/RunnerGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -112,6 +114,7 @@ export default function RunnerPage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🏃</p>
+            <HowToPlay steps={minigameHowTo('runner')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/snake/page.tsx
+++ b/app/sansu-100/minigame/snake/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import SnakeGame from '../../games/SnakeGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -128,6 +130,7 @@ export default function SnakePage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🐍</p>
+            <HowToPlay steps={minigameHowTo('snake')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>

--- a/app/sansu-100/minigame/whack/page.tsx
+++ b/app/sansu-100/minigame/whack/page.tsx
@@ -9,11 +9,13 @@ import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
 import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
 import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
 import NewRecordBanner from '../../components/NewRecordBanner';
 import WhackGame from '../../games/WhackGame';
 import { useSansuUser } from '../../hooks/useSansuUser';
 import { sansuApi } from '../../lib/api-client';
 import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
 import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
 
 type Phase = 'intro' | 'playing' | 'over';
@@ -112,6 +114,7 @@ export default function WhackPage(): React.JSX.Element {
         {phase === 'intro' ? (
           <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
             <p className="text-6xl">🐹</p>
+            <HowToPlay steps={minigameHowTo('whack')} />
             <p className="text-gray-700 dark:text-gray-200">
               コインを {SPEND_COSTS.play}まい つかって あそぶよ
             </p>


### PR DESCRIPTION
## 1) ミニゲームの「あそびかた」表示
操作方法が分からないという声に対応。各ゲームのスタート画面に操作＋目的の手順を表示。
- `lib/minigame-list.ts` に `howTo` を追加、共通 `HowToPlay` コンポーネントで8ゲームの intro に表示

## 2) キャラづくりの未保存確認ダイアログ
着せ替えを保存せず別ページに行くと変更が消える問題に対応。
- 変更があるのに「戻る」「ショップへ」へ移動しようとすると「ほぞんして いく / ほぞんせずに いく / キャンセル」を表示
- タブ閉じ/リロードは `beforeunload` で確認。`Header` に `onBackClick` を追加
- closet は各タップで即保存のため対象外

## 検証
- iPhone実機相当(Playwright): あそびかた表示・未変更時は自由に離脱・変更時はダイアログ・キャンセルで残留・破棄で遷移、を確認（console error 0）
- lint・フロント/APIビルド緑 / テスト155件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)