### PR TITLE
feat(sansu-100): コインを演算難易度ベースに（10〜100/回・ルーレットは上限対象外）

### DIFF
--- a/api/src/functions/sansuSessions.ts
+++ b/api/src/functions/sansuSessions.ts
@@ -101,12 +101,13 @@ app.http('sansuSessionsPost', {
             .toISOString()
             .slice(0, 10);
           const coin = calculateCoins({
+            operation: body.operation,
             dailyCoinDate: user.dailyCoinDate ?? '',
             dailyCoinsEarned: user.dailyCoinsEarned ?? 0,
             dailySessionCount: user.dailySessionCount ?? 0,
             todayKey,
             isNewBest,
-            // ストリークはクライアント申告を許容（上限150が歯止め）。
+            // ストリークはクライアント申告を許容（1回上限100が歯止め）。
             streakDays: body.streakDays ?? 0,
             prevStreakDays: body.prevStreakDays ?? 0,
             isCountable: !body.isRetired,

--- a/api/src/shared/coins.ts
+++ b/api/src/shared/coins.ts
@@ -2,19 +2,34 @@
 // 重要: app/sansu-100/lib/coins.ts と「同一ロジック」で複製している。
 //       片方を変えたら必ずもう片方も変えること。
 //       匿名APIのためクライアント申告は信用せず、ここで再計算した値を正とする。
+// 基本コインは演算の難しさで決まる（add<sub<mul<div）。1回あたり最大100。
+// ルーレット倍率は別枠で上限の対象外。
+
+type Operation = 'add' | 'sub' | 'mul' | 'div' | 'mixed';
 
 export const COIN_RULES = {
-  baseStart: 30, // その日1回目の基本コイン
-  baseStep: 20, // 1回ふえるごとに +20
-  baseMax: 150, // 1回あたりの基本コインの上限（1日合計の上限はなし）
+  byOperation: { add: 10, sub: 35, mul: 60, div: 90, mixed: 50 } as Record<
+    Operation,
+    number
+  >,
+  maxPerSession: 100,
   newBest: 20,
   streak3Bonus: 10,
   streak7Bonus: 30,
 } as const;
 
+const OP_LABEL: Record<Operation, string> = {
+  add: 'たしざん',
+  sub: 'ひきざん',
+  mul: 'かけざん',
+  div: 'わりざん',
+  mixed: 'ミックス',
+};
+
 export type CoinBreakdownEntry = { label: string; amount: number };
 
 export type CoinContext = {
+  operation: Operation;
   dailyCoinDate: string;
   dailyCoinsEarned: number;
   dailySessionCount: number;
@@ -50,11 +65,9 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
 
   const breakdown: CoinBreakdownEntry[] = [];
 
-  const base = Math.min(
-    COIN_RULES.baseMax,
-    COIN_RULES.baseStart + sessionCountSoFar * COIN_RULES.baseStep
-  );
-  breakdown.push({ label: `きょう${sessionCountSoFar + 1}回目`, amount: base });
+  const base =
+    COIN_RULES.byOperation[ctx.operation] ?? COIN_RULES.byOperation.mixed;
+  breakdown.push({ label: OP_LABEL[ctx.operation] ?? 'クリア', amount: base });
 
   if (ctx.isNewBest) {
     breakdown.push({ label: 'ベストこうしん', amount: COIN_RULES.newBest });
@@ -66,8 +79,11 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
     breakdown.push({ label: '3日れんぞく', amount: COIN_RULES.streak3Bonus });
   }
 
-  // 1日の上限はなし（やるほど増える）。
-  const coinsEarned = breakdown.reduce((sum, e) => sum + e.amount, 0);
+  const raw = breakdown.reduce((sum, e) => sum + e.amount, 0);
+  const coinsEarned = Math.min(COIN_RULES.maxPerSession, raw);
+  if (coinsEarned < raw) {
+    breakdown.push({ label: '1回の上限', amount: coinsEarned - raw });
+  }
 
   return {
     coinsEarned,

--- a/app/sansu-100/lib/__tests__/coins.test.ts
+++ b/app/sansu-100/lib/__tests__/coins.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { calculateCoins, COIN_RULES, type CoinContext } from '../coins';
 
 const base: CoinContext = {
+  operation: 'add',
   dailyCoinDate: '2026-06-28',
   dailyCoinsEarned: 0,
   dailySessionCount: 0,
@@ -13,68 +14,43 @@ const base: CoinContext = {
 };
 
 describe('calculateCoins', () => {
-  it('1日1回目のクリアで +30', () => {
-    const r = calculateCoins(base);
-    expect(r.coinsEarned).toBe(30);
-    expect(r.nextDailySessionCount).toBe(1);
-    expect(r.nextDailyCoinsEarned).toBe(30);
-    expect(r.nextDailyCoinDate).toBe('2026-06-28');
+  it('演算の難しさで基本コインが変わる（add<sub<mul<div）', () => {
+    const add = calculateCoins({ ...base, operation: 'add' }).coinsEarned;
+    const sub = calculateCoins({ ...base, operation: 'sub' }).coinsEarned;
+    const mul = calculateCoins({ ...base, operation: 'mul' }).coinsEarned;
+    const div = calculateCoins({ ...base, operation: 'div' }).coinsEarned;
+    expect(add).toBe(COIN_RULES.byOperation.add); // 10
+    expect(sub).toBe(COIN_RULES.byOperation.sub);
+    expect(mul).toBe(COIN_RULES.byOperation.mul);
+    expect(div).toBe(COIN_RULES.byOperation.div); // 90
+    expect(add).toBeLessThan(sub);
+    expect(sub).toBeLessThan(mul);
+    expect(mul).toBeLessThan(div);
   });
 
-  it('回数が増えるほど基本コインが +20 ずつ増える（30→50→70…）', () => {
-    const second = calculateCoins({ ...base, dailySessionCount: 1, dailyCoinsEarned: 30 });
-    expect(second.coinsEarned).toBe(50);
-    expect(second.nextDailyCoinsEarned).toBe(80);
-    const third = calculateCoins({ ...base, dailySessionCount: 2, dailyCoinsEarned: 80 });
-    expect(third.coinsEarned).toBe(70);
-  });
-
-  it('1回あたりの基本コインは baseMax(150) で頭打ち', () => {
-    const sixth = calculateCoins({ ...base, dailySessionCount: 6, dailyCoinsEarned: 999 });
-    expect(sixth.coinsEarned).toBe(COIN_RULES.baseMax); // 30+6*20=150
-    const tenth = calculateCoins({ ...base, dailySessionCount: 10, dailyCoinsEarned: 999 });
-    expect(tenth.coinsEarned).toBe(COIN_RULES.baseMax);
-  });
-
-  it('1日合計の上限はない（150を超えても付与される）', () => {
-    const r = calculateCoins({
+  it('最小は10・最大は100（1回あたり）', () => {
+    expect(calculateCoins({ ...base, operation: 'add' }).coinsEarned).toBe(10);
+    // div(90)+ベスト(20)+ストリーク → 100で頭打ち
+    const capped = calculateCoins({
       ...base,
-      dailySessionCount: 5,
-      dailyCoinsEarned: 400, // すでに400稼いでいても…
+      operation: 'div',
+      isNewBest: true,
+      streakDays: 7,
+      prevStreakDays: 6,
     });
-    expect(r.coinsEarned).toBe(130); // 30+5*20=130
-    expect(r.nextDailyCoinsEarned).toBe(530);
+    expect(capped.coinsEarned).toBe(COIN_RULES.maxPerSession); // 100
+    expect(capped.coinsEarned).toBeLessThanOrEqual(100);
+    expect(capped.breakdown.some((e) => e.label === '1回の上限')).toBe(true);
   });
 
-  it('自己ベスト更新で +20 上乗せ', () => {
-    const r = calculateCoins({ ...base, isNewBest: true });
-    expect(r.coinsEarned).toBe(30 + 20);
+  it('自己ベスト更新で +20（上限内）', () => {
+    const r = calculateCoins({ ...base, operation: 'add', isNewBest: true });
+    expect(r.coinsEarned).toBe(COIN_RULES.byOperation.add + 20);
   });
 
-  it('3日連続に到達した日だけ +10', () => {
-    const reached = calculateCoins({ ...base, streakDays: 3, prevStreakDays: 2 });
-    expect(reached.coinsEarned).toBe(30 + 10);
-    const already = calculateCoins({ ...base, streakDays: 4, prevStreakDays: 3 });
-    expect(already.coinsEarned).toBe(30);
-  });
-
-  it('7日連続に到達した日は +30（3日分は重複しない）', () => {
-    const r = calculateCoins({ ...base, streakDays: 7, prevStreakDays: 6 });
-    expect(r.coinsEarned).toBe(30 + 30);
-  });
-
-  it('日付が変わったら当日カウンタをリセットして再び 1回目=30', () => {
-    const r = calculateCoins({
-      ...base,
-      dailyCoinDate: '2026-06-27',
-      dailyCoinsEarned: 500,
-      dailySessionCount: 8,
-      todayKey: '2026-06-28',
-    });
-    expect(r.coinsEarned).toBe(30);
-    expect(r.nextDailyCoinDate).toBe('2026-06-28');
-    expect(r.nextDailyCoinsEarned).toBe(30);
-    expect(r.nextDailySessionCount).toBe(1);
+  it('ミックスは中くらい', () => {
+    const mixed = calculateCoins({ ...base, operation: 'mixed' }).coinsEarned;
+    expect(mixed).toBe(COIN_RULES.byOperation.mixed);
   });
 
   it('リタイヤ（集計対象外）は0で当日カウンタ据え置き', () => {
@@ -87,6 +63,19 @@ describe('calculateCoins', () => {
     expect(r.coinsEarned).toBe(0);
     expect(r.nextDailyCoinsEarned).toBe(80);
     expect(r.nextDailySessionCount).toBe(2);
-    expect(r.nextDailyCoinDate).toBe(base.dailyCoinDate);
+  });
+
+  it('日付が変わったら当日カウンタをリセット', () => {
+    const r = calculateCoins({
+      ...base,
+      operation: 'div',
+      dailyCoinDate: '2026-06-27',
+      dailyCoinsEarned: 500,
+      dailySessionCount: 8,
+      todayKey: '2026-06-28',
+    });
+    expect(r.coinsEarned).toBe(COIN_RULES.byOperation.div);
+    expect(r.nextDailyCoinDate).toBe('2026-06-28');
+    expect(r.nextDailySessionCount).toBe(1);
   });
 });

--- a/app/sansu-100/lib/__tests__/session-result.test.ts
+++ b/app/sansu-100/lib/__tests__/session-result.test.ts
@@ -101,8 +101,9 @@ describe('finishSession - コイン', () => {
     expect(r.coinsEarned).toBeGreaterThan(0);
     expect(r.updatedUser.coins).toBe(r.coinsEarned);
     expect(r.coinBreakdown.length).toBeGreaterThan(0);
-    // 当日1回目なので +50 を含む（ベスト更新等が上乗せされる場合あり）
-    expect(r.coinsEarned).toBeGreaterThanOrEqual(50);
+    // add の基本(10)以上（ベスト更新等が上乗せ）。1回あたり上限100。
+    expect(r.coinsEarned).toBeGreaterThanOrEqual(10);
+    expect(r.coinsEarned).toBeLessThanOrEqual(100);
     expect(r.updatedUser.dailyCoinDate).toBe(r.updatedUser.lastPlayedDate);
     expect(r.updatedUser.dailySessionCount).toBe(1);
   });

--- a/app/sansu-100/lib/coins.ts
+++ b/app/sansu-100/lib/coins.ts
@@ -3,21 +3,37 @@
 //       片方を変えたら必ずもう片方も変えること。確定値はサーバー側。
 //       挙動の一致は app/sansu-100/lib/__tests__/coins.test.ts で担保する。
 //
-// 子ども向け配慮: 減点・没収は一切しない（常に coinsEarned >= 0）。
-//                 「やればやるほど増える」ように基本コインは回数で逓増し、1日の上限はなし。
+// 子ども向け配慮: 減点・没収は一切しない（常に coinsEarned >= 0）。1日の上限はなし。
+// 基本コインは「演算の難しさ」で決まる（たし算<ひき算<かけ算<わり算）。1回あたり最大100。
+// ※フィーバーのルーレット倍率は別枠で、この上限の対象外。
+
+import type { Operation } from './types';
 
 export const COIN_RULES = {
-  baseStart: 30, // その日1回目の基本コイン
-  baseStep: 20, // 1回ふえるごとに +20（2回目50・3回目70…）
-  baseMax: 150, // 1回あたりの基本コインの上限（暴走防止。1日合計の上限はなし）
-  newBest: 20, // 自己ベスト更新
+  // 演算ごとの基本コイン（調整しやすいよう変数化）。最小10〜。
+  byOperation: { add: 10, sub: 35, mul: 60, div: 90, mixed: 50 } as Record<
+    Operation,
+    number
+  >,
+  maxPerSession: 100, // 1回あたりの上限（ルーレット倍率は対象外）
+  newBest: 20, // 自己ベスト更新ボーナス
   streak3Bonus: 10, // 3日連続に到達した日
   streak7Bonus: 30, // 7日連続に到達した日
 } as const;
 
+const OP_LABEL: Record<Operation, string> = {
+  add: 'たしざん',
+  sub: 'ひきざん',
+  mul: 'かけざん',
+  div: 'わりざん',
+  mixed: 'ミックス',
+};
+
 export type CoinBreakdownEntry = { label: string; amount: number };
 
 export type CoinContext = {
+  /** 今回の演算（たし算/ひき算/かけ算/わり算/ミックス）。基本コインを決める。 */
+  operation: Operation;
   /** 当日コイン集計の対象日（ユーザーの現在値）。todayKey と異なれば日付跨ぎ。 */
   dailyCoinDate: string;
   /** 当日すでに獲得したコイン（ユーザーの現在値）。 */
@@ -39,7 +55,6 @@ export type CoinContext = {
 export type CoinResult = {
   coinsEarned: number;
   breakdown: CoinBreakdownEntry[];
-  // 反映後の当日カウンタ（呼び出し側がユーザーに保存する）
   nextDailyCoinDate: string;
   nextDailyCoinsEarned: number;
   nextDailySessionCount: number;
@@ -57,19 +72,15 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
     };
   }
 
-  // 日付が変わっていたら当日カウンタをリセット。
   const sameDay = ctx.dailyCoinDate === ctx.todayKey;
   const earnedSoFar = sameDay ? ctx.dailyCoinsEarned : 0;
   const sessionCountSoFar = sameDay ? ctx.dailySessionCount : 0;
 
   const breakdown: CoinBreakdownEntry[] = [];
 
-  // 基本報酬: その日の回数で逓増（1回目30・2回目50…+20ずつ、baseMax で頭打ち）
-  const base = Math.min(
-    COIN_RULES.baseMax,
-    COIN_RULES.baseStart + sessionCountSoFar * COIN_RULES.baseStep
-  );
-  breakdown.push({ label: `きょう${sessionCountSoFar + 1}回目`, amount: base });
+  // 基本報酬: 演算の難しさで決まる
+  const base = COIN_RULES.byOperation[ctx.operation] ?? COIN_RULES.byOperation.mixed;
+  breakdown.push({ label: OP_LABEL[ctx.operation] ?? 'クリア', amount: base });
 
   // 自己ベスト更新
   if (ctx.isNewBest) {
@@ -83,8 +94,12 @@ export function calculateCoins(ctx: CoinContext): CoinResult {
     breakdown.push({ label: '3日れんぞく', amount: COIN_RULES.streak3Bonus });
   }
 
-  // 1日の上限はなし（やるほど増える）。減点もしない。
-  const coinsEarned = breakdown.reduce((sum, e) => sum + e.amount, 0);
+  const raw = breakdown.reduce((sum, e) => sum + e.amount, 0);
+  // 1回あたりの上限でクリップ（ルーレット倍率は別枠で対象外）。
+  const coinsEarned = Math.min(COIN_RULES.maxPerSession, raw);
+  if (coinsEarned < raw) {
+    breakdown.push({ label: '1回の上限', amount: coinsEarned - raw });
+  }
 
   return {
     coinsEarned,

--- a/app/sansu-100/lib/session-result.ts
+++ b/app/sansu-100/lib/session-result.ts
@@ -105,6 +105,7 @@ export function finishSession(input: FinishSessionInput): FinishSessionResult {
 
   const todayKey = intermediateUser.lastPlayedDate; // = completedAt の YYYY-MM-DD
   const coin = calculateCoins({
+    operation: input.operation,
     dailyCoinDate: user.dailyCoinDate ?? '',
     dailyCoinsEarned: user.dailyCoinsEarned ?? 0,
     dailySessionCount: user.dailySessionCount ?? 0,


### PR DESCRIPTION
ご要望対応：1回のコインを演算の難しさで変える（たし算<ひき算<かけ算<わり算）。1回あたり最大100・最小10。ルーレット倍率は上限の対象外。

## 変更
- 逓増ベースを廃止し、**基本コインを演算で決定**：たし算10 / ひき算35 / かけ算60 / わり算90 / ミックス50（`COIN_RULES.byOperation` で調整可）
- ベスト更新+20・ストリークを上乗せしつつ **1回あたり上限100** でクリップ（最小10・最大100）
- **フィーバーのルーレット倍率は別枠で上限対象外**（100超OK）

## 検証
- curl: add 30 / sub 55 / mul 80 / div 100(上限) ※base+ベスト20
- lint・両ビルド緑 / テスト161件緑

数値は `byOperation` の変数なので「ここを増やして」等で簡単に調整できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)