### PR TITLE
feat(sansu-100): フィーバーを「だいたい1時間に1回」のレア発生に

### DIFF
--- a/api/src/shared/fever.ts
+++ b/api/src/shared/fever.ts
@@ -1,14 +1,48 @@
 // フィーバー(おすすめ)レベル判定（サーバー版・確定値）。
+// 5分ごとに低確率(約1/12)で発生＝だいたい1時間に1回。
 // 重要: app/sansu-100/lib/fever.ts と「同一ロジック」で複製している（client/server一致）。
 
-export const FEVER_INTERVAL_MS = 15 * 60 * 1000; // 15分
+export const FEVER_INTERVAL_MS = 5 * 60 * 1000; // 5分の枠
+export const FEVER_ODDS = 12; // 約12枠に1回 = だいたい1時間に1回
 
 const FEVER_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
 export const FEVER_MULTIPLIERS = [2, 3];
 
-// 同じ15分枠でルーレットを回せる回数
 export const FEVER_MAX_PER_WINDOW = 3;
+
+function hash32(n: number): number {
+  let x = (n + 1) >>> 0;
+  x ^= x << 13;
+  x >>>= 0;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  x >>>= 0;
+  return x >>> 0;
+}
+
+export function feverIntervalIndex(now: number): number {
+  return Math.floor(now / FEVER_INTERVAL_MS);
+}
+
+export function isFeverWindow(idx: number): boolean {
+  return hash32(idx) % FEVER_ODDS === 0;
+}
+
+// フィーバー枠ならレベル(1..11)、そうでなければ null
+export function feverLevelForIndex(idx: number): number | null {
+  if (!isFeverWindow(idx)) return null;
+  return FEVER_LEVELS[(hash32(idx) >>> 8) % FEVER_LEVELS.length];
+}
+
+export function feverLevel(now: number): number | null {
+  return feverLevelForIndex(feverIntervalIndex(now));
+}
+
+/** 送信された開始時刻が信頼できる範囲か（時計詐称対策）。5分枠なので余裕を10分に。 */
+export function isStartedAtRecent(startedAt: number, now: number): boolean {
+  return startedAt <= now + 60_000 && now - startedAt < 10 * 60 * 1000;
+}
 
 /** その枠ですでに使った回数（user の枠カウントから計算）。 */
 export function feverUsesInWindow(
@@ -17,27 +51,4 @@ export function feverUsesInWindow(
   windowUses: number | undefined
 ): number {
   return windowInterval === interval ? (windowUses ?? 0) : 0;
-}
-
-export function feverIntervalIndex(now: number): number {
-  return Math.floor(now / FEVER_INTERVAL_MS);
-}
-
-export function feverLevelForIndex(idx: number): number {
-  let x = (idx + 1) >>> 0;
-  x ^= x << 13;
-  x >>>= 0;
-  x ^= x >>> 17;
-  x ^= x << 5;
-  x >>>= 0;
-  return FEVER_LEVELS[x % FEVER_LEVELS.length];
-}
-
-export function feverLevel(now: number): number {
-  return feverLevelForIndex(feverIntervalIndex(now));
-}
-
-/** 送信された開始時刻が信頼できる範囲か（時計詐称対策）。 */
-export function isStartedAtRecent(startedAt: number, now: number): boolean {
-  return startedAt <= now + 60_000 && now - startedAt < 25 * 60 * 1000;
 }

--- a/app/sansu-100/lib/__tests__/fever.test.ts
+++ b/app/sansu-100/lib/__tests__/fever.test.ts
@@ -5,37 +5,53 @@ import {
   feverLevelForIndex,
   feverIntervalIndex,
   feverSecondsRemaining,
+  isFeverWindow,
   FEVER_INTERVAL_MS,
+  FEVER_ODDS,
 } from '../fever';
 
 describe('fever', () => {
-  it('同じ15分枠なら同じレベル', () => {
+  it('ほとんどの枠はフィーバーでない（null）', () => {
+    let feverCount = 0;
+    const total = 1200;
+    for (let i = 0; i < total; i++) {
+      if (feverLevelForIndex(i) !== null) feverCount++;
+    }
+    // だいたい 1/FEVER_ODDS（1200/12=100）。広めに 40〜180 を許容
+    expect(feverCount).toBeGreaterThan(40);
+    expect(feverCount).toBeLessThan(180);
+  });
+
+  it('フィーバー枠ならレベルは1〜11、そうでなければ null', () => {
+    for (let i = 0; i < 500; i++) {
+      const lv = feverLevelForIndex(i);
+      if (lv === null) {
+        expect(isFeverWindow(i)).toBe(false);
+      } else {
+        expect(isFeverWindow(i)).toBe(true);
+        expect(lv).toBeGreaterThanOrEqual(1);
+        expect(lv).toBeLessThanOrEqual(11);
+      }
+    }
+  });
+
+  it('同じ5分枠なら同じ結果', () => {
     const t0 = 1_700_000_000_000;
     expect(feverLevel(t0)).toBe(feverLevel(t0 + 60_000));
   });
 
-  it('連続する枠ではレベルがよく入れ替わる', () => {
-    const lvls = new Set<number>();
-    for (let i = 0; i < 12; i++) lvls.add(feverLevelForIndex(1000 + i) as number);
-    expect(lvls.size).toBeGreaterThan(2);
-  });
-
-  it('レベルは常に1〜11', () => {
-    for (let i = 0; i < 100; i++) {
-      const lv = feverLevelForIndex(i) as number;
-      expect(lv).toBeGreaterThanOrEqual(1);
-      expect(lv).toBeLessThanOrEqual(11);
-    }
-  });
-
-  it('intervalIndex は15分ごとに増える', () => {
+  it('intervalIndex は5分ごとに増える', () => {
     expect(feverIntervalIndex(5 * FEVER_INTERVAL_MS + 1234)).toBe(5);
     expect(feverIntervalIndex(6 * FEVER_INTERVAL_MS)).toBe(6);
   });
 
-  it('残り秒は 1..900 の範囲', () => {
+  it('残り秒は 1..300（5分）の範囲', () => {
     const r = feverSecondsRemaining(3 * FEVER_INTERVAL_MS + 60_000);
     expect(r).toBeGreaterThan(0);
-    expect(r).toBeLessThanOrEqual(900);
+    expect(r).toBeLessThanOrEqual(300);
+  });
+
+  it('FEVER_ODDS は約1時間に1回(12)を狙う', () => {
+    expect(FEVER_ODDS).toBe(12);
   });
 });

--- a/app/sansu-100/lib/fever.ts
+++ b/app/sansu-100/lib/fever.ts
@@ -1,10 +1,12 @@
 // 「フィーバー(おすすめ)レベル」を時刻から決める純粋ロジック。
-// 15分ごとに全員共通で入れ替わる（UTCの絶対時刻ベース＝時差非依存）。
+// 5分ごとに低確率(約1/12)でフィーバーが発生＝だいたい1時間に1回。常時ではない。
 // 重要: api/src/shared/fever.ts と「同一ロジック」で複製している（client/server一致）。
 
 import type { LevelId } from './types';
 
-export const FEVER_INTERVAL_MS = 15 * 60 * 1000; // 15分
+export const FEVER_INTERVAL_MS = 5 * 60 * 1000; // 5分の枠
+// 約何枠に1回フィーバーが出るか（12枠=1時間 → だいたい1時間に1回）
+export const FEVER_ODDS = 12;
 
 // フィーバー対象になりうる具体レベル（mix は除外）
 const FEVER_LEVELS: readonly LevelId[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
@@ -12,8 +14,43 @@ const FEVER_LEVELS: readonly LevelId[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 // ルーレットの倍率候補
 export const FEVER_MULTIPLIERS = [2, 3] as const;
 
-// 同じ15分枠でルーレットを回せる回数
+// 同じフィーバー枠でルーレットを回せる回数
 export const FEVER_MAX_PER_WINDOW = 3;
+
+// xorshift32（client/server で同一の決定的ハッシュ）
+function hash32(n: number): number {
+  let x = (n + 1) >>> 0;
+  x ^= x << 13;
+  x >>>= 0;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  x >>>= 0;
+  return x >>> 0;
+}
+
+export function feverIntervalIndex(now: number): number {
+  return Math.floor(now / FEVER_INTERVAL_MS);
+}
+
+// その枠がフィーバーか（約 1/FEVER_ODDS）
+export function isFeverWindow(idx: number): boolean {
+  return hash32(idx) % FEVER_ODDS === 0;
+}
+
+// フィーバー枠ならレベル、そうでなければ null
+export function feverLevelForIndex(idx: number): LevelId | null {
+  if (!isFeverWindow(idx)) return null;
+  return FEVER_LEVELS[(hash32(idx) >>> 8) % FEVER_LEVELS.length];
+}
+
+export function feverLevel(now: number): LevelId | null {
+  return feverLevelForIndex(feverIntervalIndex(now));
+}
+
+// 今のフィーバー枠が終わる（＝入れ替わる）までの残り秒
+export function feverSecondsRemaining(now: number): number {
+  return Math.ceil((FEVER_INTERVAL_MS - (now % FEVER_INTERVAL_MS)) / 1000);
+}
 
 /** その枠で残っているルーレット回数（user の枠カウントから計算）。 */
 export function feverUsesLeft(
@@ -23,28 +60,4 @@ export function feverUsesLeft(
 ): number {
   const used = windowInterval === currentInterval ? (windowUses ?? 0) : 0;
   return Math.max(0, FEVER_MAX_PER_WINDOW - used);
-}
-
-export function feverIntervalIndex(now: number): number {
-  return Math.floor(now / FEVER_INTERVAL_MS);
-}
-
-// idx を xorshift32 でかき混ぜて1レベルを決める（決定的・client/server一致）。
-export function feverLevelForIndex(idx: number): LevelId {
-  let x = (idx + 1) >>> 0;
-  x ^= x << 13;
-  x >>>= 0;
-  x ^= x >>> 17;
-  x ^= x << 5;
-  x >>>= 0;
-  return FEVER_LEVELS[x % FEVER_LEVELS.length];
-}
-
-export function feverLevel(now: number): LevelId {
-  return feverLevelForIndex(feverIntervalIndex(now));
-}
-
-// 次の入れ替わりまでの残り秒
-export function feverSecondsRemaining(now: number): number {
-  return Math.ceil((FEVER_INTERVAL_MS - (now % FEVER_INTERVAL_MS)) / 1000);
 }


### PR DESCRIPTION
「常にボーナス中」が不自然というご指摘に対応。フィーバーをレア化。

## 変更
- 枠を **15分→5分**にし、各枠を **約1/12の確率**でフィーバーに（=**だいたい1時間に1回**）
- 非フィーバー時は **バッジを一切出さず**、達成判定もされない
- 倍率ルーレット（×2/×3・1フィーバー枠で3回まで）は据え置き
- 出現判定は時刻シードで全員共通・client/server一致

## 検証
- curl: 非フィーバー枠では全レベル `feverEligible=false`
- Playwright: 非フィーバー時はバッジ非表示
- フィーバー出現率 8.7%（≒1/12）。lint・両ビルド緑 / テスト161件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)