### PR TITLE
fix(sansu-100): あまりあり割り算の余り入力＆判定を修正

### DIFF
--- a/app/sansu-100/components/ProblemDisplay.tsx
+++ b/app/sansu-100/components/ProblemDisplay.tsx
@@ -11,15 +11,24 @@ const OP_SYMBOL: Record<Problem['op'], string> = {
   div: '÷',
 };
 
+type Field = 'quotient' | 'remainder';
+
 interface ProblemDisplayProps {
   problem: Problem;
   userInput: string;
+  // あまりあり割り算のとき: あまりの入力と、いまどちらのマスを入力中か
+  remainderInput?: string;
+  activeField?: Field;
+  onFocusField?: (field: Field) => void;
   feedback?: 'correct' | 'wrong' | null;
 }
 
 export default function ProblemDisplay({
   problem,
   userInput,
+  remainderInput = '',
+  activeField = 'quotient',
+  onFocusField,
   feedback,
 }: ProblemDisplayProps): React.JSX.Element {
   // Keep the problem text in a stable color regardless of feedback so the page
@@ -37,20 +46,59 @@ export default function ProblemDisplay({
       : feedback === 'wrong'
         ? 'border-red-600 dark:border-red-400'
         : 'border-gray-400 dark:border-gray-500';
+
+  const isRemainder = problem.remainder !== undefined;
+
+  // 入力マス。あまりありのときは active なマスをリング表示し、タップで切替できる。
+  const Slot = ({
+    field,
+    value,
+  }: {
+    field: Field;
+    value: string;
+  }): React.JSX.Element => {
+    const focused = isRemainder && !feedback && activeField === field;
+    const ring = focused ? 'ring-2 ring-blue-400 dark:ring-blue-300' : '';
+    const cls = `min-w-[1em] rounded-lg border-b-4 px-2 text-center transition-colors duration-150 ${slotBorder} ${slotBg} ${ring}`;
+    if (isRemainder && onFocusField) {
+      return (
+        <button
+          type="button"
+          onClick={() => onFocusField(field)}
+          className={cls}
+          data-testid={`answer-slot-${field}`}
+        >
+          {value || ' '}
+        </button>
+      );
+    }
+    return (
+      <span className={cls} data-testid={`answer-slot-${field}`}>
+        {value || ' '}
+      </span>
+    );
+  };
+
+  // あまりありは横に長くなるので、一行に収まるよう文字を少し小さくする。
+  const sizeCls = isRemainder
+    ? 'gap-1 text-4xl sm:gap-2 sm:text-6xl md:text-7xl'
+    : 'gap-2 text-5xl sm:gap-3 sm:text-7xl md:text-8xl';
   return (
     <div
-      className="flex items-baseline justify-center gap-2 font-mono text-5xl font-bold text-gray-900 dark:text-gray-100 sm:gap-3 sm:text-7xl md:text-8xl"
+      className={`flex flex-wrap items-baseline justify-center font-mono font-bold text-gray-900 dark:text-gray-100 ${sizeCls}`}
       data-testid="problem-display"
     >
       <span>{problem.a}</span>
       <span>{OP_SYMBOL[problem.op]}</span>
       <span>{problem.b}</span>
       <span>＝</span>
-      <span
-        className={`min-w-[1.5em] rounded-lg border-b-4 px-2 text-center transition-colors duration-150 ${slotBorder} ${slotBg}`}
-      >
-        {userInput || ' '}
-      </span>
+      <Slot field="quotient" value={userInput} />
+      {isRemainder ? (
+        <>
+          <span className="text-2xl sm:text-4xl md:text-5xl">あまり</span>
+          <Slot field="remainder" value={remainderInput} />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/app/sansu-100/hooks/useSansuSession.ts
+++ b/app/sansu-100/hooks/useSansuSession.ts
@@ -67,16 +67,21 @@ export function useSansuSession(opts: UseSansuSessionOptions) {
     : null;
 
   const submitAnswer = useCallback(
-    (userAnswer: number) => {
+    (userAnswer: number, userRemainder?: number) => {
       if (!currentProblem) return;
       const now = Date.now();
       const timeMs = now - lastAdvanceRef.current;
       lastAdvanceRef.current = now;
 
+      // あまりあり割り算は商とあまりの両方が一致して正解。
+      const remainderOk =
+        currentProblem.remainder === undefined ||
+        userRemainder === currentProblem.remainder;
       const ans: AnsweredProblem = {
         ...currentProblem,
         userAnswer,
-        isCorrect: userAnswer === currentProblem.answer,
+        ...(currentProblem.remainder !== undefined ? { userRemainder } : {}),
+        isCorrect: userAnswer === currentProblem.answer && remainderOk,
         timeMs,
       };
       setAnswered((prev) => {

--- a/app/sansu-100/lib/__tests__/problem-generator.test.ts
+++ b/app/sansu-100/lib/__tests__/problem-generator.test.ts
@@ -114,11 +114,15 @@ describe('problem-generator', () => {
     }
   });
 
-  it('Level 11: 2-digit ÷ 1-digit with remainder allowed', () => {
+  it('Level 11: 2-digit ÷ 1-digit with remainder (always non-zero)', () => {
     const set = generateSetSeeded(11, 200, 11);
     for (const p of set) {
       expect(p.op).toBe('div');
       expect(p.answer).toBe(Math.floor(p.a / p.b));
+      // あまりあり: remainder が設定され、必ず 1 以上（割り切れる問題は出さない）
+      expect(p.remainder).toBe(p.a % p.b);
+      expect(p.remainder ?? 0).toBeGreaterThan(0);
+      expect(p.a).toBe(p.answer * p.b + (p.remainder ?? 0));
     }
   });
 

--- a/app/sansu-100/lib/problem-generator.ts
+++ b/app/sansu-100/lib/problem-generator.ts
@@ -70,9 +70,12 @@ export function generateOne(level: LevelDef, rng: Rng): Problem {
         if (dividend < rangeA[0] || dividend > rangeA[1]) continue;
         return { a: dividend, b: divisor, op: 'div', answer: q };
       }
-      // with remainder: answer is the integer quotient
+      // あまりあり: 商(answer)とあまり(remainder)の両方を答える。
+      // 「あまりあり」レベルなので、割り切れる問題は除外して必ずあまりを出す。
       if (b === 0) continue;
-      return { a, b, op: 'div', answer: Math.floor(a / b) };
+      const remainder = a % b;
+      if (remainder === 0) continue;
+      return { a, b, op: 'div', answer: Math.floor(a / b), remainder };
     }
   }
 

--- a/app/sansu-100/lib/types.ts
+++ b/app/sansu-100/lib/types.ts
@@ -19,10 +19,14 @@ export type Problem = {
   b: number;
   op: Exclude<Operation, 'mixed'>;
   answer: number;
+  // あまりあり割り算のときだけ設定（商=answer・あまり=remainder の両方を答える）。
+  remainder?: number;
 };
 
 export type AnsweredProblem = Problem & {
   userAnswer: number;
+  // あまりあり割り算で子どもが入力したあまり（answer は商の入力）。
+  userRemainder?: number;
   isCorrect: boolean;
   timeMs: number;
 };

--- a/app/sansu-100/play/page.tsx
+++ b/app/sansu-100/play/page.tsx
@@ -116,6 +116,11 @@ function PlaySession({
     isDaily,
   });
   const [input, setInput] = useState('');
+  // あまりあり割り算用: あまりの入力と、入力中のマス
+  const [remInput, setRemInput] = useState('');
+  const [activeField, setActiveField] = useState<'quotient' | 'remainder'>(
+    'quotient'
+  );
   const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
   const [showRetire, setShowRetire] = useState(false);
   const [retiring, setRetiring] = useState(false);
@@ -123,18 +128,31 @@ function PlaySession({
   // state より先に効く ref で1回だけ確定させる。
   const finalizingRef = useRef(false);
 
+  const isRemainderMode = session.currentProblem?.remainder !== undefined;
+
   const judge = useCallback(
-    (value: string, isSkip = false) => {
-      if (!session.currentProblem) return;
-      const n = Number.parseInt(value, 10);
-      if (Number.isNaN(n) && !isSkip) return;
-      const answer = session.currentProblem.answer;
-      const isCorrect = !isSkip && n === answer;
+    (q: string, rem: string, isSkip = false) => {
+      const p = session.currentProblem;
+      if (!p) return;
+      const remMode = p.remainder !== undefined;
+      const n = Number.parseInt(q, 10);
+      const r = Number.parseInt(rem, 10);
+      if (!isSkip) {
+        if (Number.isNaN(n)) return;
+        if (remMode && Number.isNaN(r)) return;
+      }
+      const isCorrect =
+        !isSkip && n === p.answer && (!remMode || r === p.remainder);
       setFeedback(isCorrect ? 'correct' : 'wrong');
       setTimeout(
         () => {
-          session.submitAnswer(isSkip ? -1 : n);
+          session.submitAnswer(
+            isSkip ? -1 : n,
+            !isSkip && remMode ? r : undefined
+          );
           setInput('');
+          setRemInput('');
+          setActiveField('quotient');
           setFeedback(null);
         },
         isCorrect ? 200 : 500
@@ -143,23 +161,37 @@ function PlaySession({
     [session]
   );
 
-  // Auto-judge when input matches the answer
+  // キーパッド入力: いま入力中のマスに反映し、答えがそろったら自動で正解判定する。
   const handleInputChange = useCallback(
     (v: string) => {
+      const p = session.currentProblem;
+      if (!p || feedback) return;
+      const remMode = p.remainder !== undefined;
+      if (remMode && activeField === 'remainder') {
+        setRemInput(v);
+        const r = Number.parseInt(v, 10);
+        if (r === p.remainder && Number.parseInt(input, 10) === p.answer) {
+          judge(input, v, false);
+        }
+        return;
+      }
+      // 商（または通常の答え）のマス
       setInput(v);
-      if (!session.currentProblem || feedback) return;
       const n = Number.parseInt(v, 10);
-      if (!Number.isNaN(n) && n === session.currentProblem.answer) {
-        judge(v, false);
+      if (remMode) {
+        // 商が合ったら自動であまりのマスへ進む
+        if (n === p.answer) setActiveField('remainder');
+      } else if (n === p.answer) {
+        judge(v, '', false);
       }
     },
-    [session.currentProblem, feedback, judge]
+    [session.currentProblem, feedback, activeField, input, judge]
   );
 
   const handleSkip = useCallback(() => {
     if (feedback) return;
-    judge(input, true);
-  }, [feedback, input, judge]);
+    judge(input, remInput, true);
+  }, [feedback, input, remInput, judge]);
 
   useEffect(() => {
     if (!session.isComplete || finalizingRef.current || !user) return;
@@ -334,14 +366,26 @@ function PlaySession({
           {session.currentProblem ? <ProblemDisplay
               problem={session.currentProblem}
               userInput={input}
+              remainderInput={remInput}
+              activeField={activeField}
+              onFocusField={isRemainderMode ? setActiveField : undefined}
               feedback={feedback}
             /> : null}
         </div>
 
+        {isRemainderMode ? (
+          <p className="text-center text-sm font-semibold text-blue-600 dark:text-blue-300">
+            商（こたえ）と あまり の りょうほうを いれてね
+          </p>
+        ) : null}
+
         <NumberKeypad
-          value={input}
+          value={
+            isRemainderMode && activeField === 'remainder' ? remInput : input
+          }
           onChange={handleInputChange}
           onSkip={handleSkip}
+          maxLen={isRemainderMode ? (activeField === 'remainder' ? 1 : 2) : 4}
           disabled={feedback !== null || session.isComplete}
         />
 


### PR DESCRIPTION
レベル11「2けた÷1けた（あまりあり）」が壊れていた不具合の修正（ユーザー報告）。

## 症状
- **余りを書く欄が無い**（商しか入れられない）
- **商だけ入力すると自動で正解**になり、余りを問わない

## 原因
あまりあり割り算の答えが商のみ（`answer = floor(a/b)`）で、`a % b` を捨てていた。

## 修正
- `Problem` に `remainder` を追加。生成は `a % b !== 0` を保証（あまりありレベルは必ず余りが出る）。
- `ProblemDisplay` に「あまり」スロットを追加（商マス／余りマスの2入力。タップで切替・アクティブ表示）。横長になるので余りモードは文字を少し縮小し一行に収める。
- `play`: 商と余りの2フィールド。**商が合うと自動で余りマスへ進み、両方一致で正解**。片方だけでは正解にならない。キーパッドは商2桁/余り1桁に制限。
- `submitAnswer` に `userRemainder` を追加し、商＋余りの両方一致で `isCorrect`。

## 検証
- iPhone相当: 商だけでは進まない／商＋余りで進む（連続3問OK）／一行レイアウト（スクショ確認）
- テスト: Level11 で `remainder=a%b`・余り>0・`a=商*b+余り` を検証
- lint・ビルド緑 / テスト161件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)