### PR TITLE
feat(sansu-100): フィーバー(おすすめ問題)＋達成でルーレット倍率コイン

### DIFF
--- a/api/src/functions/sansuClaimFever.ts
+++ b/api/src/functions/sansuClaimFever.ts
@@ -1,0 +1,88 @@
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from '@azure/functions';
+
+import { FEVER_MULTIPLIERS } from '../shared/fever';
+import { type SansuUserEntity, toPublic } from '../shared/sansuTypes';
+import { USERS_PARTITION, usersTable } from '../shared/tableClient';
+
+// フィーバー達成後のルーレット倍率を適用する。倍率はクライアントが止めた値だが、
+// サーバーは {2,3} とフィーバー枠の保留(pending)有無だけ検証する（コインは飾り用途）。
+type ClaimBody = { userId?: string; multiplier?: number };
+
+app.http('sansuClaimFever', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  route: 'sansu/fever/claim',
+  handler: async (
+    req: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    try {
+      const body = (await req.json()) as ClaimBody;
+      if (!body.userId) {
+        return { status: 400, jsonBody: { error: 'missing userId' } };
+      }
+      const mult = Number(body.multiplier);
+      if (!FEVER_MULTIPLIERS.includes(mult)) {
+        return { status: 400, jsonBody: { error: 'bad multiplier' } };
+      }
+
+      const uTable = await usersTable();
+      let user: SansuUserEntity;
+      try {
+        user = await uTable.getEntity<SansuUserEntity>(
+          USERS_PARTITION,
+          body.userId
+        );
+      } catch {
+        return { status: 404, jsonBody: { error: 'user not found' } };
+      }
+
+      const pendingInterval = user.pendingFeverInterval ?? -1;
+      const pendingBase = user.pendingFeverBase ?? 0;
+      // 未claimのフィーバー枠が無い / すでにその枠でclaim済み → 何もしない（冪等）
+      if (
+        pendingInterval < 0 ||
+        (user.lastFeverInterval ?? -2) === pendingInterval
+      ) {
+        return {
+          status: 409,
+          jsonBody: { error: 'no pending fever', user: toPublic(user) },
+        };
+      }
+
+      const bonus = pendingBase * (mult - 1);
+      await uTable.updateEntity(
+        {
+          partitionKey: USERS_PARTITION,
+          rowKey: body.userId,
+          coins: (user.coins ?? 0) + bonus,
+          lastFeverInterval: pendingInterval,
+          pendingFeverInterval: -1,
+          pendingFeverBase: 0,
+        },
+        'Merge'
+      );
+      const refreshed = await uTable.getEntity<SansuUserEntity>(
+        USERS_PARTITION,
+        body.userId
+      );
+      return {
+        status: 200,
+        jsonBody: {
+          ok: true,
+          user: toPublic(refreshed),
+          multiplier: mult,
+          bonus,
+        },
+      };
+    } catch (e) {
+      context.error('sansuClaimFever error', e);
+      return { status: 500, jsonBody: { error: 'internal' } };
+    }
+  },
+});

--- a/api/src/functions/sansuSessions.ts
+++ b/api/src/functions/sansuSessions.ts
@@ -2,6 +2,11 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/fu
 
 import { calculateCoins } from '../shared/coins';
 import {
+  feverIntervalIndex,
+  feverLevelForIndex,
+  isStartedAtRecent,
+} from '../shared/fever';
+import {
   type SansuSession,
   type SansuSessionEntity,
   type SansuUserEntity,
@@ -66,6 +71,7 @@ app.http('sansuSessionsPost', {
       // ユーザー集計＋コイン。残高/集計はサーバーを権威とする。
       const uTable = await usersTable();
       let publicUser: ReturnType<typeof toPublic> | undefined;
+      let feverEligible = false; // 今回がフィーバー達成＝ルーレット権利あり
       try {
         const user = await uTable.getEntity<SansuUserEntity>(
           USERS_PARTITION,
@@ -104,6 +110,16 @@ app.http('sansuSessionsPost', {
             isCountable: !body.isRetired,
           });
 
+          // フィーバー判定: 開始時刻の15分枠の推奨レベルと一致＆その枠で未claim。
+          const interval = feverIntervalIndex(body.startedAt);
+          feverEligible =
+            !body.isRetired &&
+            coin.coinsEarned > 0 &&
+            typeof body.level === 'number' &&
+            body.level === feverLevelForIndex(interval) &&
+            (user.lastFeverInterval ?? -1) !== interval &&
+            isStartedAtRecent(body.startedAt, Date.now());
+
           const updated: Partial<SansuUserEntity> & {
             partitionKey: string;
             rowKey: string;
@@ -120,6 +136,13 @@ app.http('sansuSessionsPost', {
             dailyCoinDate: coin.nextDailyCoinDate,
             dailyCoinsEarned: coin.nextDailyCoinsEarned,
             dailySessionCount: coin.nextDailySessionCount,
+            // フィーバー達成なら倍率の対象(基本コイン)を保留。ルーレットでclaim。
+            ...(feverEligible
+              ? {
+                  pendingFeverInterval: interval,
+                  pendingFeverBase: coin.coinsEarned,
+                }
+              : {}),
           };
           await uTable.updateEntity(updated, 'Merge');
           const refreshed = await uTable.getEntity<SansuUserEntity>(
@@ -132,7 +155,10 @@ app.http('sansuSessionsPost', {
         context.warn('User aggregate update failed', e);
       }
 
-      return { status: 201, jsonBody: { ok: true, user: publicUser } };
+      return {
+        status: 201,
+        jsonBody: { ok: true, user: publicUser, feverEligible },
+      };
     } catch (e) {
       context.error('sansuSessionsPost error', e);
       return { status: 500, jsonBody: { error: 'internal' } };

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,6 +12,7 @@ import './functions/sansuSessions';
 import './functions/sansuPurchase';
 import './functions/sansuAvatar';
 import './functions/sansuSpend';
+import './functions/sansuClaimFever';
 import './functions/sansuAwardBadge';
 import './functions/sansuDebugGrant';
 import './functions/sansuAdminUsers';

--- a/api/src/shared/fever.ts
+++ b/api/src/shared/fever.ts
@@ -1,0 +1,31 @@
+// フィーバー(おすすめ)レベル判定（サーバー版・確定値）。
+// 重要: app/sansu-100/lib/fever.ts と「同一ロジック」で複製している（client/server一致）。
+
+export const FEVER_INTERVAL_MS = 15 * 60 * 1000; // 15分
+
+const FEVER_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+
+export const FEVER_MULTIPLIERS = [2, 3];
+
+export function feverIntervalIndex(now: number): number {
+  return Math.floor(now / FEVER_INTERVAL_MS);
+}
+
+export function feverLevelForIndex(idx: number): number {
+  let x = (idx + 1) >>> 0;
+  x ^= x << 13;
+  x >>>= 0;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  x >>>= 0;
+  return FEVER_LEVELS[x % FEVER_LEVELS.length];
+}
+
+export function feverLevel(now: number): number {
+  return feverLevelForIndex(feverIntervalIndex(now));
+}
+
+/** 送信された開始時刻が信頼できる範囲か（時計詐称対策）。 */
+export function isStartedAtRecent(startedAt: number, now: number): boolean {
+  return startedAt <= now + 60_000 && now - startedAt < 25 * 60 * 1000;
+}

--- a/api/src/shared/sansuTypes.ts
+++ b/api/src/shared/sansuTypes.ts
@@ -60,6 +60,10 @@ export type SansuUserEntity = {
   minigameHighScore?: number;
   minigameScoresJson?: string;
   avatarConfigJson?: string;
+  // --- フィーバー(おすすめ問題達成)＋ルーレット倍率 ---
+  lastFeverInterval?: number; // 最後にルーレットを使った15分枠（重複防止）
+  pendingFeverInterval?: number; // フィーバー達成済みで未claimの枠（-1=なし）
+  pendingFeverBase?: number; // その達成セッションで得た基本コイン（倍率の対象）
 };
 
 export function toPublic(e: SansuUserEntity): SansuUserPublic {

--- a/app/sansu-100/components/FeverRoulette.tsx
+++ b/app/sansu-100/components/FeverRoulette.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// ×2/×3 が交互の6分割ルーレット。くるくる回って「とめる！」でタイミングよく止める。
+const SEGMENTS = [2, 3, 2, 3, 2, 3];
+const N = SEGMENTS.length;
+const SEG = 360 / N;
+
+function pt(angleDeg: number, r: number): [number, number] {
+  const a = ((angleDeg - 90) * Math.PI) / 180;
+  return [100 + r * Math.cos(a), 100 + r * Math.sin(a)];
+}
+function slicePath(i: number): string {
+  const [x0, y0] = pt(i * SEG, 92);
+  const [x1, y1] = pt((i + 1) * SEG, 92);
+  return `M100,100 L${x0},${y0} A92,92 0 0 1 ${x1},${y1} Z`;
+}
+
+export default function FeverRoulette({
+  onResult,
+}: {
+  onResult: (multiplier: number) => void;
+}): React.JSX.Element {
+  const [rotation, setRotation] = useState(0);
+  const [stopped, setStopped] = useState(false);
+  const [landed, setLanded] = useState<number | null>(null);
+  const rotRef = useRef(0);
+  const rafRef = useRef<number | null>(null);
+  const lastRef = useRef<number | null>(null);
+  const soundRef = useRef(true);
+
+  useEffect(() => {
+    soundRef.current = storage.getSettings().soundOn;
+    const loop = (t: number) => {
+      if (lastRef.current === null) lastRef.current = t;
+      const dt = t - lastRef.current;
+      lastRef.current = t;
+      rotRef.current = (rotRef.current + dt * 0.5) % 360; // 約500度/秒
+      setRotation(rotRef.current);
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  const stop = () => {
+    if (stopped) return;
+    setStopped(true);
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    const r = ((rotRef.current % 360) + 360) % 360;
+    const idx = Math.floor(((360 - r) % 360) / SEG) % N;
+    // セグメント中心が上(ポインタ)に来るようスナップ
+    const center = idx * SEG + SEG / 2;
+    const snapped = (360 - center + 360) % 360;
+    rotRef.current = snapped;
+    setRotation(snapped);
+    const mult = SEGMENTS[idx];
+    setLanded(mult);
+    if (soundRef.current) sound.fanfare();
+    window.setTimeout(() => onResult(mult), 1200);
+  };
+
+  return (
+    <div
+      className="flex flex-col items-center gap-3 rounded-2xl bg-gradient-to-br from-orange-100 to-pink-100 p-5 dark:from-orange-900/30 dark:to-pink-900/30"
+      data-testid="fever-roulette"
+    >
+      <p className="text-lg font-extrabold text-orange-700 dark:text-orange-200">
+        🔥 フィーバー！ルーレット
+      </p>
+      <div className="relative size-56">
+        <div className="absolute left-1/2 top-[-4px] z-10 -translate-x-1/2 text-3xl leading-none">
+          🔻
+        </div>
+        <svg
+          viewBox="0 0 200 200"
+          className="size-56 drop-shadow-lg"
+          style={{
+            transform: `rotate(${rotation}deg)`,
+            transition: stopped
+              ? 'transform 0.4s cubic-bezier(0.2,0.8,0.3,1)'
+              : 'none',
+          }}
+        >
+          {SEGMENTS.map((m, i) => {
+            const [tx, ty] = pt(i * SEG + SEG / 2, 58);
+            return (
+              <g key={i}>
+                <path
+                  d={slicePath(i)}
+                  fill={m === 3 ? '#f472b6' : '#fbbf24'}
+                  stroke="#ffffff"
+                  strokeWidth={2}
+                />
+                <text
+                  x={tx}
+                  y={ty}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fontSize="24"
+                  fontWeight="900"
+                  fill="#ffffff"
+                >
+                  ×{m}
+                </text>
+              </g>
+            );
+          })}
+          <circle cx="100" cy="100" r="14" fill="#ffffff" />
+        </svg>
+      </div>
+      {landed === null ? (
+        <button
+          type="button"
+          onClick={stop}
+          className="rounded-full bg-red-500 px-10 py-3 text-lg font-extrabold text-white shadow-lg hover:bg-red-600 active:scale-95"
+          data-testid="roulette-stop"
+        >
+          とめる！
+        </button>
+      ) : (
+        <p
+          className="text-xl font-extrabold text-orange-700 dark:text-orange-200"
+          data-testid="roulette-result"
+        >
+          ×{landed} ！コインが ふえるよ 🎉
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/sansu-100/components/LevelPicker.tsx
+++ b/app/sansu-100/components/LevelPicker.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
+import { feverLevel, feverSecondsRemaining } from '../lib/fever';
 import { LEVELS } from '../lib/levels';
 import type { LevelId, Operation } from '../lib/types';
 
@@ -19,24 +20,49 @@ const OP_COLORS: Record<string, string> = {
 export default function LevelPicker({
   onPick,
 }: LevelPickerProps): React.JSX.Element {
+  // フィーバー(おすすめ)レベルと残り時間。15分ごとに入れ替わる。
+  // SSRと食い違わないよう now は 0 で開始し、マウント後に実時刻で更新。
+  const [now, setNow] = useState(0);
+  useEffect(() => {
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const feverLv = now > 0 ? feverLevel(now) : null;
+  const remain = now > 0 ? feverSecondsRemaining(now) : 0;
+  const mmss = `${Math.floor(remain / 60)}:${String(remain % 60).padStart(2, '0')}`;
+
   return (
     <div className="space-y-4">
       <div className="grid gap-3 sm:grid-cols-2">
-        {LEVELS.map((lv) => (
-          <button
-            key={lv.id}
-            type="button"
-            onClick={() => onPick(lv.id, lv.operation)}
-            className={`group rounded-2xl bg-gradient-to-br ${OP_COLORS[lv.operation]} p-5 text-left text-white shadow-md transition-transform hover:scale-[1.02]`}
-            data-testid={`level-pick-${lv.id}`}
-          >
-            <div className="flex items-baseline justify-between">
-              <h3 className="text-xl font-bold">{lv.label}</h3>
-              <span className="text-sm opacity-90">Lv.{lv.id}</span>
-            </div>
-            <p className="mt-1 text-sm opacity-90">{lv.description}</p>
-          </button>
-        ))}
+        {LEVELS.map((lv) => {
+          const isFever = feverLv === lv.id;
+          return (
+            <button
+              key={lv.id}
+              type="button"
+              onClick={() => onPick(lv.id, lv.operation)}
+              className={`group relative rounded-2xl bg-gradient-to-br ${OP_COLORS[lv.operation]} p-5 text-left text-white shadow-md transition-transform hover:scale-[1.02] ${
+                isFever ? 'ring-4 ring-orange-400 ring-offset-2 dark:ring-offset-gray-900' : ''
+              }`}
+              data-testid={`level-pick-${lv.id}`}
+            >
+              {isFever ? (
+                <span
+                  className="absolute -right-2 -top-2 rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white shadow"
+                  data-testid="fever-badge"
+                >
+                  🔥 ボーナス中 のこり {mmss}
+                </span>
+              ) : null}
+              <div className="flex items-baseline justify-between">
+                <h3 className="text-xl font-bold">{lv.label}</h3>
+                <span className="text-sm opacity-90">Lv.{lv.id}</span>
+              </div>
+              <p className="mt-1 text-sm opacity-90">{lv.description}</p>
+            </button>
+          );
+        })}
       </div>
       <button
         type="button"

--- a/app/sansu-100/lib/__tests__/fever.test.ts
+++ b/app/sansu-100/lib/__tests__/fever.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  feverLevel,
+  feverLevelForIndex,
+  feverIntervalIndex,
+  feverSecondsRemaining,
+  FEVER_INTERVAL_MS,
+} from '../fever';
+
+describe('fever', () => {
+  it('同じ15分枠なら同じレベル', () => {
+    const t0 = 1_700_000_000_000;
+    expect(feverLevel(t0)).toBe(feverLevel(t0 + 60_000));
+  });
+
+  it('連続する枠ではレベルがよく入れ替わる', () => {
+    const lvls = new Set<number>();
+    for (let i = 0; i < 12; i++) lvls.add(feverLevelForIndex(1000 + i) as number);
+    expect(lvls.size).toBeGreaterThan(2);
+  });
+
+  it('レベルは常に1〜11', () => {
+    for (let i = 0; i < 100; i++) {
+      const lv = feverLevelForIndex(i) as number;
+      expect(lv).toBeGreaterThanOrEqual(1);
+      expect(lv).toBeLessThanOrEqual(11);
+    }
+  });
+
+  it('intervalIndex は15分ごとに増える', () => {
+    expect(feverIntervalIndex(5 * FEVER_INTERVAL_MS + 1234)).toBe(5);
+    expect(feverIntervalIndex(6 * FEVER_INTERVAL_MS)).toBe(6);
+  });
+
+  it('残り秒は 1..900 の範囲', () => {
+    const r = feverSecondsRemaining(3 * FEVER_INTERVAL_MS + 60_000);
+    expect(r).toBeGreaterThan(0);
+    expect(r).toBeLessThanOrEqual(900);
+  });
+});

--- a/app/sansu-100/lib/api-client.ts
+++ b/app/sansu-100/lib/api-client.ts
@@ -87,10 +87,30 @@ export const sansuApi = {
     session: SansuSession,
     // ストリークボーナスのコイン計算にサーバーが使う文脈（任意）
     ctx?: { streakDays?: number; prevStreakDays?: number }
-  ): Promise<{ ok: true; user?: SansuUserPublic }> {
-    return jsonFetch<{ ok: true; user?: SansuUserPublic }>(`${BASE}/sessions`, {
+  ): Promise<{ ok: true; user?: SansuUserPublic; feverEligible?: boolean }> {
+    return jsonFetch<{
+      ok: true;
+      user?: SansuUserPublic;
+      feverEligible?: boolean;
+    }>(`${BASE}/sessions`, {
       method: 'POST',
       body: JSON.stringify({ ...session, ...(ctx ?? {}) }),
+    });
+  },
+  // フィーバー達成後のルーレット倍率を適用（サーバーが pending を消費）。
+  async claimFever(
+    userId: string,
+    multiplier: number
+  ): Promise<{
+    ok?: boolean;
+    user?: SansuUserPublic;
+    multiplier?: number;
+    bonus?: number;
+    error?: string;
+  }> {
+    return jsonFetch(`${BASE}/fever/claim`, {
+      method: 'POST',
+      body: JSON.stringify({ userId, multiplier }),
     });
   },
   async getSessions(userId: string): Promise<SansuSession[]> {

--- a/app/sansu-100/lib/fever.ts
+++ b/app/sansu-100/lib/fever.ts
@@ -1,0 +1,37 @@
+// 「フィーバー(おすすめ)レベル」を時刻から決める純粋ロジック。
+// 15分ごとに全員共通で入れ替わる（UTCの絶対時刻ベース＝時差非依存）。
+// 重要: api/src/shared/fever.ts と「同一ロジック」で複製している（client/server一致）。
+
+import type { LevelId } from './types';
+
+export const FEVER_INTERVAL_MS = 15 * 60 * 1000; // 15分
+
+// フィーバー対象になりうる具体レベル（mix は除外）
+const FEVER_LEVELS: readonly LevelId[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+
+// ルーレットの倍率候補
+export const FEVER_MULTIPLIERS = [2, 3] as const;
+
+export function feverIntervalIndex(now: number): number {
+  return Math.floor(now / FEVER_INTERVAL_MS);
+}
+
+// idx を xorshift32 でかき混ぜて1レベルを決める（決定的・client/server一致）。
+export function feverLevelForIndex(idx: number): LevelId {
+  let x = (idx + 1) >>> 0;
+  x ^= x << 13;
+  x >>>= 0;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  x >>>= 0;
+  return FEVER_LEVELS[x % FEVER_LEVELS.length];
+}
+
+export function feverLevel(now: number): LevelId {
+  return feverLevelForIndex(feverIntervalIndex(now));
+}
+
+// 次の入れ替わりまでの残り秒
+export function feverSecondsRemaining(now: number): number {
+  return Math.ceil((FEVER_INTERVAL_MS - (now % FEVER_INTERVAL_MS)) / 1000);
+}

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -177,6 +177,27 @@ function PlaySession({
     storage.pushPending(result.session);
     onFinishUpdate(() => result.updatedUser);
 
+    const goToResult = (feverEligible: boolean, coinsAfter: number) => {
+      sessionStorage.setItem(
+        'sansu-100:last-result',
+        JSON.stringify({
+          userId: user.id,
+          session: result.session,
+          newBadges: result.newBadges,
+          pointsEarned: result.pointsEarned,
+          coinsEarned: result.coinsEarned,
+          coinBreakdown: result.coinBreakdown,
+          coinsAfter,
+          bestKey: `lv${pick.level}:${pick.operation}`,
+          previousBest:
+            user.bestTimesByLevel[`lv${pick.level}:${pick.operation}`] ?? null,
+          feverEligible,
+        })
+      );
+      router.replace('/sansu-100/result');
+    };
+
+    // 完了→結果。フィーバー達成(feverEligible)はサーバー応答で確定するので待ってから遷移。
     sansuApi
       .submitSession(result.session, {
         streakDays: result.updatedUser.currentStreakDays,
@@ -184,28 +205,16 @@ function PlaySession({
       })
       .then((res) => {
         storage.clearPending([result.session.id]);
-        // サーバー権威のコイン残高でローカルを上書き同期
         if (res.user) onServerSync(res.user);
+        goToResult(
+          !!res.feverEligible,
+          res.user?.coins ?? result.updatedUser.coins ?? 0
+        );
       })
       .catch(() => {
-        // remain in pending queue for later sync
+        // オフライン等はフィーバー無しで結果へ（あとで同期）
+        goToResult(false, result.updatedUser.coins ?? 0);
       });
-
-    sessionStorage.setItem(
-      'sansu-100:last-result',
-      JSON.stringify({
-        session: result.session,
-        newBadges: result.newBadges,
-        pointsEarned: result.pointsEarned,
-        coinsEarned: result.coinsEarned,
-        coinBreakdown: result.coinBreakdown,
-        coinsAfter: result.updatedUser.coins ?? 0,
-        bestKey: `lv${pick.level}:${pick.operation}`,
-        previousBest:
-          user.bestTimesByLevel[`lv${pick.level}:${pick.operation}`] ?? null,
-      })
-    );
-    router.replace('/sansu-100/result');
   }, [
     session.isComplete,
     user,

--- a/app/sansu-100/result/page.tsx
+++ b/app/sansu-100/result/page.tsx
@@ -9,12 +9,15 @@ import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
 import BadgeUnlockOverlay from '../components/BadgeUnlockOverlay';
 import CoinBalance from '../components/CoinBalance';
+import FeverRoulette from '../components/FeverRoulette';
 import { formatDuration } from '../components/SessionTimer';
 import { useSansuUser } from '../hooks/useSansuUser';
+import { sansuApi } from '../lib/api-client';
 import type { CoinBreakdownEntry } from '../lib/coins';
 import type { SansuSession } from '../lib/types';
 
 type LastResult = {
+  userId?: string;
   session: SansuSession;
   newBadges: string[];
   pointsEarned: number;
@@ -23,13 +26,18 @@ type LastResult = {
   coinsAfter?: number;
   bestKey: string;
   previousBest: number | null;
+  feverEligible?: boolean;
 };
 
 export default function ResultPage(): React.JSX.Element {
   const router = useRouter();
-  const { currentUser } = useSansuUser();
+  const { currentUser, saveUser } = useSansuUser();
   const [result, setResult] = useState<LastResult | null>(null);
   const [showOverlay, setShowOverlay] = useState(false);
+  const [feverClaimed, setFeverClaimed] = useState(false);
+  const [feverBonus, setFeverBonus] = useState(0);
+  const [feverMult, setFeverMult] = useState(0);
+  const [claimedCoins, setClaimedCoins] = useState<number | null>(null);
 
   useEffect(() => {
     const raw = sessionStorage.getItem('sansu-100:last-result');
@@ -54,6 +62,26 @@ export default function ResultPage(): React.JSX.Element {
   const coinsEarned = result.coinsEarned ?? 0;
   const coinBreakdown = (result.coinBreakdown ?? []).filter((e) => e.amount !== 0);
   const coinsAfter = result.coinsAfter ?? currentUser.coins ?? 0;
+  const displayCoins = claimedCoins ?? coinsAfter;
+
+  // ルーレットで止めた倍率をサーバーに適用（pending を消費）
+  const onRoulette = async (mult: number) => {
+    const uid = result.userId;
+    if (uid) {
+      try {
+        const res = await sansuApi.claimFever(uid, mult);
+        if (res.ok && res.user) {
+          saveUser(res.user);
+          setFeverBonus(res.bonus ?? 0);
+          setFeverMult(res.multiplier ?? mult);
+          setClaimedCoins(res.user.coins ?? coinsAfter);
+        }
+      } catch {
+        // 通信不可は無視（ボーナスなしで結果のみ）
+      }
+    }
+    setFeverClaimed(true);
+  };
   const accuracy = Math.round(
     (session.correctCount / session.totalProblems) * 100
   );
@@ -96,9 +124,19 @@ export default function ResultPage(): React.JSX.Element {
 
           <CoinEarnedCard
             coinsEarned={coinsEarned}
-            coinsAfter={coinsAfter}
+            coinsAfter={displayCoins}
             breakdown={coinBreakdown}
           />
+
+          {result.feverEligible && !feverClaimed ? (
+            <FeverRoulette onResult={onRoulette} />
+          ) : null}
+
+          {feverClaimed && feverBonus > 0 ? (
+            <div className="rounded-xl bg-gradient-to-r from-orange-400 to-pink-500 px-4 py-3 text-center font-extrabold text-white shadow">
+              🔥 フィーバー ×{feverMult}！ +{feverBonus} コイン ボーナス！
+            </div>
+          ) : null}
 
           {newBadges.length > 0 ? (
             <div className="rounded-xl bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 p-1">


### PR DESCRIPTION
コインを「やるほど増える」逓増化(#57)に続く第2弾。フィーバー＋ルーレットを追加。

## 機能
- **15分ごとに全員共通で入れ替わる「フィーバー推奨レベル」**（UTCの時刻シード・時差非依存）
- レベル選択画面の対象レベルに「🔥ボーナス中 のこりMM:SS」バッジ＋カウントダウン
- そのレベルを完走 → 結果画面で**円盤ルーレットが回転 → タイミングよく「とめる！」で ×2/×3**
- 倍率はその**セッション獲得コインに適用**

## サーバー権威・不正対策
- フィーバー判定はセッションの**開始時刻(startedAt)基準**（15分境界を跨いでも保護、時計詐称はstartedAtの妥当性で弾く）
- **15分枠につき1回**だけ（lastFeverInterval で重複防止）
- ルーレット倍率はクライアントが止めた値だが、サーバーは **{2,3}とpending有無だけ検証**してボーナス加算（コインは飾り用途）
- 新エンドポイント `POST /sansu/fever/claim`、entity に lastFeverInterval/pendingFeverInterval/pendingFeverBase 追加

## 検証
- iPhone実機相当(Playwright): バッジ表示→フィーバーLv完走→ルーレット→×2で 50→100、ボーナス表示
- curl: 倍率5=400 / pendingなし=409
- lint・両ビルド緑 / テスト160件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)