### PR TITLE
feat(sansu-100): よけよけランナー刷新（🦖・ふゆう台・レベルアップ加速）

### DIFF
--- a/app/sansu-100/games/RunnerGame.tsx
+++ b/app/sansu-100/games/RunnerGame.tsx
@@ -12,11 +12,11 @@ import { isActionKey, startGameLoop } from '../lib/minigame-core';
 import { sound } from '../lib/sound-presets';
 import { storage } from '../lib/storage';
 
-const WORLD_H = 110; // 論理ワールド高さ（描画用）
+const RUNNER_CHAR = '🦖'; // よけよけランナー専用キャラ（アバターは使わない）
 
 function computeWidth(): number {
-  if (typeof window === 'undefined') return 300;
-  return Math.max(240, Math.min(360, window.innerWidth - 40));
+  if (typeof window === 'undefined') return 320;
+  return Math.max(260, Math.min(380, window.innerWidth - 32));
 }
 
 function emoji(
@@ -36,37 +36,51 @@ function draw(
   ctx: CanvasRenderingContext2D,
   s: RunnerState,
   w: number,
-  scale: number,
-  avatar: string
+  scale: number
 ): void {
-  const h = WORLD_H * scale;
-  // 空
-  ctx.fillStyle = '#bae6fd';
+  const h = RUNNER.worldH * scale;
+  // 空（レベルが上がるほど夕方→夜っぽく）
+  const sky = ['#bae6fd', '#a5b4fc', '#818cf8', '#6366f1', '#4338ca'][
+    Math.min(4, s.level - 1)
+  ];
+  ctx.fillStyle = sky;
   ctx.fillRect(0, 0, w, h);
-  const yGround = (WORLD_H - RUNNER.groundH) * scale;
+  const yGround = (RUNNER.worldH - RUNNER.groundH) * scale;
   // 地面
   ctx.fillStyle = '#65a30d';
   ctx.fillRect(0, yGround, w, h - yGround);
-  // 障害物（サボテン）
-  for (const o of s.obstacles) {
-    emoji(
-      ctx,
-      '🌵',
-      (o.x + o.w / 2) * scale,
-      yGround - (o.h / 2) * scale,
-      o.h * scale * 1.4
-    );
+  // ふゆう台
+  for (const p of s.platforms) {
+    const py = yGround - p.top * scale;
+    ctx.fillStyle = '#a16207';
+    ctx.fillRect(p.x * scale, py, p.w * scale, 7 * scale);
+    ctx.fillStyle = '#facc15';
+    ctx.fillRect(p.x * scale, py, p.w * scale, 2.5 * scale);
   }
-  // プレイヤー（アバター）
+  // 障害物（高い壁 or サボテン）
+  for (const o of s.obstacles) {
+    if (o.h > 40) {
+      ctx.fillStyle = '#7c2d12';
+      ctx.fillRect(o.x * scale, yGround - o.h * scale, o.w * scale, o.h * scale);
+    } else {
+      emoji(
+        ctx,
+        '🌵',
+        (o.x + o.w / 2) * scale,
+        yGround - (o.h / 2) * scale,
+        o.h * scale * 1.4
+      );
+    }
+  }
+  // プレイヤー
   const cx = (RUNNER.playerX + RUNNER.playerW / 2) * scale;
   const cy = yGround - (s.py + RUNNER.playerH / 2) * scale;
-  emoji(ctx, avatar, cx, cy, RUNNER.playerH * scale * 1.5);
+  emoji(ctx, RUNNER_CHAR, cx, cy, RUNNER.playerH * scale * 1.5);
 }
 
-// よけよけランナー本体。タップ/スペース/↑ でジャンプ。world はロジック、描画はスケール。
+// よけよけランナー本体。タップ/スペース/↑ でジャンプ。台に乗って降りられる。
 export default function RunnerGame({
   onGameOver,
-  avatar = '🐰',
 }: {
   onGameOver: (score: number) => void;
   avatar?: string;
@@ -77,6 +91,8 @@ export default function RunnerGame({
   const overRef = useRef(false);
   const soundRef = useRef(true);
   const [score, setScore] = useState(0);
+  const [level, setLevel] = useState(1);
+  const [flash, setFlash] = useState(false);
 
   const jump = () => {
     jumpRef.current = true;
@@ -89,7 +105,7 @@ export default function RunnerGame({
     if (!ctx) return;
     const cw = computeWidth();
     const scale = cw / RUNNER.worldW;
-    const ch = WORLD_H * scale;
+    const ch = RUNNER.worldH * scale;
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.round(cw * dpr);
     canvas.height = Math.round(ch * dpr);
@@ -102,6 +118,7 @@ export default function RunnerGame({
     overRef.current = false;
     soundRef.current = storage.getSettings().soundOn;
     setScore(0);
+    setLevel(1);
 
     const handle = startGameLoop({
       stepMs: () => 40,
@@ -109,8 +126,13 @@ export default function RunnerGame({
         if (overRef.current) return;
         const wasGround = stateRef.current.onGround;
         const next = stepRunner(stateRef.current, jumpRef.current, Math.random);
-        // ジャンプ音（接地→空中に変わった瞬間）
         if (wasGround && !next.onGround && soundRef.current) sound.eat();
+        if (next.leveledUp) {
+          setLevel(next.level);
+          setFlash(true);
+          window.setTimeout(() => setFlash(false), 700);
+          if (soundRef.current) sound.correct();
+        }
         jumpRef.current = false;
         stateRef.current = next;
         setScore(next.distance);
@@ -121,7 +143,7 @@ export default function RunnerGame({
           onGameOver(next.distance);
         }
       },
-      onRender: () => draw(ctx, stateRef.current, cw, scale, avatar),
+      onRender: () => draw(ctx, stateRef.current, cw, scale),
     });
 
     const onKey = (e: KeyboardEvent) => {
@@ -141,7 +163,12 @@ export default function RunnerGame({
   return (
     <div className="flex flex-col items-center gap-3">
       <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
-        きょり: <span className="tabular-nums">{score}</span>
+        レベル {level} ・ きょり <span className="tabular-nums">{score}</span>
+        {flash ? (
+          <span className="ml-2 animate-pulse font-extrabold text-orange-500">
+            ⬆️ レベルアップ！
+          </span>
+        ) : null}
       </p>
       <canvas
         ref={canvasRef}

--- a/app/sansu-100/lib/__tests__/runner.test.ts
+++ b/app/sansu-100/lib/__tests__/runner.test.ts
@@ -4,77 +4,107 @@ import { createRunner, stepRunner, RUNNER } from '../games/runner';
 const r0 = () => 0;
 
 describe('runner', () => {
-  it('初期状態は接地・距離0・未over', () => {
+  it('初期状態は接地・距離0・レベル1・未over', () => {
     const s = createRunner(r0);
     expect(s.onGround).toBe(true);
     expect(s.py).toBe(0);
     expect(s.distance).toBe(0);
+    expect(s.level).toBe(1);
     expect(s.over).toBe(false);
   });
 
   it('ジャンプで上昇し、やがて接地する', () => {
     let s = createRunner(r0);
-    s = { ...s, obstacles: [] };
+    s = { ...s, obstacles: [], spawnTimer: 9999 };
     const jumped = stepRunner(s, true, r0);
     expect(jumped.py).toBeGreaterThan(0);
     expect(jumped.onGround).toBe(false);
-    // 何ステップか進めると着地する（障害物なし）
     let cur = jumped;
-    for (let i = 0; i < 40; i++) cur = stepRunner(cur, false, r0);
+    for (let i = 0; i < 60; i++) cur = stepRunner(cur, false, r0);
     expect(cur.onGround).toBe(true);
     expect(cur.py).toBe(0);
   });
 
   it('空中ではもう一度ジャンプできない（二段ジャンプ不可）', () => {
     let s = createRunner(r0);
-    s = stepRunner(s, true, r0); // ジャンプ
+    s = { ...s, spawnTimer: 9999 };
+    s = stepRunner(s, true, r0);
     const vyAir = s.vy;
-    const again = stepRunner(s, true, r0); // 空中で再ジャンプ要求
-    // 速度は重力で減るだけ（ジャンプ初速にリセットされない）
+    const again = stepRunner(s, true, r0);
     expect(again.vy).toBeLessThan(vyAir);
   });
 
   it('距離はスコアとして増える', () => {
     let s = createRunner(r0);
-    s = { ...s, obstacles: [], spawnTimer: 9999 };
+    s = { ...s, obstacles: [], platforms: [], spawnTimer: 9999 };
     const n = stepRunner(s, false, r0);
     expect(n.distance).toBeGreaterThan(0);
   });
 
   it('地上の障害物に当たると over', () => {
     let s = createRunner(r0);
-    // プレイヤーの目の前に背の高い障害物を置く（接地中）
     s = {
       ...s,
       py: 0,
       onGround: true,
       spawnTimer: 9999,
+      platforms: [],
       obstacles: [{ x: RUNNER.playerX, w: 20, h: 25 }],
     };
     const n = stepRunner(s, false, r0);
     expect(n.over).toBe(true);
   });
 
-  it('ジャンプで障害物を飛び越えれば over しない', () => {
+  it('高くジャンプ中なら障害物に当たらない', () => {
     let s = createRunner(r0);
-    // 高く飛んでいる状態（py が障害物より上）で障害物が重なっても当たらない
     s = {
       ...s,
       py: 40,
       vy: 0,
       onGround: false,
       spawnTimer: 9999,
+      platforms: [],
       obstacles: [{ x: RUNNER.playerX, w: 20, h: 25 }],
     };
     const n = stepRunner(s, false, r0);
     expect(n.over).toBe(false);
   });
 
-  it('時間とともに speed が上がる（上限あり）', () => {
-    const s = createRunner(r0);
-    const slow = stepRunner({ ...s, distance: 0 }, false, r0).speed;
-    const fast = stepRunner({ ...s, distance: 5000 }, false, r0).speed;
-    expect(fast).toBeGreaterThan(slow);
-    expect(fast).toBeLessThanOrEqual(RUNNER.maxSpeed);
+  it('ふゆう台に乗れる（落下中に台の上で止まる）', () => {
+    let s = createRunner(r0);
+    s = {
+      ...s,
+      py: 50,
+      vy: -5,
+      onGround: false,
+      spawnTimer: 9999,
+      obstacles: [],
+      platforms: [{ x: RUNNER.playerX - 5, w: 70, top: 44 }],
+    };
+    let cur = s;
+    for (let i = 0; i < 8; i++) {
+      cur = stepRunner(cur, false, r0);
+      if (cur.onGround) break;
+    }
+    expect(cur.onGround).toBe(true);
+    expect(cur.py).toBe(44); // 台の上で止まる
+  });
+
+  it('一定距離ごとにレベルアップして速くなる', () => {
+    let s = createRunner(r0);
+    s = {
+      ...s,
+      distance: RUNNER.distPerLevel,
+      level: 1,
+      spawnTimer: 9999,
+      obstacles: [],
+      platforms: [],
+    };
+    const n = stepRunner(s, false, r0);
+    expect(n.level).toBe(2);
+    expect(n.leveledUp).toBe(true);
+    const slow = stepRunner({ ...createRunner(r0), distance: 0 }, false, r0).speed;
+    expect(n.speed).toBeGreaterThan(slow);
+    expect(n.speed).toBeLessThanOrEqual(RUNNER.maxSpeed);
   });
 });

--- a/app/sansu-100/lib/games/runner.ts
+++ b/app/sansu-100/lib/games/runner.ts
@@ -1,34 +1,45 @@
 // よけよけランナーの純粋ロジック（React非依存・テスト対象）。
-// キャラは固定位置で、世界が左へスクロール。障害物をジャンプでよける。距離=スコア。
+// キャラは固定X、世界が左へスクロール。地上の障害物はジャンプでよけ、ふゆう台(platform)には
+// 乗って走り、はしから降りられる。距離=スコア。一定距離ごとにレベルアップして速くなる。
 
 export const RUNNER = {
-  worldW: 300, // 論理ワールド幅
-  groundH: 8, // 地面の高さ（描画用）
-  playerX: 44, // プレイヤーの固定X
-  playerW: 18,
-  playerH: 24,
-  gravity: 1.1, // 1tick あたりの落下加速
-  jumpV: 12, // ジャンプ初速（上向き）
-  baseSpeed: 3, // 初期スクロール速度
-  maxSpeed: 7,
-  speedPerDist: 1 / 350, // 距離に応じた加速
-  obMinH: 14,
-  obMaxH: 30,
-  obMinW: 14,
-  obMaxW: 22,
-  spawnMin: 42, // 障害物の最小出現間隔(tick)
-  spawnRand: 34, // 追加ランダム間隔
+  worldW: 320, // 論理ワールド幅
+  worldH: 150, // 論理ワールド高さ（縦長に）
+  groundH: 10, // 地面の高さ（描画用）
+  playerX: 48, // プレイヤーの固定X
+  playerW: 20,
+  playerH: 26,
+  gravity: 0.9, // 1tick あたりの落下加速
+  jumpV: 13, // ジャンプ初速（上向き）
+  baseSpeed: 3, // レベル1のスクロール速度
+  speedPerLevel: 0.8, // レベルごとの加速
+  maxSpeed: 9,
+  distPerLevel: 240, // この距離ごとにレベルアップ
+  obMinH: 16,
+  obMaxH: 34,
+  obMinW: 16,
+  obMaxW: 24,
+  platMinTop: 42, // ふゆう台の高さ（下端）
+  platMaxTop: 62,
+  platMinW: 52,
+  platMaxW: 80,
+  spawnMin: 40, // 出現の最小間隔(tick)
+  spawnRand: 30, // 追加ランダム間隔
 } as const;
 
 export type Obstacle = { x: number; w: number; h: number };
+export type Platform = { x: number; w: number; top: number };
 
 export type RunnerState = {
-  py: number; // 地面からの高さ（0=接地, 上が正）
+  py: number; // 足元の高さ（0=地面）
   vy: number; // 縦速度（上が正）
   onGround: boolean;
   obstacles: Obstacle[];
+  platforms: Platform[];
   speed: number;
-  distance: number; // スコア（スクロール量）
+  distance: number; // スコア
+  level: number;
+  leveledUp: boolean; // このtickでレベルが上がったか（演出用）
   spawnTimer: number;
   over: boolean;
 };
@@ -39,28 +50,64 @@ export function createRunner(rand: () => number): RunnerState {
     vy: 0,
     onGround: true,
     obstacles: [],
+    platforms: [],
     speed: RUNNER.baseSpeed,
     distance: 0,
+    level: 1,
+    leveledUp: false,
     spawnTimer: RUNNER.spawnMin + Math.floor(rand() * RUNNER.spawnRand),
     over: false,
   };
 }
 
-function spawnObstacle(rand: () => number): Obstacle {
+const ri = (rand: () => number, lo: number, hi: number): number =>
+  lo + Math.floor(rand() * (hi - lo + 1));
+
+// 出現パターン: 障害物だけ / ふゆう台（その手前に背の高い壁を置いて「台に乗って降りる」誘導）
+function spawn(
+  rand: () => number
+): { obstacles: Obstacle[]; platforms: Platform[] } {
+  if (rand() < 0.45) {
+    const top = ri(rand, RUNNER.platMinTop, RUNNER.platMaxTop);
+    const w = ri(rand, RUNNER.platMinW, RUNNER.platMaxW);
+    const platforms: Platform[] = [{ x: RUNNER.worldW, w, top }];
+    const obstacles: Obstacle[] = [];
+    // 半分は台の真下あたりに「飛び越えにくい高い壁」を置く → 台に乗って回避する遊び
+    if (rand() < 0.6) {
+      obstacles.push({ x: RUNNER.worldW + 6, w: 16, h: top + 6 });
+    }
+    return { obstacles, platforms };
+  }
   return {
-    x: RUNNER.worldW,
-    w: RUNNER.obMinW + Math.floor(rand() * (RUNNER.obMaxW - RUNNER.obMinW)),
-    h: RUNNER.obMinH + Math.floor(rand() * (RUNNER.obMaxH - RUNNER.obMinH)),
+    obstacles: [
+      {
+        x: RUNNER.worldW,
+        w: ri(rand, RUNNER.obMinW, RUNNER.obMaxW),
+        h: ri(rand, RUNNER.obMinH, RUNNER.obMaxH),
+      },
+    ],
+    platforms: [],
   };
 }
 
+// プレイヤーが乗れる「足元の支え」の高さ（地面=0 か、重なっている台の上）。
+function supportTop(s: RunnerState): number {
+  const pl = RUNNER.playerX;
+  const pr = RUNNER.playerX + RUNNER.playerW;
+  let top = 0; // 地面
+  for (const p of s.platforms) {
+    const overX = pr > p.x && pl < p.x + p.w;
+    if (overX && p.top <= s.py + 0.5 && p.top > top) top = p.top;
+  }
+  return top;
+}
+
+// 地上の障害物に体が当たっているか（足元 py が障害物の高さより下＝避けられていない）。
 function hits(s: RunnerState): boolean {
-  const pL = RUNNER.playerX;
-  const pR = RUNNER.playerX + RUNNER.playerW;
+  const pl = RUNNER.playerX;
+  const pr = RUNNER.playerX + RUNNER.playerW;
   for (const o of s.obstacles) {
-    const overlapX = pL < o.x + o.w && pR > o.x;
-    // プレイヤーの足元(py)が障害物の高さより下なら衝突
-    if (overlapX && s.py < o.h) return true;
+    if (pl < o.x + o.w && pr > o.x && s.py < o.h - 1) return true;
   }
   return false;
 }
@@ -73,7 +120,6 @@ export function stepRunner(
 ): RunnerState {
   if (s.over) return s;
 
-  // ジャンプ／重力
   let vy = s.vy;
   let onGround = s.onGround;
   if (jump && onGround) {
@@ -81,27 +127,41 @@ export function stepRunner(
     onGround = false;
   }
   vy -= RUNNER.gravity;
-  let py = s.py + vy;
-  if (py <= 0) {
-    py = 0;
+  const newPy = s.py + vy;
+
+  // 足元の支え（古い py を基準に、重なっている台か地面）
+  const support = supportTop(s);
+  let py = newPy;
+  if (newPy <= support) {
+    py = support;
     vy = 0;
     onGround = true;
+  } else {
+    onGround = false;
   }
 
+  // レベル＆速度
+  const level = Math.floor(s.distance / RUNNER.distPerLevel) + 1;
+  const leveledUp = level > s.level;
   const speed = Math.min(
     RUNNER.maxSpeed,
-    RUNNER.baseSpeed + s.distance * RUNNER.speedPerDist
+    RUNNER.baseSpeed + (level - 1) * RUNNER.speedPerLevel
   );
 
-  // 障害物スクロール＋画面外除去
+  // スクロール＋画面外除去
   const obstacles = s.obstacles
     .map((o) => ({ ...o, x: o.x - speed }))
     .filter((o) => o.x + o.w > -2);
+  const platforms = s.platforms
+    .map((p) => ({ ...p, x: p.x - speed }))
+    .filter((p) => p.x + p.w > -2);
 
   // 出現
   let spawnTimer = s.spawnTimer - 1;
   if (spawnTimer <= 0) {
-    obstacles.push(spawnObstacle(rand));
+    const f = spawn(rand);
+    obstacles.push(...f.obstacles);
+    platforms.push(...f.platforms);
     spawnTimer = RUNNER.spawnMin + Math.floor(rand() * RUNNER.spawnRand);
   }
 
@@ -110,8 +170,11 @@ export function stepRunner(
     vy,
     onGround,
     obstacles,
+    platforms,
     speed,
     distance: s.distance + Math.round(speed),
+    level,
+    leveledUp,
     spawnTimer,
     over: false,
   };


### PR DESCRIPTION
ご要望対応：①キャラがパンダでださい→専用キャラ🦖に、②縦が短い→縦長＋「台に乗って降りる」、③単調→レベルアップで加速。

## 変更
- **キャラを🦖固定**（アバター依存をやめる）
- **縦長(110→150)** ＋ **ふゆう台**に乗って走り・はしから降りる物理を追加
- **一定距離ごとにレベルアップ**して加速、空の色も変化（夕方→夜）

## 検証
- iPhone実機相当(Playwright): 🦖表示・縦長168px・レベル2で空色変化＆「レベルアップ！」・障害物表示
- test: 台に乗る／レベルアップ加速を追加。lint・ビルド緑 / テスト161件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)