### PR TITLE
feat(sansu-100): 着せ替え画面に時間課金（3分10コイン・尽きたら保存して戻る）

### DIFF
--- a/api/src/shared/minigame.ts
+++ b/api/src/shared/minigame.ts
@@ -1,11 +1,12 @@
 // ミニゲームのコイン消費コスト（サーバーが正）。クライアントは reason だけ送り、
 // 金額はサーバーが引く（参加費の改ざん防止）。クライアント側 app/sansu-100/lib/minigame-economy.ts と一致させること。
 
-export type SpendReason = 'play' | 'continue';
+export type SpendReason = 'play' | 'continue' | 'dressup';
 
 export const SPEND_COSTS: Record<SpendReason, number> = {
   play: 10, // 1プレイの参加費
   continue: 15, // ゲームオーバー後のコンティニュー
+  dressup: 10, // 着せ替え画面の時間課金（一定時間ごと）
 };
 
 export function getSpendCost(reason: string): number | undefined {

--- a/app/sansu-100/avatar/page.tsx
+++ b/app/sansu-100/avatar/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
 import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
 import AvatarDisplay from '../components/AvatarDisplay';
+import CoinBalance from '../components/CoinBalance';
 import DiceBearAvatar from '../components/DiceBearAvatar';
 import { useSansuUser } from '../hooks/useSansuUser';
 import { sansuApi } from '../lib/api-client';
@@ -24,6 +25,10 @@ import {
   ownedValuesOf,
 } from '../lib/avatar-shop';
 import { normalizeAvatarConfig } from '../lib/avatar-svg';
+import {
+  DRESSUP_CHARGE_COINS,
+  DRESSUP_CHARGE_INTERVAL_SEC,
+} from '../lib/minigame-economy';
 import { sound } from '../lib/sound-presets';
 import { storage } from '../lib/storage';
 import type { AvatarConfig } from '../lib/types';
@@ -70,6 +75,86 @@ export default function AvatarBuilderPage(): React.JSX.Element {
 
   // 変更があってまだ保存していない＝離脱時に確認する
   const dirty = draft !== null && !saved;
+
+  // --- 着せ替えの時間課金（一定時間ごとに 10コイン。尽きたら強制保存して戻る）---
+  // テスト用に ?chargesec=N で間隔を短縮できる（既定 180秒）。
+  const [chargeInterval] = useState(() => {
+    if (typeof window === 'undefined') return DRESSUP_CHARGE_INTERVAL_SEC;
+    const q = new URLSearchParams(window.location.search).get('chargesec');
+    const n = q ? Number.parseInt(q, 10) : NaN;
+    return !Number.isNaN(n) && n > 0 ? n : DRESSUP_CHARGE_INTERVAL_SEC;
+  });
+  const [secsLeft, setSecsLeft] = useState(chargeInterval);
+  const [kicked, setKicked] = useState(false);
+  const secsRef = useRef(chargeInterval);
+  const chargingRef = useRef(false);
+  const leavingRef = useRef(false);
+  // 強制保存で使う「いまの見た目」と「ユーザー」を常に最新に保つ。
+  const configRef = useRef(config);
+  configRef.current = config;
+  const userRef = useRef(currentUser);
+  userRef.current = currentUser;
+
+  useEffect(() => {
+    if (!loaded || !userRef.current) return;
+    secsRef.current = chargeInterval;
+    setSecsLeft(chargeInterval);
+    let stopped = false;
+
+    const forceSaveAndLeave = async (): Promise<void> => {
+      if (leavingRef.current) return;
+      leavingRef.current = true;
+      stopped = true;
+      setKicked(true);
+      const u = userRef.current;
+      if (u) {
+        try {
+          await sansuApi.setAvatarConfig(u.id, configRef.current);
+        } catch {
+          // 通信不可でもローカルには保存される（あとで同期）
+          storage.upsertUser({ ...u, avatarConfig: configRef.current });
+        }
+      }
+      window.setTimeout(() => router.replace('/sansu-100'), 1400);
+    };
+
+    const charge = async (): Promise<void> => {
+      if (stopped || chargingRef.current || leavingRef.current) return;
+      const uid = userRef.current?.id;
+      if (!uid) return;
+      chargingRef.current = true;
+      try {
+        const res = await sansuApi.spend(uid, 'dressup');
+        if (res.ok && res.user) {
+          saveUser(res.user);
+        } else {
+          await forceSaveAndLeave();
+        }
+      } catch {
+        // 通信不可は課金せず次の周期で再試行
+      } finally {
+        chargingRef.current = false;
+      }
+    };
+
+    const id = window.setInterval(() => {
+      if (stopped) return;
+      secsRef.current -= 1;
+      if (secsRef.current <= 0) {
+        secsRef.current = chargeInterval;
+        void charge();
+      }
+      setSecsLeft(secsRef.current);
+    }, 1000);
+
+    return () => {
+      stopped = true;
+      window.clearInterval(id);
+    };
+    // currentUser はコイン更新で毎回変わるが id は不変。userRef 経由で最新を見るので
+    // ここでは loaded のときに1回だけタイマーを張る。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded, chargeInterval, router, saveUser]);
 
   const owned = useMemo(() => currentUser?.ownedItems ?? [], [currentUser]);
 
@@ -171,6 +256,28 @@ export default function AvatarBuilderPage(): React.JSX.Element {
           onBackClick={() => requestNavigate('/sansu-100')}
         />
 
+        <section
+          className={`flex items-center justify-between gap-2 rounded-2xl px-4 py-3 shadow-sm ${
+            (currentUser.coins ?? 0) < DRESSUP_CHARGE_COINS
+              ? 'bg-red-50 dark:bg-red-900/30'
+              : 'bg-amber-50 dark:bg-amber-900/30'
+          }`}
+          data-testid="dressup-charge"
+        >
+          <div className="text-sm font-bold text-amber-800 dark:text-amber-200">
+            ⏱️ きせかえタイム のこり{' '}
+            <span data-testid="dressup-secs">
+              {Math.floor(secsLeft / 60)}:
+              {String(secsLeft % 60).padStart(2, '0')}
+            </span>
+            <span className="ml-1 font-normal text-gray-500 dark:text-gray-400">
+              （{Math.round(chargeInterval / 60) || 1}ふんで 🪙
+              {DRESSUP_CHARGE_COINS}）
+            </span>
+          </div>
+          <CoinBalance coins={currentUser.coins ?? 0} size="sm" />
+        </section>
+
         <section className="flex flex-col items-center gap-2 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
           <AvatarDisplay user={previewUser} size="xl" />
           <button
@@ -265,6 +372,29 @@ export default function AvatarBuilderPage(): React.JSX.Element {
           {busy ? 'ほぞんちゅう…' : saved ? '✅ ほぞんしたよ！' : '💾 このキャラにする'}
         </button>
       </div>
+
+      {kicked ? (
+        <div
+          className="fixed inset-0 z-[80] flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          data-testid="dressup-kicked"
+        >
+          <div className="w-full max-w-xs space-y-2 rounded-2xl bg-white p-6 text-center shadow-xl dark:bg-gray-800">
+            <p className="text-4xl" aria-hidden>
+              🪙
+            </p>
+            <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
+              コインが なくなったよ
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              いまの すがたを ほぞんして もどるね。
+              <br />
+              また あそんで コインを ためてね！
+            </p>
+          </div>
+        </div>
+      ) : null}
 
       {pendingHref !== null ? (
         <div

--- a/app/sansu-100/lib/api-client.ts
+++ b/app/sansu-100/lib/api-client.ts
@@ -150,7 +150,7 @@ export const sansuApi = {
   // ミニゲームの参加費/コンティニュー。残高不足は409→error返し。
   async spend(
     userId: string,
-    reason: 'play' | 'continue'
+    reason: 'play' | 'continue' | 'dressup'
   ): Promise<{ ok: boolean; user?: SansuUserPublic; error?: string }> {
     try {
       return await jsonFetch<{ ok: boolean; user?: SansuUserPublic }>(

--- a/app/sansu-100/lib/minigame-economy.ts
+++ b/app/sansu-100/lib/minigame-economy.ts
@@ -4,6 +4,7 @@
 export const SPEND_COSTS = {
   play: 10, // 1プレイの参加費
   continue: 15, // ゲームオーバー後のコンティニュー
+  dressup: 10, // 着せ替え画面の時間課金（一定時間ごと）
 } as const;
 
 export type SpendReason = keyof typeof SPEND_COSTS;
@@ -11,3 +12,7 @@ export type SpendReason = keyof typeof SPEND_COSTS;
 // 算数ゲート: 算数を解かないとミニゲームは遊べない。算数1回で +5、1プレイで1消費。
 export const MINIGAME_PLAYS_PER_MATH = 5;
 export const MINIGAME_CREDITS_CAP = 15;
+
+// 着せ替えの時間課金: 一定時間ごとに dressup コインを引く。尽きたら強制保存して戻る。
+export const DRESSUP_CHARGE_INTERVAL_SEC = 180; // 3分
+export const DRESSUP_CHARGE_COINS = SPEND_COSTS.dressup; // 1回 10コイン


### PR DESCRIPTION
着せ替え（キャラをつくる）画面に**滞在時間の課金**を追加。

## 仕組み
- 一定時間ごと（既定**3分** = `DRESSUP_CHARGE_INTERVAL_SEC`）に **dressup として10コイン**を消費。
- 残りコインが足りなくなったら、**いまの見た目を強制保存**（`setAvatarConfig`／通信不可ならローカル保存）して**ホームへ自動で戻る**。「コインが なくなったよ」オーバーレイを表示。
- 画面上部に「⏱️ きせかえタイム のこり M:SS（3ふんで 🪙10）」＋コイン残高。残高が10未満は赤帯で警告。
- spend理由 `'dressup'`(=10) をサーバー/クライアント両方に追加（算数ゲートの対象外）。

## 検証
- iPhone相当: 25コイン→課金で15→5→不足で kick→ホーム遷移、変更(eyes)がサーバーに保存されることを確認
- テスト容易化のため `?chargesec=N` で課金間隔を短縮可能（本番は既定180秒）
- lint・ビルド(front/api)緑 / テスト161件緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)