### PR TITLE
fix(sansu-100): ユーザー固有の旧絵文字アイコンを排除（ゲームは固定キャラ）

### DIFF
--- a/app/sansu-100/admin999/page.tsx
+++ b/app/sansu-100/admin999/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 
 import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
+import AvatarDisplay from '../components/AvatarDisplay';
 import { sansuAdminApi, type AdminUserSummary } from '../lib/api-client';
 
 type Summary = {
@@ -87,7 +88,7 @@ export default function SansuAdmin999Home(): React.JSX.Element {
                     className="block rounded-xl border border-gray-200 bg-gray-50 p-4 transition-colors hover:bg-blue-50 dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700"
                   >
                     <div className="flex items-center gap-3">
-                      <span className="text-5xl">{u.avatar}</span>
+                      <AvatarDisplay user={u} size="md" />
                       <div className="min-w-0 flex-1">
                         <h3 className="font-bold text-gray-900 dark:text-gray-100">
                           {u.name}

--- a/app/sansu-100/admin999/user/page.tsx
+++ b/app/sansu-100/admin999/user/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 import Header from '../../../components/header';
 import ThemeToggle from '../../../components/theme-toggle';
+import AvatarDisplay from '../../components/AvatarDisplay';
 import PinPad from '../../components/PinPad';
 import { formatDuration } from '../../components/SessionTimer';
 import {
@@ -76,7 +77,7 @@ function UserDetailInner(): React.JSX.Element {
       </div>
       <div className="container mx-auto max-w-2xl space-y-6 px-4 py-8">
         <Header
-          title={`${user.avatar} ${user.name}`}
+          title={user.name}
           description="ユーザー詳細・リカバリー操作"
           showBackButton
           backHref="/sansu-100/admin999"
@@ -86,7 +87,7 @@ function UserDetailInner(): React.JSX.Element {
         {/* Identity card */}
         <section className="space-y-4 rounded-2xl bg-white p-6 shadow-md dark:bg-gray-800">
           <div className="flex items-center gap-4">
-            <span className="text-7xl">{user.avatar}</span>
+            <AvatarDisplay user={user} size="lg" />
             <div className="flex-1 space-y-1 text-sm text-gray-700 dark:text-gray-300">
               <p>
                 <strong>名前:</strong> {user.name}
@@ -217,7 +218,7 @@ function UserDetailInner(): React.JSX.Element {
             <p className="text-sm text-gray-500 dark:text-gray-400">
               この子のアバターはこれ
             </p>
-            <span className="text-9xl">{user.avatar}</span>
+            <AvatarDisplay user={user} size="xl" />
             <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
               {user.name}
             </p>

--- a/app/sansu-100/games/FallingGame.tsx
+++ b/app/sansu-100/games/FallingGame.tsx
@@ -54,10 +54,10 @@ function draw(
   );
 }
 
-// おちものよけ。プレイヤー(アバター)を左右に動かして いわ をよける。
+// おちものよけ。プレイヤー(固定キャラ)を左右に動かして いわ をよける。
 export default function FallingGame({
   onGameOver,
-  avatar = '🐰',
+  avatar = '🐱',
 }: {
   onGameOver: (score: number) => void;
   avatar?: string;

--- a/app/sansu-100/history/page.tsx
+++ b/app/sansu-100/history/page.tsx
@@ -38,7 +38,7 @@ export default function HistoryPage(): React.JSX.Element {
       </div>
       <div className="container mx-auto max-w-3xl space-y-6 px-4 py-8">
         <Header
-          title={`${currentUser.avatar} ${currentUser.name} のきろく`}
+          title={`${currentUser.name} のきろく`}
           description={`累計 ${currentUser.totalSessions}回 / ${currentUser.totalPoints}pt`}
           showBackButton
           backHref="/sansu-100"

--- a/app/sansu-100/minigame/falling/page.tsx
+++ b/app/sansu-100/minigame/falling/page.tsx
@@ -142,7 +142,6 @@ export default function FallingPage(): React.JSX.Element {
             <FallingGame
               key={round}
               onGameOver={handleGameOver}
-              avatar={currentUser.avatar}
             />
           </section>
         ) : null}

--- a/app/sansu-100/minigame/flappy/page.tsx
+++ b/app/sansu-100/minigame/flappy/page.tsx
@@ -147,7 +147,6 @@ export default function FlappyPage(): React.JSX.Element {
             <FlappyGame
               key={round}
               onGameOver={handleGameOver}
-              avatar={currentUser.avatar}
             />
           </section>
         ) : null}

--- a/app/sansu-100/minigame/maze/page.tsx
+++ b/app/sansu-100/minigame/maze/page.tsx
@@ -146,7 +146,6 @@ export default function MazePage(): React.JSX.Element {
               key={round}
               onScore={setLiveScore}
               onGameOver={handleGameOver}
-              avatar={currentUser.avatar}
             />
           </section>
         ) : null}

--- a/app/sansu-100/minigame/runner/page.tsx
+++ b/app/sansu-100/minigame/runner/page.tsx
@@ -142,7 +142,6 @@ export default function RunnerPage(): React.JSX.Element {
             <RunnerGame
               key={round}
               onGameOver={handleGameOver}
-              avatar={currentUser.avatar}
             />
           </section>
         ) : null}


### PR DESCRIPTION
「作成アバターに統一・ユーザー固有の旧絵文字アイコンを全部なくす」方針の続き（#70の続き）。

## 方針（ユーザー確認済み）
- ゲーム画面のキャラは**固定でOK**（ログインユーザーごとに変える必要なし）
- それ以外の**ユーザー固有の旧絵文字アイコンは全部排除**

## 変更
- ミニゲーム（よけよけランナー/おちものよけ/めいろ/フラッピー）: プレイヤーをログインユーザーの絵文字ではなく**各ゲーム固定のキャラ**に（`avatar` 受け渡しを廃止、既存の固定デフォルト 🦖/🐱/🐰/🐤 を使用。おちものよけは迷路と被らないよう 🐱）。
- きろく画面タイトル: 先頭の絵文字を削除（名前のみ）。
- admin999（管理画面）: 一覧・詳細の絵文字を `AvatarDisplay`（作成アバター）に置換。

これでユーザー固有の絵文字直書きは `AvatarDisplay` 内のフォールバック（avatarConfig 未設定の旧ユーザー保険）のみ。

## 検証
- lint・ビルド緑 / vitest 161件緑 / `npm run test:e2e:sansu` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)