### PR TITLE
feat(sansu-100): 履歴ページに演算別の正答率グラフを追加 (#86)

### DIFF
--- a/app/sansu-100/components/StatsCharts.tsx
+++ b/app/sansu-100/components/StatsCharts.tsx
@@ -48,15 +48,25 @@ export default function StatsCharts({
     accuracy: Math.round((s.correctCount / s.totalProblems) * 100),
   }));
 
-  // 演算別集計
-  const opCounts: Record<string, number> = {};
+  // 演算別集計（回数 + 正答率）
+  type OpStat = { correct: number; total: number; count: number };
+  const opStats = new Map<string, OpStat>();
   for (const s of sessions) {
-    opCounts[s.operation] = (opCounts[s.operation] ?? 0) + 1;
+    const cur = opStats.get(s.operation) ?? { correct: 0, total: 0, count: 0 };
+    cur.correct += s.correctCount;
+    cur.total += s.totalProblems;
+    cur.count += 1;
+    opStats.set(s.operation, cur);
   }
-  const opData = Object.entries(opCounts).map(([op, count]) => ({
+  const opData = Array.from(opStats.entries()).map(([op, stat]) => ({
     name: OP_LABELS[op] ?? op,
-    count,
+    count: stat.count,
+    accuracy: stat.total > 0 ? Math.round((stat.correct / stat.total) * 100) : 0,
+    hasEnoughData: stat.total >= 10,
   }));
+
+  // 正答率グラフ用（十分なデータのある演算のみ）
+  const accuracyData = opData.filter((d) => d.hasEnoughData);
 
   return (
     <div className="space-y-8">
@@ -115,6 +125,44 @@ export default function StatsCharts({
               <Bar dataKey="count" fill="#8b5cf6" radius={[6, 6, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
+        </div>
+      </section>
+
+      <section data-testid="accuracy-by-op">
+        <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-gray-100">
+          ✅ 演算別 正かい率
+        </h3>
+        {accuracyData.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            もう少し れんしゅうすると グラフが でるよ！
+          </p>
+        ) : (
+          <div className="h-48 rounded-xl bg-white p-2 dark:bg-gray-800">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={accuracyData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                <YAxis tick={{ fontSize: 12 }} domain={[0, 100]} unit="%" />
+                <Tooltip formatter={(v) => [`${String(v)}%`, '正かい率']} />
+                <Bar dataKey="accuracy" fill="#f59e0b" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        {/* 演算別サマリーを数値でも表示 */}
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {opData.map((d) => (
+            <div
+              key={d.name}
+              className={`rounded-xl p-3 text-center ${d.hasEnoughData ? 'bg-amber-50 dark:bg-amber-900/20' : 'bg-gray-100 dark:bg-gray-700/40'}`}
+            >
+              <p className="text-xs font-semibold text-gray-700 dark:text-gray-300">{d.name}</p>
+              <p className={`text-xl font-bold ${d.accuracy >= 90 ? 'text-green-600 dark:text-green-400' : d.accuracy >= 70 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-500 dark:text-red-400'}`}>
+                {d.hasEnoughData ? `${d.accuracy}%` : '-'}
+              </p>
+              <p className="text-xs text-gray-400">{d.count}かい</p>
+            </div>
+          ))}
         </div>
       </section>
     </div>

--- a/tests/sansu/accuracy-by-op.spec.ts
+++ b/tests/sansu/accuracy-by-op.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('演算別正答率グラフ', () => {
+  test('正答率セクションが history ページに表示される', async ({ page }) => {
+    await page.goto('/sansu-100/history');
+    // redirect to home if not logged in — just check the page loads
+    await expect(page).toHaveURL(/sansu-100/);
+  });
+
+  test('StatsCharts に accuracy-by-op セクションが存在する', async ({ page }) => {
+    // Inject a user and sessions into localStorage to test chart rendering
+    await page.goto('/sansu-100');
+    await page.evaluate(() => {
+      const userId = 'test-acc-user';
+      const user = {
+        id: userId,
+        name: 'テストくん',
+        pinHash: '',
+        createdAt: Date.now(),
+        totalSessions: 10,
+        coins: 0,
+        earnedBadges: [],
+        minigameScores: {},
+        minigameCredits: 0,
+        avatarConfig: null,
+        ownedItems: [],
+      };
+      // 10 sessions: 5 add (80% accuracy), 5 sub (60% accuracy)
+      const sessions = Array.from({ length: 10 }, (_, i) => ({
+        id: `sess-${i}`,
+        userId,
+        level: 'standard' as const,
+        operation: i < 5 ? 'add' : 'sub',
+        durationMs: 60000,
+        correctCount: i < 5 ? 80 : 60,
+        totalProblems: 100,
+        completedAt: Date.now() - i * 86400000,
+        isDaily: false,
+      }));
+      localStorage.setItem('sansu_current_user', JSON.stringify(user));
+      localStorage.setItem(`sansu_sessions_${userId}`, JSON.stringify(sessions));
+      localStorage.setItem(
+        'sansu_recent_users',
+        JSON.stringify([{ id: userId, name: 'テストくん' }])
+      );
+    });
+
+    await page.goto('/sansu-100/history');
+    await expect(page.locator('[data-testid="accuracy-by-op"]')).toBeVisible({
+      timeout: 8000,
+    });
+  });
+
+  test('演算別カードに正答率が数値で表示される', async ({ page }) => {
+    await page.goto('/sansu-100');
+    await page.evaluate(() => {
+      const userId = 'test-acc-user2';
+      const user = {
+        id: userId,
+        name: 'テストくん2',
+        pinHash: '',
+        createdAt: Date.now(),
+        totalSessions: 5,
+        coins: 0,
+        earnedBadges: [],
+        minigameScores: {},
+        minigameCredits: 0,
+        avatarConfig: null,
+        ownedItems: [],
+      };
+      const sessions = Array.from({ length: 5 }, (_, i) => ({
+        id: `sess2-${i}`,
+        userId,
+        level: 'standard' as const,
+        operation: 'mul',
+        durationMs: 50000,
+        correctCount: 90,
+        totalProblems: 100,
+        completedAt: Date.now() - i * 86400000,
+        isDaily: false,
+      }));
+      localStorage.setItem('sansu_current_user', JSON.stringify(user));
+      localStorage.setItem(`sansu_sessions_${userId}`, JSON.stringify(sessions));
+      localStorage.setItem(
+        'sansu_recent_users',
+        JSON.stringify([{ id: userId, name: 'テストくん2' }])
+      );
+    });
+
+    await page.goto('/sansu-100/history');
+    const section = page.locator('[data-testid="accuracy-by-op"]');
+    await expect(section).toBeVisible({ timeout: 8000 });
+    // 90% accuracy should appear somewhere in the section
+    await expect(section).toContainText('90%');
+  });
+
+  test('セッションが少ない場合はデータ不足メッセージが出る', async ({ page }) => {
+    await page.goto('/sansu-100');
+    await page.evaluate(() => {
+      const userId = 'test-acc-user3';
+      const user = {
+        id: userId,
+        name: 'テストくん3',
+        pinHash: '',
+        createdAt: Date.now(),
+        totalSessions: 1,
+        coins: 0,
+        earnedBadges: [],
+        minigameScores: {},
+        minigameCredits: 0,
+        avatarConfig: null,
+        ownedItems: [],
+      };
+      // Only 1 session with 9 total problems (< 10 threshold)
+      const sessions = [
+        {
+          id: 'sess3-0',
+          userId,
+          level: 'standard' as const,
+          operation: 'add',
+          durationMs: 30000,
+          correctCount: 8,
+          totalProblems: 9,
+          completedAt: Date.now(),
+          isDaily: false,
+        },
+      ];
+      localStorage.setItem('sansu_current_user', JSON.stringify(user));
+      localStorage.setItem(`sansu_sessions_${userId}`, JSON.stringify(sessions));
+      localStorage.setItem(
+        'sansu_recent_users',
+        JSON.stringify([{ id: userId, name: 'テストくん3' }])
+      );
+    });
+
+    await page.goto('/sansu-100/history');
+    const section = page.locator('[data-testid="accuracy-by-op"]');
+    await expect(section).toBeVisible({ timeout: 8000 });
+    await expect(section).toContainText('もう少し れんしゅうすると');
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #86: 履歴ページの StatsCharts に「演算別 正かい率」セクションを追加
- `SansuSession.correctCount / totalProblems` を演算種別ごとに集計
- 棒グラフ（recharts）と数値カード（90%以上=緑 / 70%以上=黄 / 未満=赤）で表示
- 10問以上のデータがない演算は「もう少し れんしゅうすると グラフが でるよ！」

## 変更ファイル
- `app/sansu-100/components/StatsCharts.tsx` — AccuracyByOp セクション追加
- `tests/sansu/accuracy-by-op.spec.ts` — E2E テスト4件

## Test plan
- [ ] 履歴ページに「演算別 正かい率」セクションが表示される
- [ ] 10問以上の演算で正答率%が表示される
- [ ] データ不足の場合は「もう少し れんしゅう…」メッセージが出る
- [ ] 正答率に応じて緑/黄/赤の色分けが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)