### PR TITLE
feat(seo): Google Search Console 所有権確認メタタグを追加

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,9 @@ export const metadata: Metadata = {
   },
   description: 'URLからウェブページの本文を簡単に抽出できるアプリケーション',
   manifest: '/manifest.json',
+  verification: {
+    google: '0BvGA_MS_dtzSY9VbRl27MsgBgYPgIHr_Sw-agrqI2s',
+  },
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',


### PR DESCRIPTION
## 概要
Google Search Console で `https://snap-content.takumi-oda.com/`（URLプレフィックスプロパティ）の所有権を確認するため、`google-site-verification` メタタグを全ページの `<head>` に出力する。

- `app/layout.tsx` の `metadata.verification.google` にトークンを設定
- このトークンは公開HTMLに出力される前提の「目印」であり、APIキー等のシークレットではない（他人が知っても所有権を奪えない／発行アカウントとドメインに紐づく）

## 背景
GSCの既存プロパティは `mogu-exercise.takumi-oda.com` と `takumi-oda.com/blog/`（いずれもURLプレフィックス型）のみで、`takumi-oda.com` のドメインプロパティは無し。そのため snap-content サブドメインは別途プロパティ追加＋所有権確認が必要だった。本PRのデプロイ後に「確認」ボタンを押す。

## 検証
- `npm run build`（Node 22）成功。`out/index.html` と `out/sansu-100.html` の両方に `<meta name="google-site-verification" content="0BvGA_...">` が出力されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)