### PR TITLE
feat(sansu-100): フィーバーを15分枠3回までに＋使い切ったらバッジを消す(縦折れ修正)

### DIFF
--- a/api/src/functions/sansuClaimFever.ts
+++ b/api/src/functions/sansuClaimFever.ts
@@ -5,7 +5,11 @@ import {
   InvocationContext,
 } from '@azure/functions';
 
-import { FEVER_MULTIPLIERS } from '../shared/fever';
+import {
+  FEVER_MAX_PER_WINDOW,
+  FEVER_MULTIPLIERS,
+  feverUsesInWindow,
+} from '../shared/fever';
 import { type SansuUserEntity, toPublic } from '../shared/sansuTypes';
 import { USERS_PARTITION, usersTable } from '../shared/tableClient';
 
@@ -44,11 +48,13 @@ app.http('sansuClaimFever', {
 
       const pendingInterval = user.pendingFeverInterval ?? -1;
       const pendingBase = user.pendingFeverBase ?? 0;
-      // 未claimのフィーバー枠が無い / すでにその枠でclaim済み → 何もしない（冪等）
-      if (
-        pendingInterval < 0 ||
-        (user.lastFeverInterval ?? -2) === pendingInterval
-      ) {
+      const used = feverUsesInWindow(
+        pendingInterval,
+        user.feverWindowInterval,
+        user.feverWindowUses
+      );
+      // 未claimのフィーバー枠が無い / その枠の回数を使い切った → 何もしない
+      if (pendingInterval < 0 || used >= FEVER_MAX_PER_WINDOW) {
         return {
           status: 409,
           jsonBody: { error: 'no pending fever', user: toPublic(user) },
@@ -61,7 +67,8 @@ app.http('sansuClaimFever', {
           partitionKey: USERS_PARTITION,
           rowKey: body.userId,
           coins: (user.coins ?? 0) + bonus,
-          lastFeverInterval: pendingInterval,
+          feverWindowInterval: pendingInterval,
+          feverWindowUses: used + 1,
           pendingFeverInterval: -1,
           pendingFeverBase: 0,
         },

--- a/api/src/functions/sansuSessions.ts
+++ b/api/src/functions/sansuSessions.ts
@@ -2,8 +2,10 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/fu
 
 import { calculateCoins } from '../shared/coins';
 import {
+  FEVER_MAX_PER_WINDOW,
   feverIntervalIndex,
   feverLevelForIndex,
+  feverUsesInWindow,
   isStartedAtRecent,
 } from '../shared/fever';
 import {
@@ -117,7 +119,11 @@ app.http('sansuSessionsPost', {
             coin.coinsEarned > 0 &&
             typeof body.level === 'number' &&
             body.level === feverLevelForIndex(interval) &&
-            (user.lastFeverInterval ?? -1) !== interval &&
+            feverUsesInWindow(
+              interval,
+              user.feverWindowInterval,
+              user.feverWindowUses
+            ) < FEVER_MAX_PER_WINDOW &&
             isStartedAtRecent(body.startedAt, Date.now());
 
           const updated: Partial<SansuUserEntity> & {

--- a/api/src/shared/fever.ts
+++ b/api/src/shared/fever.ts
@@ -7,6 +7,18 @@ const FEVER_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
 export const FEVER_MULTIPLIERS = [2, 3];
 
+// 同じ15分枠でルーレットを回せる回数
+export const FEVER_MAX_PER_WINDOW = 3;
+
+/** その枠ですでに使った回数（user の枠カウントから計算）。 */
+export function feverUsesInWindow(
+  interval: number,
+  windowInterval: number | undefined,
+  windowUses: number | undefined
+): number {
+  return windowInterval === interval ? (windowUses ?? 0) : 0;
+}
+
 export function feverIntervalIndex(now: number): number {
   return Math.floor(now / FEVER_INTERVAL_MS);
 }

--- a/api/src/shared/sansuTypes.ts
+++ b/api/src/shared/sansuTypes.ts
@@ -30,6 +30,8 @@ export type SansuUserPublic = {
   minigameHighScore?: number;
   minigameScores?: Record<string, number>;
   avatarConfig?: AvatarConfig;
+  feverWindowInterval?: number;
+  feverWindowUses?: number;
 };
 
 export type SansuUserEntity = {
@@ -61,7 +63,8 @@ export type SansuUserEntity = {
   minigameScoresJson?: string;
   avatarConfigJson?: string;
   // --- フィーバー(おすすめ問題達成)＋ルーレット倍率 ---
-  lastFeverInterval?: number; // 最後にルーレットを使った15分枠（重複防止）
+  feverWindowInterval?: number; // ルーレット回数をカウントしている15分枠
+  feverWindowUses?: number; // その枠でルーレットを回した回数（上限 FEVER_MAX_PER_WINDOW）
   pendingFeverInterval?: number; // フィーバー達成済みで未claimの枠（-1=なし）
   pendingFeverBase?: number; // その達成セッションで得た基本コイン（倍率の対象）
 };
@@ -92,6 +95,8 @@ export function toPublic(e: SansuUserEntity): SansuUserPublic {
     minigameHighScore: e.minigameHighScore ?? 0,
     minigameScores: safeParseObject(e.minigameScoresJson ?? '{}'),
     avatarConfig: safeParseAvatarConfig(e.avatarConfigJson),
+    feverWindowInterval: e.feverWindowInterval,
+    feverWindowUses: e.feverWindowUses ?? 0,
   };
 }
 

--- a/app/sansu-100/components/LevelPicker.tsx
+++ b/app/sansu-100/components/LevelPicker.tsx
@@ -2,12 +2,20 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { feverLevel, feverSecondsRemaining } from '../lib/fever';
+import {
+  feverIntervalIndex,
+  feverLevel,
+  feverSecondsRemaining,
+  feverUsesLeft,
+} from '../lib/fever';
 import { LEVELS } from '../lib/levels';
 import type { LevelId, Operation } from '../lib/types';
 
 interface LevelPickerProps {
   onPick: (level: LevelId, operation: Operation) => void;
+  // フィーバー枠の使用状況（残りルーレット回数の計算に使う）
+  feverWindowInterval?: number;
+  feverWindowUses?: number;
 }
 
 const OP_COLORS: Record<string, string> = {
@@ -19,6 +27,8 @@ const OP_COLORS: Record<string, string> = {
 
 export default function LevelPicker({
   onPick,
+  feverWindowInterval,
+  feverWindowUses,
 }: LevelPickerProps): React.JSX.Element {
   // フィーバー(おすすめ)レベルと残り時間。15分ごとに入れ替わる。
   // SSRと食い違わないよう now は 0 で開始し、マウント後に実時刻で更新。
@@ -31,28 +41,33 @@ export default function LevelPicker({
   const feverLv = now > 0 ? feverLevel(now) : null;
   const remain = now > 0 ? feverSecondsRemaining(now) : 0;
   const mmss = `${Math.floor(remain / 60)}:${String(remain % 60).padStart(2, '0')}`;
+  // この枠で残っているルーレット回数（使い切ったらバッジを出さない）
+  const usesLeft =
+    now > 0
+      ? feverUsesLeft(feverIntervalIndex(now), feverWindowInterval, feverWindowUses)
+      : 0;
 
   return (
     <div className="space-y-4">
       <div className="grid gap-3 sm:grid-cols-2">
         {LEVELS.map((lv) => {
-          const isFever = feverLv === lv.id;
+          const isFever = feverLv === lv.id && usesLeft > 0;
           return (
             <button
               key={lv.id}
               type="button"
               onClick={() => onPick(lv.id, lv.operation)}
-              className={`group relative rounded-2xl bg-gradient-to-br ${OP_COLORS[lv.operation]} p-5 text-left text-white shadow-md transition-transform hover:scale-[1.02] ${
+              className={`group rounded-2xl bg-gradient-to-br ${OP_COLORS[lv.operation]} p-5 text-left text-white shadow-md transition-transform hover:scale-[1.02] ${
                 isFever ? 'ring-4 ring-orange-400 ring-offset-2 dark:ring-offset-gray-900' : ''
               }`}
               data-testid={`level-pick-${lv.id}`}
             >
               {isFever ? (
                 <span
-                  className="absolute -right-2 -top-2 rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white shadow"
+                  className="mb-1 inline-block whitespace-nowrap rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white shadow"
                   data-testid="fever-badge"
                 >
-                  🔥 ボーナス中 のこり {mmss}
+                  🔥 ボーナス あと{usesLeft}回 ・ のこり{mmss}
                 </span>
               ) : null}
               <div className="flex items-baseline justify-between">

--- a/app/sansu-100/lib/fever.ts
+++ b/app/sansu-100/lib/fever.ts
@@ -12,6 +12,19 @@ const FEVER_LEVELS: readonly LevelId[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 // ルーレットの倍率候補
 export const FEVER_MULTIPLIERS = [2, 3] as const;
 
+// 同じ15分枠でルーレットを回せる回数
+export const FEVER_MAX_PER_WINDOW = 3;
+
+/** その枠で残っているルーレット回数（user の枠カウントから計算）。 */
+export function feverUsesLeft(
+  currentInterval: number,
+  windowInterval: number | undefined,
+  windowUses: number | undefined
+): number {
+  const used = windowInterval === currentInterval ? (windowUses ?? 0) : 0;
+  return Math.max(0, FEVER_MAX_PER_WINDOW - used);
+}
+
 export function feverIntervalIndex(now: number): number {
   return Math.floor(now / FEVER_INTERVAL_MS);
 }

--- a/app/sansu-100/lib/types.ts
+++ b/app/sansu-100/lib/types.ts
@@ -74,6 +74,8 @@ export type SansuUserPublic = {
   minigameHighScore?: number; // ミニゲーム最高スコア（全体・後方互換）
   minigameScores?: Record<string, number>; // ゲームごとの最高スコア
   avatarConfig?: AvatarConfig; // パーツ組み立て式アバター（未設定なら絵文字 avatar を使う）
+  feverWindowInterval?: number; // ルーレット回数をカウントしている15分枠
+  feverWindowUses?: number; // その枠でルーレットを回した回数
 };
 
 export type SansuUserServer = SansuUserPublic & {

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -62,6 +62,8 @@ function PlayInner(): React.JSX.Element {
           />
           <LevelPicker
             onPick={(level, operation) => setPick({ level, operation })}
+            feverWindowInterval={currentUser.feverWindowInterval}
+            feverWindowUses={currentUser.feverWindowUses}
           />
         </div>
       </main>


### PR DESCRIPTION
ご要望対応：①ルーレットを同じ15分枠で**3回まで**OKに、②使い切ったら「🔥ボーナス中」**バッジを消す**（残ると「ずっとボーナス中」に見える）。あわせて**バッジが縦に折り返していた不具合**も修正。

## 変更
- フィーバー枠の判定を「1回」→「**3回まで**」（`FEVER_MAX_PER_WINDOW=3`）。entity を `feverWindowInterval`+`feverWindowUses` に置換し、サーバーで回数を検証・カウント
- レベル選択のバッジ：`whitespace-nowrap` の通常 inline 要素に変更（縦折れ解消）、「🔥ボーナス あとN回・のこりMM:SS」表示、**使い切ると非表示**

## 検証
- iPhone実機相当(Playwright): あと3→2→1回でルーレット3回、4回目はバッジ消失＆ルーレットなし、バッジは1行(高さ20px)
- lint・両ビルド緑 / テスト160件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)