### PR TITLE
feat(sansu-100): コインを逓増(30→50→70…)にして1日上限を撤廃

### DIFF
--- a/api/src/shared/coins.ts
+++ b/api/src/shared/coins.ts
@@ -4,12 +4,12 @@
 //       匿名APIのためクライアント申告は信用せず、ここで再計算した値を正とする。
 
 export const COIN_RULES = {
-  firstClearOfDay: 50,
-  subsequentClear: 10,
+  baseStart: 30, // その日1回目の基本コイン
+  baseStep: 20, // 1回ふえるごとに +20
+  baseMax: 150, // 1回あたりの基本コインの上限（1日合計の上限はなし）
   newBest: 20,
   streak3Bonus: 10,
   streak7Bonus: 30,
-  dailyCap: 150,
 } as const;
 
 export type CoinBreakdownEntry = { label: string; amount: number };
@@ -50,11 +50,11 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
 
   const breakdown: CoinBreakdownEntry[] = [];
 
-  if (sessionCountSoFar === 0) {
-    breakdown.push({ label: 'きょう1回目', amount: COIN_RULES.firstClearOfDay });
-  } else {
-    breakdown.push({ label: 'クリア', amount: COIN_RULES.subsequentClear });
-  }
+  const base = Math.min(
+    COIN_RULES.baseMax,
+    COIN_RULES.baseStart + sessionCountSoFar * COIN_RULES.baseStep
+  );
+  breakdown.push({ label: `きょう${sessionCountSoFar + 1}回目`, amount: base });
 
   if (ctx.isNewBest) {
     breakdown.push({ label: 'ベストこうしん', amount: COIN_RULES.newBest });
@@ -66,14 +66,8 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
     breakdown.push({ label: '3日れんぞく', amount: COIN_RULES.streak3Bonus });
   }
 
-  const raw = breakdown.reduce((sum, e) => sum + e.amount, 0);
-
-  const capRemaining = Math.max(0, COIN_RULES.dailyCap - earnedSoFar);
-  const coinsEarned = Math.min(raw, capRemaining);
-
-  if (coinsEarned < raw) {
-    breakdown.push({ label: '1日上限', amount: coinsEarned - raw });
-  }
+  // 1日の上限はなし（やるほど増える）。
+  const coinsEarned = breakdown.reduce((sum, e) => sum + e.amount, 0);
 
   return {
     coinsEarned,

--- a/app/sansu-100/lib/__tests__/coins.test.ts
+++ b/app/sansu-100/lib/__tests__/coins.test.ts
@@ -13,85 +13,67 @@ const base: CoinContext = {
 };
 
 describe('calculateCoins', () => {
-  it('1日1回目のクリアで +50', () => {
+  it('1日1回目のクリアで +30', () => {
     const r = calculateCoins(base);
-    expect(r.coinsEarned).toBe(50);
+    expect(r.coinsEarned).toBe(30);
     expect(r.nextDailySessionCount).toBe(1);
-    expect(r.nextDailyCoinsEarned).toBe(50);
+    expect(r.nextDailyCoinsEarned).toBe(30);
     expect(r.nextDailyCoinDate).toBe('2026-06-28');
   });
 
-  it('2回目以降のクリアで +10', () => {
+  it('回数が増えるほど基本コインが +20 ずつ増える（30→50→70…）', () => {
+    const second = calculateCoins({ ...base, dailySessionCount: 1, dailyCoinsEarned: 30 });
+    expect(second.coinsEarned).toBe(50);
+    expect(second.nextDailyCoinsEarned).toBe(80);
+    const third = calculateCoins({ ...base, dailySessionCount: 2, dailyCoinsEarned: 80 });
+    expect(third.coinsEarned).toBe(70);
+  });
+
+  it('1回あたりの基本コインは baseMax(150) で頭打ち', () => {
+    const sixth = calculateCoins({ ...base, dailySessionCount: 6, dailyCoinsEarned: 999 });
+    expect(sixth.coinsEarned).toBe(COIN_RULES.baseMax); // 30+6*20=150
+    const tenth = calculateCoins({ ...base, dailySessionCount: 10, dailyCoinsEarned: 999 });
+    expect(tenth.coinsEarned).toBe(COIN_RULES.baseMax);
+  });
+
+  it('1日合計の上限はない（150を超えても付与される）', () => {
     const r = calculateCoins({
       ...base,
-      dailyCoinsEarned: 50,
-      dailySessionCount: 1,
+      dailySessionCount: 5,
+      dailyCoinsEarned: 400, // すでに400稼いでいても…
     });
-    expect(r.coinsEarned).toBe(10);
-    expect(r.nextDailyCoinsEarned).toBe(60);
-    expect(r.nextDailySessionCount).toBe(2);
+    expect(r.coinsEarned).toBe(130); // 30+5*20=130
+    expect(r.nextDailyCoinsEarned).toBe(530);
   });
 
   it('自己ベスト更新で +20 上乗せ', () => {
     const r = calculateCoins({ ...base, isNewBest: true });
-    expect(r.coinsEarned).toBe(50 + 20);
+    expect(r.coinsEarned).toBe(30 + 20);
   });
 
   it('3日連続に到達した日だけ +10', () => {
-    const reached = calculateCoins({
-      ...base,
-      streakDays: 3,
-      prevStreakDays: 2,
-    });
-    expect(reached.coinsEarned).toBe(50 + 10);
-    // すでに3日を超えている日は付かない
-    const already = calculateCoins({
-      ...base,
-      streakDays: 4,
-      prevStreakDays: 3,
-    });
-    expect(already.coinsEarned).toBe(50);
+    const reached = calculateCoins({ ...base, streakDays: 3, prevStreakDays: 2 });
+    expect(reached.coinsEarned).toBe(30 + 10);
+    const already = calculateCoins({ ...base, streakDays: 4, prevStreakDays: 3 });
+    expect(already.coinsEarned).toBe(30);
   });
 
   it('7日連続に到達した日は +30（3日分は重複しない）', () => {
     const r = calculateCoins({ ...base, streakDays: 7, prevStreakDays: 6 });
-    expect(r.coinsEarned).toBe(50 + 30);
+    expect(r.coinsEarned).toBe(30 + 30);
   });
 
-  it('1日上限150を超えない（残り分だけ付与）', () => {
+  it('日付が変わったら当日カウンタをリセットして再び 1回目=30', () => {
     const r = calculateCoins({
       ...base,
-      dailyCoinsEarned: 145,
-      dailySessionCount: 5,
-      isNewBest: true, // raw=10+20=30 だが残り5しか付かない
-    });
-    expect(r.coinsEarned).toBe(5);
-    expect(r.nextDailyCoinsEarned).toBe(COIN_RULES.dailyCap);
-    // 上限到達の説明エントリが入る
-    expect(r.breakdown.some((e) => e.label === '1日上限')).toBe(true);
-  });
-
-  it('上限に達していると0（マイナスにはならない）', () => {
-    const r = calculateCoins({
-      ...base,
-      dailyCoinsEarned: 150,
-      dailySessionCount: 6,
-    });
-    expect(r.coinsEarned).toBe(0);
-    expect(r.coinsEarned).toBeGreaterThanOrEqual(0);
-  });
-
-  it('日付が変わったら当日カウンタをリセットして再び +50', () => {
-    const r = calculateCoins({
-      ...base,
-      dailyCoinDate: '2026-06-27', // 前日
-      dailyCoinsEarned: 150,
+      dailyCoinDate: '2026-06-27',
+      dailyCoinsEarned: 500,
       dailySessionCount: 8,
       todayKey: '2026-06-28',
     });
-    expect(r.coinsEarned).toBe(50);
+    expect(r.coinsEarned).toBe(30);
     expect(r.nextDailyCoinDate).toBe('2026-06-28');
-    expect(r.nextDailyCoinsEarned).toBe(50);
+    expect(r.nextDailyCoinsEarned).toBe(30);
     expect(r.nextDailySessionCount).toBe(1);
   });
 
@@ -99,11 +81,11 @@ describe('calculateCoins', () => {
     const r = calculateCoins({
       ...base,
       isCountable: false,
-      dailyCoinsEarned: 60,
+      dailyCoinsEarned: 80,
       dailySessionCount: 2,
     });
     expect(r.coinsEarned).toBe(0);
-    expect(r.nextDailyCoinsEarned).toBe(60);
+    expect(r.nextDailyCoinsEarned).toBe(80);
     expect(r.nextDailySessionCount).toBe(2);
     expect(r.nextDailyCoinDate).toBe(base.dailyCoinDate);
   });

--- a/app/sansu-100/lib/coins.ts
+++ b/app/sansu-100/lib/coins.ts
@@ -4,15 +4,15 @@
 //       挙動の一致は app/sansu-100/lib/__tests__/coins.test.ts で担保する。
 //
 // 子ども向け配慮: 減点・没収は一切しない（常に coinsEarned >= 0）。
-//                 1日の獲得上限を設けて「短時間の毎日の習慣」を促す。
+//                 「やればやるほど増える」ように基本コインは回数で逓増し、1日の上限はなし。
 
 export const COIN_RULES = {
-  firstClearOfDay: 50, // 1日1回目のクリア
-  subsequentClear: 10, // 2回目以降のクリア
+  baseStart: 30, // その日1回目の基本コイン
+  baseStep: 20, // 1回ふえるごとに +20（2回目50・3回目70…）
+  baseMax: 150, // 1回あたりの基本コインの上限（暴走防止。1日合計の上限はなし）
   newBest: 20, // 自己ベスト更新
   streak3Bonus: 10, // 3日連続に到達した日
   streak7Bonus: 30, // 7日連続に到達した日
-  dailyCap: 150, // 1日に計算で稼げる上限
 } as const;
 
 export type CoinBreakdownEntry = { label: string; amount: number };
@@ -64,12 +64,12 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
 
   const breakdown: CoinBreakdownEntry[] = [];
 
-  // 基本報酬（1日1回目 or 2回目以降）
-  if (sessionCountSoFar === 0) {
-    breakdown.push({ label: 'きょう1回目', amount: COIN_RULES.firstClearOfDay });
-  } else {
-    breakdown.push({ label: 'クリア', amount: COIN_RULES.subsequentClear });
-  }
+  // 基本報酬: その日の回数で逓増（1回目30・2回目50…+20ずつ、baseMax で頭打ち）
+  const base = Math.min(
+    COIN_RULES.baseMax,
+    COIN_RULES.baseStart + sessionCountSoFar * COIN_RULES.baseStep
+  );
+  breakdown.push({ label: `きょう${sessionCountSoFar + 1}回目`, amount: base });
 
   // 自己ベスト更新
   if (ctx.isNewBest) {
@@ -83,16 +83,8 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
     breakdown.push({ label: '3日れんぞく', amount: COIN_RULES.streak3Bonus });
   }
 
-  const raw = breakdown.reduce((sum, e) => sum + e.amount, 0);
-
-  // 1日上限でクリップ（残り上限まで）。減点はしない。
-  const capRemaining = Math.max(0, COIN_RULES.dailyCap - earnedSoFar);
-  const coinsEarned = Math.min(raw, capRemaining);
-
-  // 上限で削られた分を表示に反映
-  if (coinsEarned < raw) {
-    breakdown.push({ label: '1日上限', amount: coinsEarned - raw });
-  }
+  // 1日の上限はなし（やるほど増える）。減点もしない。
+  const coinsEarned = breakdown.reduce((sum, e) => sum + e.amount, 0);
 
   return {
     coinsEarned,


### PR DESCRIPTION
上限150に達するとコインが増えず「解いてももらえない」のが不評だったため対応。

## 変更
- **1日の獲得上限を撤廃**（やるほど増える）
- **基本コインを回数で逓増**: 1回目30 → 2回目50 → …**+20ずつ**（1回あたり150で頭打ち、1日合計は無制限）
- ベスト更新+20・ストリークボーナスは据え置き
- client/server の `coins.ts` を同一改修、テスト更新

## 検証
- iPhone実機相当(Playwright): 1→2→3回目で基本30/50/70、合計150超でも加算継続を確認（console error 0）
- lint・両ビルド緑 / テスト155件緑

※ フィーバー＋ルーレットは別PRで追加予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)