### PR TITLE
feat(sansu-100): ミニゲームに算数ゲート（算数1回で5プレイ）

### DIFF
--- a/api/src/functions/sansuSessions.ts
+++ b/api/src/functions/sansuSessions.ts
@@ -9,6 +9,10 @@ import {
   isStartedAtRecent,
 } from '../shared/fever';
 import {
+  MINIGAME_CREDITS_CAP,
+  MINIGAME_PLAYS_PER_MATH,
+} from '../shared/minigame';
+import {
   type SansuSession,
   type SansuSessionEntity,
   type SansuUserEntity,
@@ -143,6 +147,15 @@ app.http('sansuSessionsPost', {
             dailyCoinDate: coin.nextDailyCoinDate,
             dailyCoinsEarned: coin.nextDailyCoinsEarned,
             dailySessionCount: coin.nextDailySessionCount,
+            // 算数ゲート: 完走でミニゲームの「あそべる回数」を付与（リタイヤは無し）。
+            ...(!body.isRetired
+              ? {
+                  minigameCredits: Math.min(
+                    MINIGAME_CREDITS_CAP,
+                    (user.minigameCredits ?? 0) + MINIGAME_PLAYS_PER_MATH
+                  ),
+                }
+              : {}),
             // フィーバー達成なら倍率の対象(基本コイン)を保留。ルーレットでclaim。
             ...(feverEligible
               ? {

--- a/api/src/functions/sansuSpend.ts
+++ b/api/src/functions/sansuSpend.ts
@@ -38,6 +38,14 @@ app.http('sansuSpendPost', {
       }
 
       const coins = user.coins ?? 0;
+      const credits = user.minigameCredits ?? 0;
+      // 算数ゲート: 新規プレイは「あそべる回数」が必要。0なら算数を解くまで遊べない。
+      if (body.reason === 'play' && credits <= 0) {
+        return {
+          status: 409,
+          jsonBody: { error: 'no_plays', minigameCredits: 0 },
+        };
+      }
       if (coins < cost) {
         return {
           status: 409,
@@ -45,11 +53,20 @@ app.http('sansuSpendPost', {
         };
       }
 
-      const updated = {
+      const updated: {
+        partitionKey: string;
+        rowKey: string;
+        coins: number;
+        minigameCredits?: number;
+      } = {
         partitionKey: USERS_PARTITION,
         rowKey: body.userId,
         coins: coins - cost,
       };
+      // プレイ参加でクレジットを1消費（コンティニューは消費しない）。
+      if (body.reason === 'play') {
+        updated.minigameCredits = Math.max(0, credits - 1);
+      }
       await uTable.updateEntity(updated, 'Merge');
       const refreshed = await uTable.getEntity<SansuUserEntity>(
         USERS_PARTITION,

--- a/api/src/shared/minigame.ts
+++ b/api/src/shared/minigame.ts
@@ -13,3 +13,8 @@ export function getSpendCost(reason: string): number | undefined {
     ? SPEND_COSTS[reason as SpendReason]
     : undefined;
 }
+
+// 算数ゲート: 算数を解かないとミニゲームは遊べない。算数1回完走で「あそべる回数」を付与し、
+// 1プレイで1消費する（=5回ごとに1回は算数）。クライアント lib/minigame-economy.ts と一致させる。
+export const MINIGAME_PLAYS_PER_MATH = 5; // 算数1回で増えるプレイ回数
+export const MINIGAME_CREDITS_CAP = 15; // ためられる上限（3回ぶん）

--- a/api/src/shared/sansuTypes.ts
+++ b/api/src/shared/sansuTypes.ts
@@ -29,6 +29,7 @@ export type SansuUserPublic = {
   dailySessionCount?: number;
   minigameHighScore?: number;
   minigameScores?: Record<string, number>;
+  minigameCredits?: number;
   avatarConfig?: AvatarConfig;
   feverWindowInterval?: number;
   feverWindowUses?: number;
@@ -61,6 +62,7 @@ export type SansuUserEntity = {
   dailySessionCount?: number;
   minigameHighScore?: number;
   minigameScoresJson?: string;
+  minigameCredits?: number; // あそべる回数（算数ゲート）。算数完走で増え、1プレイで1消費。
   avatarConfigJson?: string;
   // --- フィーバー(おすすめ問題達成)＋ルーレット倍率 ---
   feverWindowInterval?: number; // ルーレット回数をカウントしている15分枠
@@ -94,6 +96,7 @@ export function toPublic(e: SansuUserEntity): SansuUserPublic {
     dailySessionCount: e.dailySessionCount ?? 0,
     minigameHighScore: e.minigameHighScore ?? 0,
     minigameScores: safeParseObject(e.minigameScoresJson ?? '{}'),
+    minigameCredits: e.minigameCredits ?? 0,
     avatarConfig: safeParseAvatarConfig(e.avatarConfigJson),
     feverWindowInterval: e.feverWindowInterval,
     feverWindowUses: e.feverWindowUses ?? 0,

--- a/app/sansu-100/lib/api-client.ts
+++ b/app/sansu-100/lib/api-client.ts
@@ -159,7 +159,9 @@ export const sansuApi = {
       );
     } catch (e) {
       if (e instanceof Error && /HTTP 409/.test(e.message)) {
-        return { ok: false, error: 'insufficient' };
+        // 算数ゲート(no_plays)と残高不足(insufficient)を区別する。
+        const reason = /no_plays/.test(e.message) ? 'no_plays' : 'insufficient';
+        return { ok: false, error: reason };
       }
       throw e;
     }

--- a/app/sansu-100/lib/minigame-economy.ts
+++ b/app/sansu-100/lib/minigame-economy.ts
@@ -7,3 +7,7 @@ export const SPEND_COSTS = {
 } as const;
 
 export type SpendReason = keyof typeof SPEND_COSTS;
+
+// 算数ゲート: 算数を解かないとミニゲームは遊べない。算数1回で +5、1プレイで1消費。
+export const MINIGAME_PLAYS_PER_MATH = 5;
+export const MINIGAME_CREDITS_CAP = 15;

--- a/app/sansu-100/lib/types.ts
+++ b/app/sansu-100/lib/types.ts
@@ -73,6 +73,7 @@ export type SansuUserPublic = {
   dailySessionCount?: number; // 当日のクリア回数（1回目/2回目判定）
   minigameHighScore?: number; // ミニゲーム最高スコア（全体・後方互換）
   minigameScores?: Record<string, number>; // ゲームごとの最高スコア
+  minigameCredits?: number; // あそべる回数（算数ゲート。算数完走で増え、1プレイで1消費）
   avatarConfig?: AvatarConfig; // パーツ組み立て式アバター（未設定なら絵文字 avatar を使う）
   feverWindowInterval?: number; // ルーレット回数をカウントしている15分枠
   feverWindowUses?: number; // その枠でルーレットを回した回数

--- a/app/sansu-100/minigame/breakout/page.tsx
+++ b/app/sansu-100/minigame/breakout/page.tsx
@@ -46,7 +46,11 @@ export default function BreakoutPage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/falling/page.tsx
+++ b/app/sansu-100/minigame/falling/page.tsx
@@ -45,7 +45,11 @@ export default function FallingPage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/flappy/page.tsx
+++ b/app/sansu-100/minigame/flappy/page.tsx
@@ -45,7 +45,11 @@ export default function FlappyPage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/maze/page.tsx
+++ b/app/sansu-100/minigame/maze/page.tsx
@@ -47,7 +47,11 @@ export default function MazePage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/memory/page.tsx
+++ b/app/sansu-100/minigame/memory/page.tsx
@@ -47,7 +47,11 @@ export default function MemoryPage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/page.tsx
+++ b/app/sansu-100/minigame/page.tsx
@@ -9,7 +9,10 @@ import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
 import CoinBalance from '../components/CoinBalance';
 import { useSansuUser } from '../hooks/useSansuUser';
-import { SPEND_COSTS } from '../lib/minigame-economy';
+import {
+  MINIGAME_PLAYS_PER_MATH,
+  SPEND_COSTS,
+} from '../lib/minigame-economy';
 import { MINIGAMES } from '../lib/minigame-list';
 
 // ミニゲームのハブ画面。コインで遊ぶ（参加費）。報酬は限定バッジ＝コインは増えない。
@@ -24,6 +27,7 @@ export default function MinigameHubPage(): React.JSX.Element {
   if (!currentUser) return <main className="p-8" />;
 
   const coins = currentUser.coins ?? 0;
+  const playCredits = currentUser.minigameCredits ?? 0;
 
   return (
     <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
@@ -40,14 +44,37 @@ export default function MinigameHubPage(): React.JSX.Element {
         />
 
         <section className="flex items-center justify-between rounded-2xl bg-white p-5 shadow-md dark:bg-gray-800">
-          <p className="font-bold text-gray-900 dark:text-gray-100">
-            もっているコイン
-          </p>
+          <div>
+            <p className="font-bold text-gray-900 dark:text-gray-100">
+              もっているコイン
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              あそべる かいすう:{' '}
+              <span className="font-bold text-purple-600 dark:text-purple-300">
+                {playCredits}
+              </span>
+            </p>
+          </div>
           <CoinBalance coins={coins} size="lg" />
         </section>
 
+        {playCredits <= 0 ? (
+          <Link
+            href="/sansu-100/play"
+            className="block rounded-2xl bg-gradient-to-r from-orange-400 to-pink-500 p-5 text-center font-bold text-white shadow-md"
+            data-testid="math-gate"
+          >
+            🧮 さんすうを 1かい といたら、ゲームが {MINIGAME_PLAYS_PER_MATH}
+            かい あそべるよ！
+            <span className="mt-1 block text-sm font-normal opacity-90">
+              タップして れんしゅうへ →
+            </span>
+          </Link>
+        ) : null}
+
         <div className="grid grid-cols-2 gap-3">
           {MINIGAMES.map((g) => {
+            const locked = playCredits <= 0;
             const best = currentUser.minigameScores?.[g.id];
             const card = (
               <div className="flex h-full flex-col items-center gap-1 rounded-2xl bg-white p-4 text-center shadow-md dark:bg-gray-800">
@@ -65,18 +92,22 @@ export default function MinigameHubPage(): React.JSX.Element {
                     🏆 さいこう {best}
                   </span>
                 ) : null}
-                {g.available ? (
-                  <span className="mt-1 rounded-full bg-blue-100 px-3 py-1 text-sm font-bold text-blue-700 dark:bg-blue-900/40 dark:text-blue-200">
-                    🪙 {SPEND_COSTS.play} であそぶ
-                  </span>
-                ) : (
+                {!g.available ? (
                   <span className="mt-1 rounded-full bg-gray-200 px-3 py-1 text-sm font-bold text-gray-500 dark:bg-gray-700 dark:text-gray-400">
                     じゅんびちゅう
+                  </span>
+                ) : locked ? (
+                  <span className="mt-1 whitespace-nowrap rounded-full bg-orange-100 px-3 py-1 text-sm font-bold text-orange-700 dark:bg-orange-900/40 dark:text-orange-200">
+                    🧮 さんすうしてね
+                  </span>
+                ) : (
+                  <span className="mt-1 rounded-full bg-blue-100 px-3 py-1 text-sm font-bold text-blue-700 dark:bg-blue-900/40 dark:text-blue-200">
+                    🪙 {SPEND_COSTS.play} であそぶ
                   </span>
                 )}
               </div>
             );
-            return g.available ? (
+            return g.available && !locked ? (
               <Link
                 key={g.id}
                 href={`/sansu-100/minigame/${g.id}`}
@@ -86,7 +117,10 @@ export default function MinigameHubPage(): React.JSX.Element {
                 {card}
               </Link>
             ) : (
-              <div key={g.id} className="opacity-70">
+              <div
+                key={g.id}
+                className={g.available && locked ? 'opacity-60' : 'opacity-70'}
+              >
                 {card}
               </div>
             );

--- a/app/sansu-100/minigame/runner/page.tsx
+++ b/app/sansu-100/minigame/runner/page.tsx
@@ -45,7 +45,11 @@ export default function RunnerPage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/snake/page.tsx
+++ b/app/sansu-100/minigame/snake/page.tsx
@@ -46,7 +46,11 @@ export default function SnakePage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');

--- a/app/sansu-100/minigame/whack/page.tsx
+++ b/app/sansu-100/minigame/whack/page.tsx
@@ -45,7 +45,11 @@ export default function WhackPage(): React.JSX.Element {
         setRound((r) => r + 1);
         setPhase('playing');
       } else {
-        setMessage('コインが たりないよ');
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
       }
     } catch {
       setMessage('いまは つうしんできないよ（あとでね）');


### PR DESCRIPTION
コインがあっても**算数を解かないとミニゲームを遊べない**ようにする（5回ごとに1回は算数）。

## 仕組み
- ユーザーに `minigameCredits`（あそべる回数）を追加。算数を**1回完走で +5**、上限15（3回ぶん）。
- ミニゲーム参加(`spend 'play'`)で **credits を1消費**。0なら `409 no_plays` でブロック（コインも別途必要）。コンティニューは消費しない。
- ハブ: 「あそべる かいすう」表示。**0でゲート案内＋全カードをロック**（🧮 さんすうしてね→練習へ誘導）。1以上で通常表示。
- `insufficient`(コイン不足)と`no_plays`(算数ゲート)をクライアントで区別し適切なメッセージ。

サーバー/クライアント両方に定数を複製（`MINIGAME_PLAYS_PER_MATH=5` / `CAP=15`、調整しやすいよう変数化）。

## 検証
- API実測: credits0→no_plays / 算数完走→+5 / プレイで減少 / 4回完走で15頭打ち
- iPhone相当UI: 0でゲート＋8枚ロック、5でゲート消え8枚プレイ可（スクショ確認）
- lint・ビルド(front/api)緑 / テスト161件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)