### PR TITLE
fix(sansu-100): ホームのあいさつ文が縦に折り返す不具合を修正

### DIFF
--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -107,23 +107,25 @@ export default function SansuHome(): React.JSX.Element {
 
         {currentUser ? (
           <section className="space-y-6 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
-            <div className="flex items-center gap-4">
-              <AvatarDisplay user={currentUser} size="lg" />
-              <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  こんにちは
-                </p>
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                  {currentUser.name}
-                </h2>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  これまで {currentUser.totalSessions}回 / バッジ{' '}
-                  {currentUser.earnedBadges.length}
-                </p>
+            <div className="space-y-2">
+              <div className="flex items-center gap-3">
+                <AvatarDisplay user={currentUser} size="md" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-gray-600 dark:text-gray-400">
+                    こんにちは
+                  </p>
+                  <h2 className="truncate text-2xl font-bold text-gray-900 dark:text-gray-100">
+                    {currentUser.name}
+                  </h2>
+                </div>
+                <div data-testid="coin-balance">
+                  <CoinBalance coins={currentUser.coins} size="md" />
+                </div>
               </div>
-              <div className="ml-auto" data-testid="coin-balance">
-                <CoinBalance coins={currentUser.coins} size="lg" />
-              </div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                これまで {currentUser.totalSessions}回 ・ バッジ{' '}
+                {currentUser.earnedBadges.length}
+              </p>
             </div>
             <button
               type="button"


### PR DESCRIPTION
ホーム画面の「これまで○回 / バッジ○」が**縦に1文字ずつ折り返す**不具合の修正（スクショ報告）。

## 原因
アバター(lg)＋コイン残高に挟まれて文字領域が1文字幅まで潰れ、日本語はどこでも改行できるため縦積みになっていた。

## 修正
- アバターを md に縮小、名前は truncate（単一行）
- 「これまで○回 ・ バッジ○」を**アバター行の下に全幅で配置**＝横一行で読める

## 検証
- iPhone相当(幅360): 統計行が単一行(高さ20px・全文表示)
- lint・ビルド緑 / テスト161件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)