### PR TITLE
feat(sansu-100): ミニゲーム「スワイプわけっこ」を追加

### DIFF
--- a/app/sansu-100/games/SwipeSortGame.tsx
+++ b/app/sansu-100/games/SwipeSortGame.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// スワイプわけっこ（左右フリック仕分けゲーム）
+// 数字カードが表示されるので、偶数なら右へ・奇数なら左へスワイプ（または矢印キー）で仕分ける。
+// 制限時間内の正解数がスコア。3回まちがえると終了。
+
+const TIME_LIMIT = 20; // 秒
+const LIVES = 3;
+const SWIPE_THRESHOLD = 40; // px
+
+function randomNumber(): number {
+  return 1 + Math.floor(Math.random() * 99);
+}
+
+type Feedback = 'correct' | 'wrong' | null;
+
+export default function SwipeSortGame({
+  onGameOver,
+}: {
+  onGameOver: (score: number) => void;
+}): React.JSX.Element {
+  const [current, setCurrent] = useState(randomNumber);
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(LIVES);
+  const [timeLeft, setTimeLeft] = useState(TIME_LIMIT);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [flyDir, setFlyDir] = useState<'left' | 'right' | null>(null);
+
+  const scoreRef = useRef(0);
+  const livesRef = useRef(LIVES);
+  const timeLeftRef = useRef(TIME_LIMIT);
+  const overRef = useRef(false);
+  const soundRef = useRef(true);
+  const busyRef = useRef(false);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    soundRef.current = storage.getSettings().soundOn;
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (overRef.current) return;
+      const t = timeLeftRef.current - 1;
+      timeLeftRef.current = t;
+      setTimeLeft(Math.max(0, t));
+      if (t <= 0) {
+        clearInterval(id);
+        if (!overRef.current) {
+          overRef.current = true;
+          if (soundRef.current) sound.crash();
+          onGameOver(scoreRef.current);
+        }
+      }
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1回
+  }, []);
+
+  const judge = useCallback(
+    (dir: 'left' | 'right') => {
+      if (overRef.current || busyRef.current) return;
+      busyRef.current = true;
+      const isEven = current % 2 === 0;
+      const correct = (dir === 'right' && isEven) || (dir === 'left' && !isEven);
+      setFlyDir(dir);
+      setFeedback(correct ? 'correct' : 'wrong');
+
+      if (correct) {
+        scoreRef.current += 1;
+        setScore(scoreRef.current);
+        if (soundRef.current) sound.correct();
+      } else {
+        livesRef.current -= 1;
+        setLives(Math.max(0, livesRef.current));
+        if (soundRef.current) sound.crash();
+      }
+
+      setTimeout(() => {
+        if (livesRef.current <= 0) {
+          overRef.current = true;
+          onGameOver(scoreRef.current);
+          return;
+        }
+        setCurrent(randomNumber());
+        setFeedback(null);
+        setFlyDir(null);
+        busyRef.current = false;
+      }, 280);
+    },
+    [current, onGameOver]
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') judge('left');
+      else if (e.key === 'ArrowRight') judge('right');
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [judge]);
+
+  const isEvenNow = current % 2 === 0;
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex w-full items-center justify-between px-1 text-sm font-bold text-gray-800 dark:text-gray-100">
+        <span>スコア: <span className="tabular-nums">{score}</span></span>
+        <span>{'❤️'.repeat(lives)}</span>
+        <span className={timeLeft <= 5 ? 'text-red-600' : ''}>⏱ {timeLeft}秒</span>
+      </div>
+
+      <div
+        className="flex h-40 w-full max-w-xs select-none items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-400 to-purple-500 shadow-lg"
+        style={{ touchAction: 'none' }}
+        data-testid="swipesort-card"
+        data-value={current}
+        data-parity={isEvenNow ? 'even' : 'odd'}
+        onPointerDown={(e) => {
+          touchStart.current = { x: e.clientX, y: e.clientY };
+        }}
+        onPointerUp={(e) => {
+          const s0 = touchStart.current;
+          touchStart.current = null;
+          if (!s0) return;
+          const dx = e.clientX - s0.x;
+          if (Math.abs(dx) < SWIPE_THRESHOLD) return;
+          judge(dx > 0 ? 'right' : 'left');
+        }}
+      >
+        <span
+          className={`text-6xl font-extrabold text-white transition-transform ${
+            flyDir === 'left' ? '-translate-x-16 opacity-0' : flyDir === 'right' ? 'translate-x-16 opacity-0' : ''
+          }`}
+        >
+          {current}
+        </span>
+      </div>
+
+      {feedback ? (
+        <p
+          className={`text-lg font-bold ${feedback === 'correct' ? 'text-green-600' : 'text-red-600'}`}
+          data-testid="swipesort-feedback"
+        >
+          {feedback === 'correct' ? '◯ せいかい！' : '× ざんねん'}
+        </p>
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          ぐうすう(2,4,6…) は みぎへ、きすう(1,3,5…) は ひだりへ！
+        </p>
+      )}
+
+      <div className="flex w-full max-w-xs justify-between gap-4">
+        <button
+          type="button"
+          onClick={() => judge('left')}
+          data-testid="swipesort-left"
+          aria-label="ひだり（きすう）"
+          className="flex-1 rounded-xl bg-red-100 py-4 text-2xl font-bold text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-300"
+        >
+          ◀ きすう
+        </button>
+        <button
+          type="button"
+          onClick={() => judge('right')}
+          data-testid="swipesort-right"
+          aria-label="みぎ（ぐうすう）"
+          className="flex-1 rounded-xl bg-blue-100 py-4 text-2xl font-bold text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-300"
+        >
+          ぐうすう ▶
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/games/SwipeSortGame.tsx
+++ b/app/sansu-100/games/SwipeSortGame.tsx
@@ -82,6 +82,7 @@ export default function SwipeSortGame({
       }
 
       setTimeout(() => {
+        if (overRef.current) return;
         if (livesRef.current <= 0) {
           overRef.current = true;
           onGameOver(scoreRef.current);

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -98,6 +98,8 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'flappy_master', category: 'minigame', name: 'ぱたぱた王', description: 'ぱたぱたで30てん', icon: '👑', tier: 'gold', rarity: 'epic' },
   { id: 'oboete_sharp', category: 'minigame', name: 'きおく力じまん', description: 'おぼえてタッチで レベル5', icon: '🧠', tier: 'silver', rarity: 'rare' },
   { id: 'oboete_genius', category: 'minigame', name: 'きおくの天才児', description: 'おぼえてタッチで レベル10', icon: '💡', tier: 'gold', rarity: 'epic' },
+  { id: 'swipesort_quick', category: 'minigame', name: 'わけっこ名人', description: 'スワイプわけっこで15てん', icon: '🔀', tier: 'silver', rarity: 'rare' },
+  { id: 'swipesort_lightning', category: 'minigame', name: 'いなずまの手', description: 'スワイプわけっこで30てん', icon: '⚡', tier: 'gold', rarity: 'epic' },
   { id: 'games_explorer', category: 'minigame', name: 'ゲームたんけんか', description: '5しゅるいの ゲームで あそんだ', icon: '🎮', tier: 'silver', rarity: 'rare' },
   { id: 'games_allstar', category: 'minigame', name: 'ゲームマスター', description: 'ぜんぶの ゲームで あそんだ', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -131,6 +131,18 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     ],
     available: true,
   },
+  {
+    id: 'swipesort',
+    name: 'スワイプわけっこ',
+    emoji: '🔀',
+    desc: 'ぐうすう・きすうを すばやく わけよう！',
+    howTo: [
+      'すうじの カードが でてくるよ',
+      'ぐうすう（2,4,6…）なら みぎへ、きすう（1,3,5…）なら ひだりへ スワイプ！',
+      'せいげん時間の 中で なんかい せいかいできるかな。3かい まちがえると おわり',
+    ],
+    available: true,
+  },
 ];
 
 const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(

--- a/app/sansu-100/lib/minigame-rewards.ts
+++ b/app/sansu-100/lib/minigame-rewards.ts
@@ -11,7 +11,8 @@ export type MinigameId =
   | 'maze'
   | 'flappy'
   | 'pakupaku'
-  | 'oboete';
+  | 'oboete'
+  | 'swipesort';
 
 // gameId ごとの { しきい値: バッジID }（昇順）
 const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
@@ -54,6 +55,10 @@ const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
   oboete: [
     { score: 5, badgeId: 'oboete_sharp' },
     { score: 10, badgeId: 'oboete_genius' },
+  ],
+  swipesort: [
+    { score: 15, badgeId: 'swipesort_quick' },
+    { score: 30, badgeId: 'swipesort_lightning' },
   ],
 };
 

--- a/app/sansu-100/minigame/swipesort/page.tsx
+++ b/app/sansu-100/minigame/swipesort/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
+import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
+import NewRecordBanner from '../../components/NewRecordBanner';
+import SwipeSortGame from '../../games/SwipeSortGame';
+import { useSansuUser } from '../../hooks/useSansuUser';
+import { sansuApi } from '../../lib/api-client';
+import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
+import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
+
+type Phase = 'intro' | 'playing' | 'over';
+
+export default function SwipeSortPage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, saveUser, loaded } = useSansuUser();
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [lastScore, setLastScore] = useState(0);
+  const [round, setRound] = useState(0);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [overlayBadges, setOverlayBadges] = useState<string[]>([]);
+  const [newRecord, setNewRecord] = useState(false);
+
+  const coins = currentUser?.coins ?? 0;
+
+  const start = useCallback(async () => {
+    if (!currentUser) return;
+    setBusy(true);
+    setMessage(null);
+    setNewRecord(false);
+    try {
+      const res = await sansuApi.spend(currentUser.id, 'play');
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        setRound((r) => r + 1);
+        setPhase('playing');
+      } else {
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
+      }
+    } catch {
+      setMessage('いまは つうしんできないよ（あとでね）');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentUser, saveUser]);
+
+  const handleGameOver = useCallback(
+    async (score: number) => {
+      setLastScore(score);
+      setPhase('over');
+      if (!currentUser) return;
+      const newBadges = evaluateMinigameBadges(
+        'swipesort',
+        score,
+        currentUser.earnedBadges
+      );
+      try {
+        const res = await sansuApi.awardBadge(currentUser.id, newBadges, score, 'swipesort');
+        if (res.user) saveUser(res.user);
+        if (res.newRecord) setNewRecord(true);
+        if (newBadges.length > 0) setOverlayBadges(newBadges);
+      } catch {
+        // 報酬付与失敗は致命的でない
+      }
+    },
+    [currentUser, saveUser]
+  );
+
+  if (loaded && !currentUser) {
+    if (typeof window !== 'undefined') router.replace('/sansu-100');
+    return <main className="p-8" />;
+  }
+  if (!currentUser) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-4 p-4">
+        {phase === 'playing' ? (
+          <Link
+            href="/sansu-100/minigame"
+            className="inline-block text-sm font-semibold text-blue-600 dark:text-blue-300"
+          >
+            ← やめる
+          </Link>
+        ) : (
+          <Header
+            title="🔀 スワイプわけっこ"
+            description="ぐうすう・きすうを すばやく わけよう！"
+            showBackButton
+            backHref="/sansu-100/minigame"
+            backLabel="ゲームせんたくにもどる"
+          />
+        )}
+
+        {message ? (
+          <div className="rounded-xl bg-yellow-100 px-4 py-3 text-center font-bold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            {message}
+          </div>
+        ) : null}
+
+        {phase === 'intro' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-6xl">🔀</p>
+            <HowToPlay steps={minigameHowTo('swipesort')} />
+            <p className="text-gray-700 dark:text-gray-200">
+              コインを {SPEND_COSTS.play}まい つかって あそぶよ
+            </p>
+            <div className="flex justify-center">
+              <CoinBalance coins={coins} />
+            </div>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-purple-600 py-4 text-lg font-bold text-white hover:bg-purple-700 disabled:opacity-60"
+              data-testid="swipesort-start"
+            >
+              🪙 {SPEND_COSTS.play} であそぶ
+            </button>
+          </section>
+        ) : null}
+
+        {phase === 'playing' ? (
+          <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
+            <SwipeSortGame key={round} onGameOver={handleGameOver} />
+          </section>
+        ) : null}
+
+        {phase === 'over' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              おわり！
+            </p>
+            <p className="text-lg text-gray-700 dark:text-gray-200">
+              スコア: <b data-testid="swipesort-final-score">{lastScore}</b>
+            </p>
+            {newRecord ? <NewRecordBanner score={lastScore} /> : null}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-purple-600 py-4 text-lg font-bold text-white hover:bg-purple-700 disabled:opacity-60"
+              data-testid="swipesort-again"
+            >
+              🪙 {SPEND_COSTS.play} で もういちど
+            </button>
+            <Link
+              href="/sansu-100/minigame"
+              className="block rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ほかの ゲームへ
+            </Link>
+          </section>
+        ) : null}
+      </div>
+
+      {overlayBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={overlayBadges}
+          onDone={() => setOverlayBadges([])}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/tests/sansu/swipesort.spec.ts
+++ b/tests/sansu/swipesort.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * スワイプわけっこ（偶数/奇数 仕分けゲーム）のE2Eテスト。
+ *
+ * - 本番ユーザは触らない。毎回ユニークな E2E 接頭辞ユーザを新規作成する。
+ * - baseURL は http://localhost:4280 (playwright.config.sansu.ts 参照)
+ * - スワイプ操作はheadlessでのpointer down/up再現が不安定になりやすいため、
+ *   操作確認は画面下の「きすう」「ぐうすう」ボタン（swipesort-left/right）で行う。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `SWS${suffix}`;
+}
+
+async function registerAndLogin(page: Page, name: string): Promise<void> {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sansu-100:dev-seeded', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of PIN) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'これでとうろく！' }).click();
+  await page.waitForURL('**/sansu-100', { timeout: 10000 });
+}
+
+async function earnCoinsViaDebug(page: Page): Promise<void> {
+  await page.goto('/sansu-100/play');
+  await page.waitForLoadState('networkidle');
+  const lv1 = page.locator('[data-testid="level-pick-1"]');
+  if (await lv1.isVisible()) {
+    await lv1.click();
+  }
+  const dbgBtn = page.locator('[data-testid="debug-finish-perfect"]');
+  if (await dbgBtn.isVisible({ timeout: 5000 })) {
+    await dbgBtn.click();
+  }
+  await page.goto('/sansu-100');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('スワイプわけっこ ミニゲーム', () => {
+  test('ミニゲーム一覧にスワイプわけっこが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('スワイプわけっこ')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('スワイプわけっこページにアクセスすると intro 画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame/swipesort');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('スワイプわけっこ').first()).toBeVisible({ timeout: 8000 });
+    const startBtn = page.locator('[data-testid="swipesort-start"]');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('コイン不足時にスタートするとエラーメッセージが出る', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await page.goto('/sansu-100/minigame/swipesort');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="swipesort-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+    await expect(
+      page.getByText(/さんすうを|コインが/)
+    ).toBeVisible({ timeout: 6000 });
+  });
+
+  test('コイン取得後にスタートするとカードが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/swipesort');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="swipesort-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    await expect(page.locator('[data-testid="swipesort-card"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="swipesort-left"]')).toBeVisible();
+    await expect(page.locator('[data-testid="swipesort-right"]')).toBeVisible();
+    await expect(page.getByText('← やめる')).toBeVisible();
+  });
+
+  test('正しいボタンを押すと正解になりスコアが増える', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/swipesort');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="swipesort-start"]').click();
+
+    const card = page.locator('[data-testid="swipesort-card"]');
+    await expect(card).toBeVisible({ timeout: 8000 });
+
+    // 正しい判定ボタンを押すと「せいかい！」が出て、スコアが加算される
+    for (let i = 0; i < 5; i++) {
+      const parity = await card.getAttribute('data-parity');
+      const btn = page.locator(
+        parity === 'even' ? '[data-testid="swipesort-right"]' : '[data-testid="swipesort-left"]'
+      );
+      await btn.click();
+      await expect(page.getByTestId('swipesort-feedback')).toHaveText('◯ せいかい！', {
+        timeout: 3000,
+      });
+      await page.waitForTimeout(350);
+    }
+
+    await expect(page.getByText(/スコア: 5/)).toBeVisible();
+  });
+
+  test('まちがえたボタンを3回押すとゲームオーバーになる', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/swipesort');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="swipesort-start"]').click();
+
+    const card = page.locator('[data-testid="swipesort-card"]');
+    await expect(card).toBeVisible({ timeout: 8000 });
+
+    for (let i = 0; i < 3; i++) {
+      const parity = await card.getAttribute('data-parity');
+      // わざと逆のボタンを押して間違える
+      const wrongBtn = page.locator(
+        parity === 'even' ? '[data-testid="swipesort-left"]' : '[data-testid="swipesort-right"]'
+      );
+      await wrongBtn.click();
+      await page.waitForTimeout(350);
+    }
+
+    await expect(page.getByTestId('swipesort-final-score')).toBeVisible({ timeout: 8000 });
+  });
+});


### PR DESCRIPTION
## 概要
ミニゲームハブに新しいゲーム「スワイプわけっこ」を追加する。100マス計算アプリらしく偶数/奇数の判定をテーマにした。

## 遊び方
- 画面中央に数字カードが表示される
- 偶数なら右（ぐうすう）、奇数なら左（きすう）へスワイプ or ボタンタップで仕分ける
- 制限時間20秒。3回間違えると終了。正解数がスコア

## 実装内容
- `app/sansu-100/games/SwipeSortGame.tsx`: ゲーム本体。Canvas不要、pointer down/upでスワイプ検知（pakupakuと同パターン）+ 左右ボタンでも操作可能
- `app/sansu-100/minigame/swipesort/page.tsx`: ページラッパー（既存ゲームと同じintro/playing/overパターン）
- `minigame-list.ts` / `minigame-rewards.ts` / `badge-catalog.ts`: 一覧登録・バッジ2種追加
- `tests/sansu/swipesort.spec.ts`: E2Eテスト6件（headlessでのポインタースワイプは不安定になりやすいため、判定は左右ボタン操作で検証）

## 動作確認
- `npm run build` 成功
- ローカルSWA環境（localhost:4280）で6テスト × 2リピート＝12回全てpass確認済み

Closes #135