### PR TITLE
fix(sansu-100): ログイン/選択画面のアイコンを作成アバターに統一＋E2E追加

### DIFF
--- a/app/sansu-100/login/page.tsx
+++ b/app/sansu-100/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
+import AvatarDisplay from '../components/AvatarDisplay';
 import PinPad from '../components/PinPad';
 import { useSansuUser } from '../hooks/useSansuUser';
 import { sansuApi } from '../lib/api-client';
@@ -105,7 +106,7 @@ export default function LoginPage(): React.JSX.Element {
         ) : (
           <div className="space-y-4 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
             <div className="flex flex-col items-center gap-2">
-              <span className="text-6xl">{foundUser.avatar}</span>
+              <AvatarDisplay user={foundUser} size="lg" />
               <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">
                 {foundUser.name}
               </h3>

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -243,7 +243,7 @@ export default function SansuHome(): React.JSX.Element {
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex flex-col items-center gap-2">
-                <span className="text-6xl">{selectingUser.avatar}</span>
+                <AvatarDisplay user={selectingUser} size="lg" />
                 <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">
                   {selectingUser.name} の あいことば
                 </h3>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:e2e:swa:headed": "npx playwright test --config=playwright.config.swa.ts --headed",
     "test:e2e:no-auth": "WITH_API=true npx playwright test --config=playwright.config.no-auth.ts",
     "test:e2e:no-auth:headed": "WITH_API=true npx playwright test --config=playwright.config.no-auth.ts --headed",
+    "test:e2e:sansu": "npx playwright test --config=playwright.config.sansu.ts",
+    "test:e2e:sansu:headed": "npx playwright test --config=playwright.config.sansu.ts --headed",
     "dev:with-api": "npm run build:api && swa start http://localhost:3000 --api-location api --run \"npm run dev\"",
     "sansu:stop": "pkill -f 'azurite' 2>/dev/null; pkill -f 'swa start' 2>/dev/null; pkill -f 'func start' 2>/dev/null; lsof -ti:4280,7071,3000,10000,10001,10002 | xargs kill -9 2>/dev/null; sleep 1; echo 'stopped.'",
     "sansu:dev": "npm run sansu:stop && mkdir -p /tmp/azurite-sansu && (azurite --location /tmp/azurite-sansu --loose > /tmp/azurite.log 2>&1 &) && sleep 1 && npm run build:api && swa start http://localhost:3000 --api-location api --run \"npm run dev\"",

--- a/playwright.config.no-auth.ts
+++ b/playwright.config.no-auth.ts
@@ -6,8 +6,8 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
-  /* 認証エミュレーターテストを除外 */
-  testIgnore: '**/auth-emulator.spec.ts',
+  /* 認証エミュレーター・sansu-100専用テストを除外 */
+  testIgnore: ['**/auth-emulator.spec.ts', '**/sansu/**'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.sansu.ts
+++ b/playwright.config.sansu.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * sansu-100（100マス計算）用の E2E 設定。
+ * ローカル SWA 環境（azurite + Azure Functions + Next.js）を ポート4280 で起動し、
+ * 登録・アバター表示・ログインのフローを検証する。
+ *
+ * 実行: `npm run test:e2e:sansu`
+ * （すでに `npm run sansu:dev` を起動済みなら、それを再利用する）
+ */
+export default defineConfig({
+  testDir: './tests/sansu',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'list' : 'html',
+  use: {
+    baseURL: 'http://localhost:4280',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], headless: true },
+    },
+  ],
+  /* ローカル SWA 環境を自動起動（起動済みなら再利用）。初回は azurite/func/next の
+     ビルド・起動で時間がかかるためタイムアウトを長めにとる。 */
+  webServer: {
+    command: 'npm run sansu:dev',
+    port: 4280,
+    reuseExistingServer: true,
+    timeout: 240000,
+    stdout: 'ignore',
+    stderr: 'ignore',
+  },
+  outputDir: 'test-results/sansu',
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,8 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
+  /* sansu-100 の E2E は専用設定(playwright.config.sansu.ts)で実行する */
+  testIgnore: '**/sansu/**',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/sansu/avatar.spec.ts
+++ b/tests/sansu/avatar.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * 登録 → 作成アバター(SVG)表示 → 選択ダイアログ → ログイン のE2E。
+ *
+ * 重要:
+ * - 本番に実在するユーザ（例: たくみ）は触らない。毎回ユニークな名前のテストユーザを新規作成する。
+ * - 「作成アバター」は DiceBearAvatar が <svg> を描画する。旧バグでは絵文字テキストのみで
+ *   <svg> が無かった（ログイン画面・選択ダイアログ）。このテストは avatar 部分に <svg> が
+ *   出ることを検証し、回帰を防ぐ。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  // 適当な（ただし衝突しない）テスト名。名前は12文字までなので短くする。
+  // 本番ユーザ名（たくみ 等）と被らないよう接頭辞 E2E をつける。
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `E2E${suffix}`; // 例: E2E834625（9文字）
+}
+
+async function enterPin(page: Page, pin: string, confirmLabel: string) {
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of pin) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: confirmLabel }).click();
+}
+
+// AvatarDisplay 経由の「作成アバター」は <svg> を含む。emoji フォールバックは <span> のみ。
+async function expectBuiltAvatar(page: Page, name: string) {
+  const avatar = page.locator(`[aria-label="${name}のアバター"]`).first();
+  await expect(avatar).toBeVisible();
+  await expect(avatar.locator('svg')).toBeVisible();
+}
+
+test.describe('sansu-100 登録・アバター・ログイン', () => {
+  test('登録すると作成アバター(SVG)で表示され、選択ダイアログ・ログインでも同じアバターが出る', async ({
+    page,
+  }) => {
+    const name = uniqueName();
+    // Playwright は各テストで隔離コンテキスト（localStorage 空）なので明示クリアは不要。
+    // ただしローカルの dev-seed が「たろう」を作って自動ログインしてしまうため、
+    // seed のガード(sessionStorage)を先に立てて無効化する（テスト専用・アプリ非変更）。
+    await page.addInitScript(() => {
+      try {
+        sessionStorage.setItem('sansu-100:dev-seeded', '1');
+      } catch {
+        /* ignore */
+      }
+    });
+
+    // --- 登録 ---
+    await page.goto('/sansu-100/register');
+    await page.getByTestId('register-name-input').fill(name);
+    await page.getByTestId('register-name-next').click();
+    await enterPin(page, PIN, 'これでとうろく！');
+
+    // ホームへ遷移。あいさつのアバターが作成アバター(SVG)であること。
+    await page.waitForURL('**/sansu-100');
+    await expectBuiltAvatar(page, name);
+
+    // --- 選択（ログイン）ダイアログ: ログアウト状態で recentUsers から選ぶ ---
+    await page.evaluate(() => localStorage.removeItem('sansu-100:current-user'));
+    await page.goto('/sansu-100');
+    await page.waitForLoadState('networkidle');
+    const tile = page.locator('[data-testid^="user-tile-"]').first();
+    await expect(tile).toBeVisible();
+    await expect(tile.locator('svg')).toBeVisible(); // タイルも作成アバター
+    // ハイドレーション/再レンダの落ち着きを待ってからクリック（要素のdetach回避）
+    await page.waitForTimeout(600);
+    await tile.click();
+    await expect(page.locator('[data-testid=pin-pad]')).toBeVisible();
+    await expectBuiltAvatar(page, name); // ← 旧バグ(絵文字のみ)では失敗する箇所
+
+    // あいことばを入れてログイン
+    await enterPin(page, PIN, 'これでOK！');
+    await page.waitForURL('**/sansu-100');
+    await expectBuiltAvatar(page, name);
+
+    // --- 名前さがしのログイン画面でも作成アバターが出る ---
+    await page.evaluate(() => localStorage.removeItem('sansu-100:current-user'));
+    await page.goto('/sansu-100/login');
+    await page.getByRole('textbox').first().fill(name);
+    await page.getByRole('button', { name: 'さがす' }).click();
+    await expect(page.locator('[data-testid=pin-pad]')).toBeVisible();
+    await expectBuiltAvatar(page, name); // ← 旧バグ(絵文字のみ)では失敗する箇所
+
+    await enterPin(page, PIN, 'これでOK！');
+    await page.waitForURL('**/sansu-100');
+  });
+});


### PR DESCRIPTION
ログインまわりで**作成アバターが出ず旧絵文字アイコンが残る**不具合の修正（ユーザー報告）＋E2E追加。

## 原因
- ログイン画面 `login/page.tsx` と ホームのPIN入力ダイアログ `page.tsx` が、`AvatarDisplay` を使わず**旧 `user.avatar`(絵文字)を直接表示**していた。
- 他の画面（ホームのあいさつ・ユーザータイル・ショップ・着せ替え）は `AvatarDisplay` 済みだったため、ここだけ古いアイコンが残っていた。

## 修正
- 両箇所を `<AvatarDisplay user={...} size="lg" />` に置換（`avatarConfig` があれば作成アバターSVG、無ければ絵文字フォールバック）。

## E2E（組み込みテスト）を追加
- `tests/sansu/avatar.spec.ts`: **適当な名前のテストユーザを毎回新規登録**し、ホームのあいさつ／選択ダイアログ／名前さがしログインの各アバターがすべて**作成アバター(SVG)**で出ることを検証。旧バグ（絵文字のみ＝SVG無し）では失敗する。**本番の実ユーザ（たくみ等）は一切触らない。**
- `playwright.config.sansu.ts`（ローカルSWA env, :4280）＋ `npm run test:e2e:sansu`。既存 e2e 設定からは `tests/sansu` を `testIgnore` で除外。
- ローカル dev-seed の自動ログインはテスト内で seed ガードを立てて無効化。

## 検証
- `npm run test:e2e:sansu` を3回連続で安定パス
- lint・ビルド緑 / vitest 161件緑

## 補足（CI）
本E2Eは azurite+Functions+SWA のローカル環境が要るため、現状は**ローカル実行スクリプト**として提供（既存の他E2Eも同様にCI外）。CIへの組み込みは別途インフラ対応が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)