### PR TITLE
fix(sansu-100): コイン残高をサーバーと再同期（あるのに遊べない不具合）

### DIFF
--- a/app/sansu-100/hooks/useSansuUser.ts
+++ b/app/sansu-100/hooks/useSansuUser.ts
@@ -2,8 +2,37 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { sansuApi } from '../lib/api-client';
 import { storage } from '../lib/storage';
 import type { SansuUserPublic } from '../lib/types';
+
+// サーバー同期はアプリ起動中1回だけ（ユーザーごと）。
+const reconciled = new Set<string>();
+
+// 起動時の同期: (1)未送信セッションを再送して取りこぼしコインをサーバーに反映し、
+// (2)サーバー権威の残高でローカルを上書き。これで「コインはあるのに参加費が払えない」
+// （ローカルだけ多くサーバーは少ない）ズレを解消する。冪等(既送信は409で二重加算なし)。
+async function reconcileWithServer(
+  id: string,
+  apply: (u: SansuUserPublic) => void
+): Promise<void> {
+  const pending = storage.getPendingSync().filter((s) => s.userId === id);
+  for (const s of pending) {
+    try {
+      const res = await sansuApi.submitSession(s);
+      storage.clearPending([s.id]);
+      if (res.user) apply(res.user);
+    } catch {
+      // 送れなければ pending のまま（次回再試行）
+    }
+  }
+  try {
+    const server = await sansuApi.getUser(id);
+    if (server) apply(server);
+  } catch {
+    // 取得できなければローカルのまま
+  }
+}
 
 export function useSansuUser() {
   const [currentUser, setCurrentUser] = useState<SansuUserPublic | null>(null);
@@ -17,6 +46,15 @@ export function useSansuUser() {
     const u = id ? users.find((x) => x.id === id) ?? null : null;
     setCurrentUser(u);
     setLoaded(true);
+
+    if (id && !reconciled.has(id)) {
+      reconciled.add(id);
+      void reconcileWithServer(id, (fresh) => {
+        storage.upsertUser(fresh);
+        setRecentUsers(storage.getUsers());
+        setCurrentUser((cur) => (cur && cur.id === fresh.id ? fresh : cur));
+      });
+    }
   }, []);
 
   const selectUser = useCallback((user: SansuUserPublic | null) => {


### PR DESCRIPTION
「コインがあるのに参加費が払えない（あそべない）」不具合の修正。

## 原因
- 残高はサーバー権威だが、**起動時にサーバーから取り直していなかった**＋**送信失敗セッションの再送もなかった**ため、ローカルのコインだけ増えてサーバーは少ない、というズレが発生。サーバー権威の spend が弾いていた。

## 修正
`useSansuUser` のマウント時に1回だけ：
1. **未送信(pending)セッションを再送**して取りこぼしコインをサーバーへ反映（冪等＝既送信は二重加算なし）
2. **getUser でサーバー権威の残高に同期**

## 検証
- iPhone実機相当(Playwright): ローカル80/サーバー0＋未送信1件 → 同期後 両方55・pending0。spend が通るように
- lint・ビルド緑 / テスト161件緑

※ デプロイ後、端末側はPWA更新（更新トースト or 再読込）で新クライアントが走ると残高が同期されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)