### PR TITLE
feat(sansu-100): ミニゲーム「おぼえてタッチ」を追加

### DIFF
--- a/app/sansu-100/games/OboeteTouchGame.tsx
+++ b/app/sansu-100/games/OboeteTouchGame.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// おぼえてタッチ（サイモンセイズ風の記憶ゲーム）
+// 4色ボタンが順番に光るので、同じ順でタップする。正解するたびに1つ増えてレベルアップ。
+// 間違えたら終了、そこまでクリアしたレベル数（=シーケンス長-1）がスコア。
+
+const PADS = [
+  { id: 0, color: '#ef4444', lit: '#fca5a5' },
+  { id: 1, color: '#3b82f6', lit: '#93c5fd' },
+  { id: 2, color: '#eab308', lit: '#fde68a' },
+  { id: 3, color: '#22c55e', lit: '#86efac' },
+] as const;
+
+type Phase = 'showing' | 'input' | 'wrong';
+
+export default function OboeteTouchGame({
+  onGameOver,
+}: {
+  onGameOver: (score: number) => void;
+}): React.JSX.Element {
+  const [sequence, setSequence] = useState<number[]>([]);
+  const [inputIdx, setInputIdx] = useState(0);
+  const [litPad, setLitPad] = useState<number | null>(null);
+  const [phase, setPhase] = useState<Phase>('showing');
+  const soundRef = useRef(true);
+  const overRef = useRef(false);
+
+  useEffect(() => {
+    soundRef.current = storage.getSettings().soundOn;
+    setSequence([Math.floor(Math.random() * PADS.length)]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1回
+  }, []);
+
+  // シーケンスが変わるたびに、最初から順番に光らせて見せる
+  useEffect(() => {
+    if (sequence.length === 0 || overRef.current) return;
+    setPhase('showing');
+    setInputIdx(0);
+    let cancelled = false;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    sequence.forEach((padId, i) => {
+      timers.push(
+        setTimeout(() => {
+          if (cancelled) return;
+          setLitPad(padId);
+          if (soundRef.current) sound.correct();
+        }, i * 650)
+      );
+      timers.push(
+        setTimeout(() => {
+          if (cancelled) return;
+          setLitPad(null);
+        }, i * 650 + 400)
+      );
+    });
+    timers.push(
+      setTimeout(
+        () => {
+          if (cancelled) return;
+          setPhase('input');
+        },
+        sequence.length * 650
+      )
+    );
+    return () => {
+      cancelled = true;
+      timers.forEach(clearTimeout);
+    };
+  }, [sequence]);
+
+  const handlePadTap = useCallback(
+    (padId: number) => {
+      if (phase !== 'input' || overRef.current) return;
+      setLitPad(padId);
+      setTimeout(() => setLitPad(null), 200);
+
+      if (padId !== sequence[inputIdx]) {
+        overRef.current = true;
+        setPhase('wrong');
+        if (soundRef.current) sound.crash();
+        onGameOver(sequence.length - 1);
+        return;
+      }
+
+      if (soundRef.current) sound.correct();
+      const nextIdx = inputIdx + 1;
+      if (nextIdx === sequence.length) {
+        // 1ラウンドクリア → 次のレベルへ
+        if (soundRef.current) sound.fanfare();
+        setTimeout(() => {
+          if (overRef.current) return;
+          setSequence((s) => [...s, Math.floor(Math.random() * PADS.length)]);
+        }, 700);
+      } else {
+        setInputIdx(nextIdx);
+      }
+    },
+    [phase, sequence, inputIdx, onGameOver]
+  );
+
+  const level = Math.max(0, sequence.length - 1);
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
+        レベル {level}
+      </p>
+      <p className="text-sm text-gray-600 dark:text-gray-400" data-testid="oboete-status">
+        {phase === 'showing' ? 'よく みてね…' : phase === 'input' ? 'じゅんばん どおりに タッチ！' : 'ざんねん！'}
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        {PADS.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            disabled={phase !== 'input'}
+            onClick={() => handlePadTap(p.id)}
+            data-testid={`oboete-pad-${p.id}`}
+            className="size-24 rounded-2xl shadow-md transition-transform active:scale-90 disabled:active:scale-100"
+            style={{ backgroundColor: litPad === p.id ? p.lit : p.color }}
+            aria-label={`パッド${p.id + 1}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/games/OboeteTouchGame.tsx
+++ b/app/sansu-100/games/OboeteTouchGame.tsx
@@ -16,7 +16,7 @@ const PADS = [
   { id: 3, color: '#22c55e', lit: '#86efac' },
 ] as const;
 
-type Phase = 'showing' | 'input' | 'wrong';
+type Phase = 'showing' | 'input' | 'gap' | 'wrong';
 
 export default function OboeteTouchGame({
   onGameOver,
@@ -90,7 +90,10 @@ export default function OboeteTouchGame({
       if (soundRef.current) sound.correct();
       const nextIdx = inputIdx + 1;
       if (nextIdx === sequence.length) {
-        // 1ラウンドクリア → 次のレベルへ
+        // 1ラウンドクリア → 次のシーケンスが始まるまでは入力を受け付けない
+        // （'gap' 中にパッドをタップできてしまうと、直前の正解パッドへの二重判定や
+        // 誤った即ゲームオーバーが起きるため）
+        setPhase('gap');
         if (soundRef.current) sound.fanfare();
         setTimeout(() => {
           if (overRef.current) return;
@@ -111,7 +114,13 @@ export default function OboeteTouchGame({
         レベル {level}
       </p>
       <p className="text-sm text-gray-600 dark:text-gray-400" data-testid="oboete-status">
-        {phase === 'showing' ? 'よく みてね…' : phase === 'input' ? 'じゅんばん どおりに タッチ！' : 'ざんねん！'}
+        {phase === 'input'
+          ? 'じゅんばん どおりに タッチ！'
+          : phase === 'wrong'
+            ? 'ざんねん！'
+            : phase === 'gap'
+              ? 'せいかい！ つぎへ…'
+              : 'よく みてね…'}
       </p>
       <div className="grid grid-cols-2 gap-3">
         {PADS.map((p) => (

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -96,6 +96,8 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'maze_master', category: 'minigame', name: 'めいろ名人', description: 'めいろを 5つ クリア', icon: '🧭', tier: 'gold', rarity: 'epic' },
   { id: 'flappy_pro', category: 'minigame', name: 'ぱたぱた名人', description: 'ぱたぱたで10てん', icon: '🐤', tier: 'silver', rarity: 'rare' },
   { id: 'flappy_master', category: 'minigame', name: 'ぱたぱた王', description: 'ぱたぱたで30てん', icon: '👑', tier: 'gold', rarity: 'epic' },
+  { id: 'oboete_sharp', category: 'minigame', name: 'きおく力じまん', description: 'おぼえてタッチで レベル5', icon: '🧠', tier: 'silver', rarity: 'rare' },
+  { id: 'oboete_genius', category: 'minigame', name: 'きおくの天才児', description: 'おぼえてタッチで レベル10', icon: '💡', tier: 'gold', rarity: 'epic' },
   { id: 'games_explorer', category: 'minigame', name: 'ゲームたんけんか', description: '5しゅるいの ゲームで あそんだ', icon: '🎮', tier: 'silver', rarity: 'rare' },
   { id: 'games_allstar', category: 'minigame', name: 'ゲームマスター', description: 'ぜんぶの ゲームで あそんだ', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -119,6 +119,18 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     ],
     available: true,
   },
+  {
+    id: 'oboete',
+    name: 'おぼえてタッチ',
+    emoji: '🧠',
+    desc: 'ひかった じゅんばんを おぼえて タッチ！',
+    howTo: [
+      '4つの ボタンが じゅんばんに ひかるよ',
+      'ひかった とおりの じゅんばんで ボタンを タッチしよう',
+      'せいかいすると 1つずつ ながく なるよ。まちがえたら おわり',
+    ],
+    available: true,
+  },
 ];
 
 const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(

--- a/app/sansu-100/lib/minigame-rewards.ts
+++ b/app/sansu-100/lib/minigame-rewards.ts
@@ -10,7 +10,8 @@ export type MinigameId =
   | 'memory'
   | 'maze'
   | 'flappy'
-  | 'pakupaku';
+  | 'pakupaku'
+  | 'oboete';
 
 // gameId ごとの { しきい値: バッジID }（昇順）
 const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
@@ -49,6 +50,10 @@ const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
   pakupaku: [
     { score: 500, badgeId: 'pakupaku_debut' },
     { score: 2000, badgeId: 'pakupaku_glutton' },
+  ],
+  oboete: [
+    { score: 5, badgeId: 'oboete_sharp' },
+    { score: 10, badgeId: 'oboete_genius' },
   ],
 };
 

--- a/app/sansu-100/minigame/oboete/page.tsx
+++ b/app/sansu-100/minigame/oboete/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
+import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
+import NewRecordBanner from '../../components/NewRecordBanner';
+import OboeteTouchGame from '../../games/OboeteTouchGame';
+import { useSansuUser } from '../../hooks/useSansuUser';
+import { sansuApi } from '../../lib/api-client';
+import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
+import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
+
+type Phase = 'intro' | 'playing' | 'over';
+
+export default function OboetePage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, saveUser, loaded } = useSansuUser();
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [lastScore, setLastScore] = useState(0);
+  const [round, setRound] = useState(0);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [overlayBadges, setOverlayBadges] = useState<string[]>([]);
+  const [newRecord, setNewRecord] = useState(false);
+
+  const coins = currentUser?.coins ?? 0;
+
+  const start = useCallback(async () => {
+    if (!currentUser) return;
+    setBusy(true);
+    setMessage(null);
+    setNewRecord(false);
+    try {
+      const res = await sansuApi.spend(currentUser.id, 'play');
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        setRound((r) => r + 1);
+        setPhase('playing');
+      } else {
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
+      }
+    } catch {
+      setMessage('いまは つうしんできないよ（あとでね）');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentUser, saveUser]);
+
+  const handleGameOver = useCallback(
+    async (score: number) => {
+      setLastScore(score);
+      setPhase('over');
+      if (!currentUser) return;
+      const newBadges = evaluateMinigameBadges(
+        'oboete',
+        score,
+        currentUser.earnedBadges
+      );
+      try {
+        const res = await sansuApi.awardBadge(currentUser.id, newBadges, score, 'oboete');
+        if (res.user) saveUser(res.user);
+        if (res.newRecord) setNewRecord(true);
+        if (newBadges.length > 0) setOverlayBadges(newBadges);
+      } catch {
+        // 報酬付与失敗は致命的でない
+      }
+    },
+    [currentUser, saveUser]
+  );
+
+  if (loaded && !currentUser) {
+    if (typeof window !== 'undefined') router.replace('/sansu-100');
+    return <main className="p-8" />;
+  }
+  if (!currentUser) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-4 p-4">
+        {phase === 'playing' ? (
+          <Link
+            href="/sansu-100/minigame"
+            className="inline-block text-sm font-semibold text-blue-600 dark:text-blue-300"
+          >
+            ← やめる
+          </Link>
+        ) : (
+          <Header
+            title="🧠 おぼえてタッチ"
+            description="ひかった じゅんばんを おぼえて タッチ！"
+            showBackButton
+            backHref="/sansu-100/minigame"
+            backLabel="ゲームせんたくにもどる"
+          />
+        )}
+
+        {message ? (
+          <div className="rounded-xl bg-yellow-100 px-4 py-3 text-center font-bold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            {message}
+          </div>
+        ) : null}
+
+        {phase === 'intro' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-6xl">🧠</p>
+            <HowToPlay steps={minigameHowTo('oboete')} />
+            <p className="text-gray-700 dark:text-gray-200">
+              コインを {SPEND_COSTS.play}まい つかって あそぶよ
+            </p>
+            <div className="flex justify-center">
+              <CoinBalance coins={coins} />
+            </div>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-indigo-600 py-4 text-lg font-bold text-white hover:bg-indigo-700 disabled:opacity-60"
+              data-testid="oboete-start"
+            >
+              🪙 {SPEND_COSTS.play} であそぶ
+            </button>
+          </section>
+        ) : null}
+
+        {phase === 'playing' ? (
+          <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
+            <OboeteTouchGame key={round} onGameOver={handleGameOver} />
+          </section>
+        ) : null}
+
+        {phase === 'over' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              おわり！
+            </p>
+            <p className="text-lg text-gray-700 dark:text-gray-200">
+              スコア: <b data-testid="oboete-final-score">{lastScore}</b>
+            </p>
+            {newRecord ? <NewRecordBanner score={lastScore} /> : null}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-indigo-600 py-4 text-lg font-bold text-white hover:bg-indigo-700 disabled:opacity-60"
+              data-testid="oboete-again"
+            >
+              🪙 {SPEND_COSTS.play} で もういちど
+            </button>
+            <Link
+              href="/sansu-100/minigame"
+              className="block rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ほかの ゲームへ
+            </Link>
+          </section>
+        ) : null}
+      </div>
+
+      {overlayBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={overlayBadges}
+          onDone={() => setOverlayBadges([])}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/tests/sansu/oboete.spec.ts
+++ b/tests/sansu/oboete.spec.ts
@@ -133,4 +133,42 @@ test.describe('おぼえてタッチ ミニゲーム', () => {
 
     await expect(finalScore).toBeVisible({ timeout: 8000 });
   });
+
+  test('ラウンドクリア後の待機中（gapフェーズ）にタップしてもゲームオーバーにならない', async ({ page }) => {
+    // Math.random を固定し、シーケンスが常にパッド0になるようにして挙動を決定的にする。
+    await page.addInitScript(() => {
+      Math.random = () => 0;
+    });
+
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/oboete');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="oboete-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    const status = page.getByTestId('oboete-status');
+    const finalScore = page.getByTestId('oboete-final-score');
+    const pad0 = page.locator('[data-testid="oboete-pad-0"]');
+    const pad1 = page.locator('[data-testid="oboete-pad-1"]');
+
+    // 1問目（シーケンス長1・正解は常にパッド0）をクリアする
+    await expect(status).toHaveText('じゅんばん どおりに タッチ！', { timeout: 8000 });
+    await pad0.click();
+
+    // クリア直後の gap フェーズでは、他のパッドをタップしても無視される
+    // （無視されずに誤判定されると、この時点で即ゲームオーバーになってしまう）
+    await expect(status).toHaveText('せいかい！ つぎへ…', { timeout: 2000 });
+    await expect(pad1).toBeDisabled();
+    await pad1.click({ force: true });
+    await page.waitForTimeout(100);
+    await expect(finalScore).not.toBeVisible();
+
+    // gap が終わって次のラウンド（レベル1）が正常に始まる
+    await expect(status).toHaveText('じゅんばん どおりに タッチ！', { timeout: 3000 });
+    await expect(page.getByText('レベル 1')).toBeVisible();
+  });
 });

--- a/tests/sansu/oboete.spec.ts
+++ b/tests/sansu/oboete.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * おぼえてタッチ（サイモンセイズ風記憶ゲーム）のE2Eテスト。
+ *
+ * - 本番ユーザは触らない。毎回ユニークな E2E 接頭辞ユーザを新規作成する。
+ * - baseURL は http://localhost:4280 (playwright.config.sansu.ts 参照)
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `OBT${suffix}`;
+}
+
+async function registerAndLogin(page: Page, name: string): Promise<void> {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sansu-100:dev-seeded', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of PIN) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'これでとうろく！' }).click();
+  await page.waitForURL('**/sansu-100', { timeout: 10000 });
+}
+
+async function earnCoinsViaDebug(page: Page): Promise<void> {
+  await page.goto('/sansu-100/play');
+  await page.waitForLoadState('networkidle');
+  const lv1 = page.locator('[data-testid="level-pick-1"]');
+  if (await lv1.isVisible()) {
+    await lv1.click();
+  }
+  const dbgBtn = page.locator('[data-testid="debug-finish-perfect"]');
+  if (await dbgBtn.isVisible({ timeout: 5000 })) {
+    await dbgBtn.click();
+  }
+  await page.goto('/sansu-100');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('おぼえてタッチ ミニゲーム', () => {
+  test('ミニゲーム一覧におぼえてタッチが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('おぼえてタッチ')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('おぼえてタッチページにアクセスすると intro 画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame/oboete');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('おぼえてタッチ').first()).toBeVisible({ timeout: 8000 });
+    const startBtn = page.locator('[data-testid="oboete-start"]');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('コイン不足時にスタートするとエラーメッセージが出る', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await page.goto('/sansu-100/minigame/oboete');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="oboete-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+    await expect(
+      page.getByText(/さんすうを|コインが/)
+    ).toBeVisible({ timeout: 6000 });
+  });
+
+  test('コイン取得後にスタートするとパッドが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/oboete');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="oboete-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    // playing フェーズ: 4色パッドが表示される
+    await expect(page.locator('[data-testid="oboete-pad-0"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="oboete-pad-1"]')).toBeVisible();
+    await expect(page.locator('[data-testid="oboete-pad-2"]')).toBeVisible();
+    await expect(page.locator('[data-testid="oboete-pad-3"]')).toBeVisible();
+    await expect(page.getByText('← やめる')).toBeVisible();
+  });
+
+  test('まちがえたパッドをタップするとゲームオーバーになる', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/oboete');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="oboete-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    // 毎ラウンド、入力フェーズになったら常にパッド0だけをタップし続ける。
+    // 正解のシーケンスはランダムなので、ラウンドを重ねるたびにパッド0が
+    // 正解する確率は 1/4 ずつ下がっていき、数ラウンド以内にほぼ確実に不正解＝
+    // ゲームオーバー（ゲーム画面が終了画面に切り替わる）へ到達する（1回でハズレる確率は75%）。
+    const finalScore = page.getByTestId('oboete-final-score');
+    const status = page.getByTestId('oboete-status');
+    let clicks = 0;
+    for (let poll = 0; poll < 60 && clicks < 15; poll++) {
+      if (await finalScore.isVisible().catch(() => false)) break;
+      const text = await status.textContent().catch(() => null);
+      if (text === 'じゅんばん どおりに タッチ！') {
+        await page.locator('[data-testid="oboete-pad-0"]').click();
+        clicks++;
+        await page.waitForTimeout(250);
+      } else {
+        await page.waitForTimeout(200);
+      }
+    }
+
+    await expect(finalScore).toBeVisible({ timeout: 8000 });
+  });
+});


### PR DESCRIPTION
## 概要
ミニゲームハブに新しいゲーム「おぼえてタッチ」（サイモンセイズ風の記憶ゲーム）を追加する。

## 遊び方
- 4色パッドが順番に光る
- 同じ順番でタップする
- 正解するたびに1つずつ長くなる（レベルアップ）
- 間違えたら終了。そこまでクリアしたレベル数がスコア

## 実装内容
- `app/sansu-100/games/OboeteTouchGame.tsx`: ゲーム本体。Canvasを使わず、React DOM（ボタン）とsetTimeoutのみで実装（既存ゲームの中で最も軽量）
- `app/sansu-100/minigame/oboete/page.tsx`: ページラッパー。既存ゲーム（whack等）と同じintro/playing/overフェーズ管理パターンを踏襲
- `app/sansu-100/lib/minigame-list.ts`: `id: 'oboete'` で登録（available: true）
- `app/sansu-100/lib/minigame-rewards.ts`: MinigameId型に追加、スコアしきい値バッジ設定
- `app/sansu-100/lib/badge-catalog.ts`: oboete_sharp（レベル5）/ oboete_genius（レベル10）バッジを追加
- `tests/sansu/oboete.spec.ts`: E2Eテスト5件

## 動作確認
- `npm run build` 成功
- ローカルSWA環境（localhost:4280）で5テスト × 3回リピート実行、全15回pass確認済み

Closes #133