### PR TITLE
feat(seo): 100マス計算ページのSEO対応一式

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,11 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  title: 'URL本文抽出アプリ',
+  metadataBase: new URL('https://snap-content.takumi-oda.com'),
+  title: {
+    default: 'URL本文抽出アプリ',
+    template: '%s | snap-content',
+  },
   description: 'URLからウェブページの本文を簡単に抽出できるアプリケーション',
   manifest: '/manifest.json',
   appleWebApp: {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://snap-content.takumi-oda.com';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/authenticated/', '/api/'],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/app/sansu-100/layout.tsx
+++ b/app/sansu-100/layout.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+
+const title = '100マス計算｜無料の計算ドリル・タイム計測アプリ';
+const description =
+  '足し算・引き算・掛け算の100マス計算を無料でできる学習アプリ。タイムを計測してベスト記録を更新、毎日の計算練習を習慣化できます。スマホ・タブレット・PWA対応で小学生の計算力アップに。';
+
+export const metadata: Metadata = {
+  title: { absolute: title },
+  description,
+  keywords: [
+    '100マス計算',
+    '百マス計算',
+    '計算ドリル',
+    '計算練習',
+    '足し算',
+    '引き算',
+    '掛け算',
+    '小学生',
+    'タイム計測',
+    '無料',
+  ],
+  alternates: {
+    canonical: '/sansu-100',
+  },
+  openGraph: {
+    type: 'website',
+    url: 'https://snap-content.takumi-oda.com/sansu-100',
+    title,
+    description,
+    siteName: 'snap-content',
+    locale: 'ja_JP',
+    images: [
+      {
+        url: '/icons/icon-512x512.png',
+        width: 512,
+        height: 512,
+        alt: '100マス計算',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary',
+    title,
+    description,
+    images: ['/icons/icon-512x512.png'],
+  },
+};
+
+export default function Sansu100Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return <>{children}</>;
+}

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -91,10 +91,65 @@ export default function SansuHome(): React.JSX.Element {
     }
   };
 
-  if (!loaded) return <main className="p-8" />;
+  // 構造化データ（検索エンジン向け）。ローディング状態に関わらず常に静的HTMLに出力する。
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: '100マス計算',
+    url: 'https://snap-content.takumi-oda.com/sansu-100',
+    description:
+      '足し算・引き算・掛け算の100マス計算を無料でできる学習アプリ。タイムを計測してベスト記録を更新し、毎日の計算練習を習慣化できます。',
+    applicationCategory: 'EducationalApplication',
+    operatingSystem: 'Web',
+    inLanguage: 'ja',
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'JPY',
+    },
+  };
+
+  // SEO向けの説明コンテンツ。クローラが評価できる本文として常に出力する。
+  const seoIntro = (
+    <section className="sr-only">
+      <h1>100マス計算 ｜ 無料の計算ドリル・タイム計測アプリ</h1>
+      <p>
+        100マス計算（百マス計算）は、足し算・引き算・掛け算を素早く解いて計算力をきたえる定番のトレーニングです。
+        本アプリは無料で使え、解き終わるまでのタイムを自動で計測し、ベスト記録の更新を目指して毎日の計算練習を習慣化できます。
+      </p>
+      <h2>このアプリでできること</h2>
+      <ul>
+        <li>足し算・引き算・掛け算の100マス計算をブラウザですぐに開始</li>
+        <li>解答タイムの自動計測とベスト記録の保存</li>
+        <li>練習の履歴やバッジで毎日のがんばりを見える化</li>
+        <li>スマホ・タブレット・PCに対応、PWAでアプリのように利用可能</li>
+      </ul>
+      <h2>こんな方におすすめ</h2>
+      <p>
+        小学生の計算力アップ、毎日の計算ドリルの習慣づけ、大人の脳トレや暗算トレーニングにも活用できます。
+      </p>
+    </section>
+  );
+
+  if (!loaded)
+    return (
+      <main className="p-8">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+        {seoIntro}
+      </main>
+    );
 
   return (
     <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {seoIntro}
       <div className="absolute right-4 top-4">
         <ThemeToggle />
       </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://snap-content.takumi-oda.com';
+
+export const dynamic = 'force-static';
+
+// 公開・インデックス対象の主要ページのみを列挙する。
+// ログインやプレイ中などのアプリ状態ページ（/sansu-100/play 等）は含めない。
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date('2026-06-30');
+
+  return [
+    {
+      url: `${BASE_URL}/`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/sansu-100`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/url-extractor`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${BASE_URL}/link-collector`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+  ];
+}

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -12,7 +12,9 @@
             "/sw.js",
             "/workbox-*.js",
             "/manifest.json",
-            "/icons/*"
+            "/icons/*",
+            "/robots.txt",
+            "/sitemap.xml"
         ]
     },
     "routes": [


### PR DESCRIPTION
## 概要
100マス計算（/sansu-100）が検索に引っかからない原因を調査し、SEOの土台を一通り整備しました。

### 修正前の問題
- 全ページのタイトルが `URL本文抽出アプリ` 固定で、sansu-100 にも「100マス計算」の語が一切無かった
- `metadataBase` 未設定で canonical / OGP の絶対URLが生成できない
- robots.txt / sitemap.xml が実在せず、SWAのフォールバックでSPAのHTMLが返っていた
- `if (!loaded) return` の早期returnにより、静的HTMLに本文がほぼ無かった（クロール材料ゼロ）

### 変更内容
- `app/layout.tsx`: `metadataBase`（本番ドメイン）とタイトルテンプレートを追加
- `app/sansu-100/layout.tsx` (新規): 100マス計算専用の title / description / keywords / canonical / OGP / Twitterカード
- `app/robots.ts` (新規): robots.txt を静的生成（/authenticated, /api を除外、sitemap明示）
- `app/sitemap.ts` (新規): sitemap.xml を静的生成（公開4ページ、sansu-100 を priority 1.0）
- `staticwebapp.config.json`: robots.txt / sitemap.xml をフォールバック除外に追加
- `app/sansu-100/page.tsx`: h1・説明本文・JSON-LD(WebApplication) を追加し、ローディング前でも静的HTMLに出力されるよう修正

### 検証
- `npm run build`（Node 22）成功。`out/` で robots.txt / sitemap.xml / sansu-100 の title・description・canonical・OGP・h1・JSON-LD・本文が静的HTMLに出力されていることを確認済み。

### デプロイ後の手動作業
- Google Search Console でサイトマップ送信＋URL検査（別途対応中）

🤖 Generated with [Claude Code](https://claude.com/claude-code)