### PR TITLE
feat(sansu-100): 神経衰弱を制限時間制に（時間内クリアでレベルアップ）

### DIFF
--- a/app/sansu-100/games/MemoryGame.tsx
+++ b/app/sansu-100/games/MemoryGame.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import {
   createMemory,
+  memoryTimeLimit,
   pickCard,
   resolveMemory,
   type MemoryState,
@@ -13,28 +14,59 @@ import { storage } from '../lib/storage';
 
 const CARD_EMOJI = ['🐶', '🐱', '🦊', '🐼', '🦁', '🐰', '🐸', '🐧'];
 
-// 神経衰弱。1ボードそろえるたびに もっとカードが増える（レベルアップ）。
-// 終わりは「やめる」で、そろえたボード数がスコア。onScore で親に報告。
+// 神経衰弱。レベルごとの制限時間内にそろえるとレベルアップ（カードが増える）。
+// 時間切れ or「やめる」で終了。スコア=そろえたボード数。onScore=途中経過, onGameOver=時間切れ。
 export default function MemoryGame({
   onScore,
+  onGameOver,
 }: {
   onScore: (boardsCleared: number) => void;
+  onGameOver: (boardsCleared: number) => void;
 }): React.JSX.Element {
   const [state, setState] = useState<MemoryState>(() =>
     createMemory(Math.random, 1)
   );
   const [level, setLevel] = useState(1);
+  const [timeLeft, setTimeLeft] = useState(() => memoryTimeLimit(1));
+  const timeLeftRef = useRef(memoryTimeLimit(1));
   const levelRef = useRef(1);
+  const clearedRef = useRef(0); // そろえたボード数
+  const overRef = useRef(false);
   const soundRef = useRef(true);
 
   useEffect(() => {
     soundRef.current = storage.getSettings().soundOn;
     levelRef.current = 1;
+    clearedRef.current = 0;
+    overRef.current = false;
     setLevel(1);
     setState(createMemory(Math.random, 1));
     onScore(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1回
   }, []);
+
+  // レベルが変わるたびに制限時間をリセットしてカウントダウン開始。0で時間切れ＝終了。
+  useEffect(() => {
+    if (overRef.current) return;
+    const limit = memoryTimeLimit(level);
+    timeLeftRef.current = limit;
+    setTimeLeft(limit);
+    const id = setInterval(() => {
+      const t = timeLeftRef.current - 1;
+      timeLeftRef.current = t;
+      setTimeLeft(Math.max(0, t));
+      if (t <= 0) {
+        clearInterval(id);
+        if (!overRef.current) {
+          overRef.current = true;
+          if (soundRef.current) sound.crash();
+          onGameOver(clearedRef.current); // setState更新関数の外で呼ぶ
+        }
+      }
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- level 変化で時計を作り直す
+  }, [level]);
 
   // 不一致表示中は少し待って裏返す
   useEffect(() => {
@@ -43,23 +75,25 @@ export default function MemoryGame({
     return () => clearTimeout(t);
   }, [state.busy]);
 
-  // 1ボード クリア → 次のレベル（カードが増える）
+  // 1ボード クリア → 次のレベル（カードが増える・制限時間リセット）
   useEffect(() => {
-    if (!state.cleared) return;
+    if (!state.cleared || overRef.current) return;
     if (soundRef.current) sound.fanfare();
-    const cleared = levelRef.current; // このボード= levelRef 枚目
-    onScore(cleared);
+    clearedRef.current = levelRef.current; // このボードまでクリア
+    onScore(clearedRef.current);
     const t = setTimeout(() => {
+      if (overRef.current) return;
       const next = levelRef.current + 1;
       levelRef.current = next;
       setLevel(next);
       setState(createMemory(Math.random, next));
-    }, 950);
+    }, 900);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- cleared をトリガに進める
   }, [state.cleared]);
 
   const pick = (i: number) => {
+    if (overRef.current) return;
     setState((s) => {
       const before = s.pairs;
       const next = pickCard(s, i);
@@ -68,11 +102,30 @@ export default function MemoryGame({
     });
   };
 
+  const limit = memoryTimeLimit(level);
+  const pct = Math.max(0, Math.min(100, (timeLeft / limit) * 100));
+  const low = timeLeft <= 5;
+
   return (
     <div className="flex flex-col items-center gap-3">
       <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
         レベル {level} ・ そろった {state.pairs}/{state.boardPairs}
       </p>
+      <div className="w-full max-w-xs">
+        <div className="mb-1 flex justify-between text-sm font-bold">
+          <span className={low ? 'text-red-600' : 'text-gray-700 dark:text-gray-200'}>
+            ⏱ のこり {timeLeft}秒
+          </span>
+        </div>
+        <div className="h-2.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+          <div
+            className={`h-full rounded-full transition-all duration-1000 ease-linear ${
+              low ? 'bg-red-500' : 'bg-green-500'
+            }`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
       <div className="grid grid-cols-4 gap-2">
         {state.cards.map((c, i) => {
           const face = c.revealed || c.matched;
@@ -100,7 +153,7 @@ export default function MemoryGame({
         })}
       </div>
       <p className="text-xs text-gray-500 dark:text-gray-400">
-        おなじ えを 2まい さがそう！
+        じかんない に おなじ えを 2まい さがそう！
       </p>
     </div>
   );

--- a/app/sansu-100/lib/__tests__/memory.test.ts
+++ b/app/sansu-100/lib/__tests__/memory.test.ts
@@ -4,6 +4,7 @@ import {
   pickCard,
   resolveMemory,
   memoryPairs,
+  memoryTimeLimit,
   MEMORY,
 } from '../games/memory';
 
@@ -24,6 +25,14 @@ describe('memory', () => {
     expect(memoryPairs(1)).toBe(MEMORY.basePairs);
     expect(memoryPairs(2)).toBe(MEMORY.basePairs + 1);
     expect(memoryPairs(99)).toBe(MEMORY.maxPairs);
+  });
+
+  it('制限時間はレベル別、範囲外は最後の値', () => {
+    expect(memoryTimeLimit(1)).toBe(MEMORY.timeLimitSec[0]);
+    expect(memoryTimeLimit(2)).toBe(MEMORY.timeLimitSec[1]);
+    expect(memoryTimeLimit(99)).toBe(
+      MEMORY.timeLimitSec[MEMORY.timeLimitSec.length - 1]
+    );
   });
 
   it('1枚目をめくると revealed・firstIdx 設定', () => {

--- a/app/sansu-100/lib/games/memory.ts
+++ b/app/sansu-100/lib/games/memory.ts
@@ -1,14 +1,22 @@
 // 神経衰弱（メモリーめくり）の純粋ロジック（React非依存・テスト対象）。
-// 1ボードそろえるたびに もっとカードが増えて難しくなる（レベルアップ）。
-// 終わりは「やめる」で、それまでにそろえたボード数がスコア。
+// レベルごとに「制限時間」内にそろえるとレベルアップ。時間切れで終了。
+// 終わりは時間切れ or 「やめる」で、それまでにそろえたボード数がスコア。
 
 export const MEMORY = {
   basePairs: 5, // レベル1のペア数
   maxPairs: 8, // 上限（4x4=16枚）
+  // レベル別の制限時間(秒)。調整しやすいよう配列で持つ（範囲外は最後の値を使う）。
+  timeLimitSec: [40, 50, 60, 70],
 } as const;
 
 export function memoryPairs(level: number): number {
   return Math.min(MEMORY.maxPairs, MEMORY.basePairs + level - 1);
+}
+
+/** レベルの制限時間(秒)。配列の範囲外は最後の値。 */
+export function memoryTimeLimit(level: number): number {
+  const t = MEMORY.timeLimitSec;
+  return t[Math.min(Math.max(1, level), t.length) - 1];
 }
 
 export type Card = { value: number; revealed: boolean; matched: boolean };

--- a/app/sansu-100/minigame/memory/page.tsx
+++ b/app/sansu-100/minigame/memory/page.tsx
@@ -101,7 +101,7 @@ export default function MemoryPage(): React.JSX.Element {
         ) : (
           <Header
             title="🧠 しんけいすいじゃく"
-            description="おなじ えの カードを 2まい さがそう！"
+            description="せいげんじかん内に そろえて レベルアップ！"
             showBackButton
             backHref="/sansu-100/minigame"
             backLabel="ゲームせんたくにもどる"
@@ -138,7 +138,11 @@ export default function MemoryPage(): React.JSX.Element {
 
         {phase === 'playing' ? (
           <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
-            <MemoryGame key={round} onScore={setLiveScore} />
+            <MemoryGame
+              key={round}
+              onScore={setLiveScore}
+              onGameOver={handleGameOver}
+            />
           </section>
         ) : null}
 


### PR DESCRIPTION
ご要望対応：神経衰弱を「制限時間内にそろえてレベルアップ」する方式に。時間は調整しやすく変数で保持。

## 変更
- レベルごとの**制限時間**内にそろえると**レベルアップ**（カード増）。時間切れで終了
- 制限時間は `MEMORY.timeLimitSec`（配列）で保持＝**レベル別に調整しやすい**（既定 [40,50,60,70]秒）
- カウントダウン＋ゲージ表示、レベルアップで時計リセット

## 検証
- iPhone実機相当(Playwright): カウントダウン減少・クリアでLv2へ＆50sリセット・時間切れ→結果画面
- setState警告なし・console error 0。lint・ビルド緑 / テスト161件緑

※ 迷路も同様に制限時間化を別PRで対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)