### PR TITLE
feat(sansu-100): ミニゲーム「ぽんぽんジャンプ」を追加

### DIFF
--- a/app/sansu-100/games/PonPonJumpGame.tsx
+++ b/app/sansu-100/games/PonPonJumpGame.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { startGameLoop } from '../lib/minigame-core';
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// ぽんぽんジャンプ（縦スクロールジャンプアクション）
+// キャラクターが自動で跳ね続けるので、左右に動かして足場を乗り継ぎ、上へ登っていく。
+// 画面下（カメラの外）に落ちたら終了。到達した高さがスコア。
+
+const W = 260;
+const H = 380;
+const PLAYER_R = 10;
+const GRAVITY = 0.35;
+const JUMP_VY = -9.5;
+const MOVE_SPEED = 4;
+const PLAT_W = 52;
+const PLAT_H = 8;
+const PLAT_GAP_MIN = 42;
+const PLAT_GAP_MAX = 72;
+
+type Platform = { x: number; y: number };
+
+interface GS {
+  playerX: number;
+  playerY: number;
+  vy: number;
+  platforms: Platform[];
+  cameraY: number; // 画面上端に対応するワールドY（値が小さいほど高い）
+  maxHeight: number; // これまでの最高到達スコア（登った高さ）
+  over: boolean;
+}
+
+function createGS(rand: () => number): GS {
+  const platforms: Platform[] = [];
+  // 最初の足場（プレイヤーの真下）
+  platforms.push({ x: W / 2 - PLAT_W / 2, y: H - 30 });
+  let y = H - 30;
+  while (y > -H) {
+    y -= PLAT_GAP_MIN + rand() * (PLAT_GAP_MAX - PLAT_GAP_MIN);
+    const x = rand() * (W - PLAT_W);
+    platforms.push({ x, y });
+  }
+  return {
+    playerX: W / 2,
+    playerY: H - 30 - PLAYER_R,
+    vy: JUMP_VY,
+    platforms,
+    cameraY: 0,
+    maxHeight: 0,
+    over: false,
+  };
+}
+
+function tick(
+  gs: GS,
+  moveDir: number,
+  rand: () => number,
+  onEvent: (ev: 'bounce' | 'over') => void
+): void {
+  if (gs.over) return;
+
+  gs.playerX += moveDir * MOVE_SPEED;
+  if (gs.playerX < -PLAYER_R) gs.playerX = W + PLAYER_R;
+  if (gs.playerX > W + PLAYER_R) gs.playerX = -PLAYER_R;
+
+  const prevY = gs.playerY;
+  gs.vy += GRAVITY;
+  gs.playerY += gs.vy;
+
+  // 足場との当たり判定（落下中のみ、かつ足場を上から踏んだときだけ）
+  if (gs.vy > 0) {
+    for (const p of gs.platforms) {
+      const withinX = gs.playerX + PLAYER_R > p.x && gs.playerX - PLAYER_R < p.x + PLAT_W;
+      const crossing =
+        prevY + PLAYER_R <= p.y && gs.playerY + PLAYER_R >= p.y && gs.playerY + PLAYER_R <= p.y + PLAT_H + 6;
+      if (withinX && crossing) {
+        gs.vy = JUMP_VY;
+        gs.playerY = p.y - PLAYER_R;
+        onEvent('bounce');
+        break;
+      }
+    }
+  }
+
+  // カメラをプレイヤーの最高到達点に合わせて上へスクロール
+  const margin = H * 0.4;
+  if (gs.playerY < gs.cameraY + margin) {
+    const dy = gs.cameraY + margin - gs.playerY;
+    gs.cameraY -= dy;
+    gs.maxHeight = Math.max(gs.maxHeight, Math.floor(-gs.cameraY / 10));
+
+    // 足場を上に補充する
+    let topY = Math.min(...gs.platforms.map((p) => p.y));
+    while (topY > gs.cameraY - H) {
+      topY -= PLAT_GAP_MIN + rand() * (PLAT_GAP_MAX - PLAT_GAP_MIN);
+      gs.platforms.push({ x: rand() * (W - PLAT_W), y: topY });
+    }
+    // 画面外に大きく外れた（下に落ちた）足場は掃除
+    gs.platforms = gs.platforms.filter((p) => p.y < gs.cameraY + H + 100);
+  }
+
+  // 画面（カメラ）の下端より下に落ちたら終了
+  if (gs.playerY - gs.cameraY > H + PLAYER_R * 3) {
+    gs.over = true;
+    onEvent('over');
+  }
+}
+
+function draw(ctx: CanvasRenderingContext2D, gs: GS, scale: number): void {
+  ctx.fillStyle = '#e0f2fe';
+  ctx.fillRect(0, 0, W * scale, H * scale);
+
+  ctx.fillStyle = '#22c55e';
+  for (const p of gs.platforms) {
+    const sy = (p.y - gs.cameraY) * scale;
+    if (sy < -PLAT_H * scale || sy > H * scale) continue;
+    ctx.fillRect(p.x * scale, sy, PLAT_W * scale, PLAT_H * scale);
+  }
+
+  ctx.fillStyle = '#f97316';
+  ctx.beginPath();
+  ctx.arc(
+    gs.playerX * scale,
+    (gs.playerY - gs.cameraY) * scale,
+    PLAYER_R * scale,
+    0,
+    Math.PI * 2
+  );
+  ctx.fill();
+}
+
+function computeWidth(): number {
+  if (typeof window === 'undefined') return W;
+  return Math.max(220, Math.min(320, window.innerWidth - 48));
+}
+
+export default function PonPonJumpGame({
+  onGameOver,
+}: {
+  onGameOver: (score: number) => void;
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gsRef = useRef<GS>(createGS(Math.random));
+  const moveRef = useRef(0);
+  const scaleRef = useRef(1);
+  const overRef = useRef(false);
+  const soundRef = useRef(true);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const cw = computeWidth();
+    const scale = cw / W;
+    scaleRef.current = scale;
+    const ch = H * scale;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(cw * dpr);
+    canvas.height = Math.round(ch * dpr);
+    canvas.style.width = `${cw}px`;
+    canvas.style.height = `${ch}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const rand = Math.random.bind(Math);
+    gsRef.current = createGS(rand);
+    overRef.current = false;
+    moveRef.current = 0;
+    soundRef.current = storage.getSettings().soundOn;
+    setHeight(0);
+
+    const handle = startGameLoop({
+      stepMs: () => 16,
+      onTick: () => {
+        if (overRef.current) return;
+        const gs = gsRef.current;
+        tick(gs, moveRef.current, rand, (ev) => {
+          if (ev === 'bounce' && soundRef.current) sound.correct();
+          if (ev === 'over' && !overRef.current) {
+            overRef.current = true;
+            handle.stop();
+            if (soundRef.current) sound.crash();
+            onGameOver(gs.maxHeight);
+          }
+        });
+        setHeight(gs.maxHeight);
+      },
+      onRender: () => draw(ctx, gsRef.current, scaleRef.current),
+    });
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') moveRef.current = -1;
+      else if (e.key === 'ArrowRight') moveRef.current = 1;
+    };
+    const onKeyUp = () => {
+      moveRef.current = 0;
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      handle.stop();
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1ゲーム。再戦は親が key で再マウント
+  }, []);
+
+  const onMove = (e: React.PointerEvent) => {
+    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
+    const logicalX = (e.clientX - rect.left) / scaleRef.current;
+    gsRef.current.playerX = logicalX;
+  };
+
+  const btn =
+    'flex h-14 flex-1 items-center justify-center rounded-xl bg-gray-200 text-2xl font-bold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 select-none';
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
+        たかさ: <span className="tabular-nums" data-testid="ponpon-height">{height}</span>
+      </p>
+      <canvas
+        ref={canvasRef}
+        data-testid="ponpon-canvas"
+        onPointerDown={onMove}
+        onPointerMove={onMove}
+        className="touch-none rounded-xl shadow-md"
+        style={{ touchAction: 'none' }}
+      />
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        ゆびで うごかす、ボタンでもOK（じどうで ジャンプするよ）
+      </p>
+      <div className="flex w-full max-w-xs gap-3">
+        <button
+          type="button"
+          className={btn}
+          data-testid="ponpon-left"
+          aria-label="ひだり"
+          onPointerDown={() => (moveRef.current = -1)}
+          onPointerUp={() => (moveRef.current = 0)}
+          onPointerLeave={() => (moveRef.current = 0)}
+        >
+          ◀
+        </button>
+        <button
+          type="button"
+          className={btn}
+          data-testid="ponpon-right"
+          aria-label="みぎ"
+          onPointerDown={() => (moveRef.current = 1)}
+          onPointerUp={() => (moveRef.current = 0)}
+          onPointerLeave={() => (moveRef.current = 0)}
+        >
+          ▶
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -104,6 +104,8 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'rhythmdon_maestro', category: 'minigame', name: 'リズムの達人', description: 'リズムでドンで25てん', icon: '🎵', tier: 'gold', rarity: 'epic' },
   { id: 'starshooter_ace', category: 'minigame', name: 'エースパイロット', description: 'ピューピュー星空で15てん', icon: '🚀', tier: 'silver', rarity: 'rare' },
   { id: 'starshooter_hero', category: 'minigame', name: '宇宙のヒーロー', description: 'ピューピュー星空で35てん', icon: '🌟', tier: 'gold', rarity: 'epic' },
+  { id: 'ponpon_climber', category: 'minigame', name: 'のぼり名人', description: 'ぽんぽんジャンプで たかさ30', icon: '🐰', tier: 'silver', rarity: 'rare' },
+  { id: 'ponpon_skyhigh', category: 'minigame', name: '天まで とどけ', description: 'ぽんぽんジャンプで たかさ80', icon: '☁️', tier: 'gold', rarity: 'epic' },
   { id: 'games_explorer', category: 'minigame', name: 'ゲームたんけんか', description: '5しゅるいの ゲームで あそんだ', icon: '🎮', tier: 'silver', rarity: 'rare' },
   { id: 'games_allstar', category: 'minigame', name: 'ゲームマスター', description: 'ぜんぶの ゲームで あそんだ', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -167,6 +167,18 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     ],
     available: true,
   },
+  {
+    id: 'ponpon',
+    name: 'ぽんぽんジャンプ',
+    emoji: '🐰',
+    desc: 'あしばを つたって うえを めざそう！',
+    howTo: [
+      'キャラクターは じどうで はねつづけるよ',
+      'ゆびで うごかす か ◀▶ボタンで あしばを つたって うえへ すすもう',
+      'あしばを ふみはずして したに おちると おわり。とどいた たかさが スコア',
+    ],
+    available: true,
+  },
 ];
 
 const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(

--- a/app/sansu-100/lib/minigame-rewards.ts
+++ b/app/sansu-100/lib/minigame-rewards.ts
@@ -14,7 +14,8 @@ export type MinigameId =
   | 'oboete'
   | 'swipesort'
   | 'rhythmdon'
-  | 'starshooter';
+  | 'starshooter'
+  | 'ponpon';
 
 // gameId ごとの { しきい値: バッジID }（昇順）
 const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
@@ -69,6 +70,10 @@ const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
   starshooter: [
     { score: 15, badgeId: 'starshooter_ace' },
     { score: 35, badgeId: 'starshooter_hero' },
+  ],
+  ponpon: [
+    { score: 30, badgeId: 'ponpon_climber' },
+    { score: 80, badgeId: 'ponpon_skyhigh' },
   ],
 };
 

--- a/app/sansu-100/minigame/ponpon/page.tsx
+++ b/app/sansu-100/minigame/ponpon/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
+import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
+import NewRecordBanner from '../../components/NewRecordBanner';
+import PonPonJumpGame from '../../games/PonPonJumpGame';
+import { useSansuUser } from '../../hooks/useSansuUser';
+import { sansuApi } from '../../lib/api-client';
+import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
+import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
+
+type Phase = 'intro' | 'playing' | 'over';
+
+export default function PonPonJumpPage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, saveUser, loaded } = useSansuUser();
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [lastScore, setLastScore] = useState(0);
+  const [round, setRound] = useState(0);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [overlayBadges, setOverlayBadges] = useState<string[]>([]);
+  const [newRecord, setNewRecord] = useState(false);
+
+  const coins = currentUser?.coins ?? 0;
+
+  const start = useCallback(async () => {
+    if (!currentUser) return;
+    setBusy(true);
+    setMessage(null);
+    setNewRecord(false);
+    try {
+      const res = await sansuApi.spend(currentUser.id, 'play');
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        setRound((r) => r + 1);
+        setPhase('playing');
+      } else {
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
+      }
+    } catch {
+      setMessage('いまは つうしんできないよ（あとでね）');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentUser, saveUser]);
+
+  const handleGameOver = useCallback(
+    async (score: number) => {
+      setLastScore(score);
+      setPhase('over');
+      if (!currentUser) return;
+      const newBadges = evaluateMinigameBadges(
+        'ponpon',
+        score,
+        currentUser.earnedBadges
+      );
+      try {
+        const res = await sansuApi.awardBadge(currentUser.id, newBadges, score, 'ponpon');
+        if (res.user) saveUser(res.user);
+        if (res.newRecord) setNewRecord(true);
+        if (newBadges.length > 0) setOverlayBadges(newBadges);
+      } catch {
+        // 報酬付与失敗は致命的でない
+      }
+    },
+    [currentUser, saveUser]
+  );
+
+  if (loaded && !currentUser) {
+    if (typeof window !== 'undefined') router.replace('/sansu-100');
+    return <main className="p-8" />;
+  }
+  if (!currentUser) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-4 p-4">
+        {phase === 'playing' ? (
+          <Link
+            href="/sansu-100/minigame"
+            className="inline-block text-sm font-semibold text-blue-600 dark:text-blue-300"
+          >
+            ← やめる
+          </Link>
+        ) : (
+          <Header
+            title="🐰 ぽんぽんジャンプ"
+            description="あしばを つたって うえを めざそう！"
+            showBackButton
+            backHref="/sansu-100/minigame"
+            backLabel="ゲームせんたくにもどる"
+          />
+        )}
+
+        {message ? (
+          <div className="rounded-xl bg-yellow-100 px-4 py-3 text-center font-bold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            {message}
+          </div>
+        ) : null}
+
+        {phase === 'intro' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-6xl">🐰</p>
+            <HowToPlay steps={minigameHowTo('ponpon')} />
+            <p className="text-gray-700 dark:text-gray-200">
+              コインを {SPEND_COSTS.play}まい つかって あそぶよ
+            </p>
+            <div className="flex justify-center">
+              <CoinBalance coins={coins} />
+            </div>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-green-600 py-4 text-lg font-bold text-white hover:bg-green-700 disabled:opacity-60"
+              data-testid="ponpon-start"
+            >
+              🪙 {SPEND_COSTS.play} であそぶ
+            </button>
+          </section>
+        ) : null}
+
+        {phase === 'playing' ? (
+          <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
+            <PonPonJumpGame key={round} onGameOver={handleGameOver} />
+          </section>
+        ) : null}
+
+        {phase === 'over' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              おわり！
+            </p>
+            <p className="text-lg text-gray-700 dark:text-gray-200">
+              たかさ: <b data-testid="ponpon-final-score">{lastScore}</b>
+            </p>
+            {newRecord ? <NewRecordBanner score={lastScore} /> : null}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-green-600 py-4 text-lg font-bold text-white hover:bg-green-700 disabled:opacity-60"
+              data-testid="ponpon-again"
+            >
+              🪙 {SPEND_COSTS.play} で もういちど
+            </button>
+            <Link
+              href="/sansu-100/minigame"
+              className="block rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ほかの ゲームへ
+            </Link>
+          </section>
+        ) : null}
+      </div>
+
+      {overlayBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={overlayBadges}
+          onDone={() => setOverlayBadges([])}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/tests/sansu/ponpon.spec.ts
+++ b/tests/sansu/ponpon.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * ぽんぽんジャンプ（縦スクロールジャンプアクション）のE2Eテスト。
+ *
+ * - 本番ユーザは触らない。毎回ユニークな E2E 接頭辞ユーザを新規作成する。
+ * - baseURL は http://localhost:4280 (playwright.config.sansu.ts 参照)
+ * - ジャンプ・足場判定はCanvas内のゲームロジックで発生するため、
+ *   ここでは「ページ表示・スタート・高さ表示・ゲームオーバー画面遷移」まで確認する。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `PPJ${suffix}`;
+}
+
+async function registerAndLogin(page: Page, name: string): Promise<void> {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sansu-100:dev-seeded', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of PIN) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'これでとうろく！' }).click();
+  await page.waitForURL('**/sansu-100', { timeout: 10000 });
+}
+
+async function earnCoinsViaDebug(page: Page): Promise<void> {
+  await page.goto('/sansu-100/play');
+  await page.waitForLoadState('networkidle');
+  const lv1 = page.locator('[data-testid="level-pick-1"]');
+  if (await lv1.isVisible()) {
+    await lv1.click();
+  }
+  const dbgBtn = page.locator('[data-testid="debug-finish-perfect"]');
+  if (await dbgBtn.isVisible({ timeout: 5000 })) {
+    await dbgBtn.click();
+  }
+  await page.goto('/sansu-100');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('ぽんぽんジャンプ ミニゲーム', () => {
+  test('ミニゲーム一覧にぽんぽんジャンプが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('ぽんぽんジャンプ')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('ぽんぽんジャンプページにアクセスすると intro 画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame/ponpon');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('ぽんぽんジャンプ').first()).toBeVisible({ timeout: 8000 });
+    const startBtn = page.locator('[data-testid="ponpon-start"]');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('コイン不足時にスタートするとエラーメッセージが出る', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await page.goto('/sansu-100/minigame/ponpon');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="ponpon-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+    await expect(
+      page.getByText(/さんすうを|コインが/)
+    ).toBeVisible({ timeout: 6000 });
+  });
+
+  test('コイン取得後にスタートするとキャンバスと操作ボタンが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/ponpon');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="ponpon-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    await expect(page.locator('[data-testid="ponpon-canvas"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="ponpon-left"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ponpon-right"]')).toBeVisible();
+    await expect(page.getByText('← やめる')).toBeVisible();
+  });
+
+  test('しばらく待つと自動ジャンプで高さが増える', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/ponpon');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="ponpon-start"]').click();
+
+    await expect(page.locator('[data-testid="ponpon-canvas"]')).toBeVisible({ timeout: 8000 });
+
+    const heightText = page.getByTestId('ponpon-height');
+    await expect(heightText).toBeVisible({ timeout: 8000 });
+    // 高さは非負の数値として表示され続ける（実際に登れるかは足場配置次第だが、
+    // ゲームが正常に動作し続けている＝クラッシュしていないことを確認する）
+    await page.waitForTimeout(2000);
+    const text = await heightText.textContent();
+    expect(text).toMatch(/^\d+$/);
+  });
+
+  test('落下してゲームオーバーになると最終スコア画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/ponpon');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="ponpon-start"]').click();
+
+    await expect(page.locator('[data-testid="ponpon-canvas"]')).toBeVisible({ timeout: 8000 });
+
+    // 左右ボタンを押しっぱなしにして画面外へキャラクターを追いやり、
+    // 足場を外して落下→ゲームオーバーに到達させる
+    const leftBtn = page.locator('[data-testid="ponpon-left"]');
+    await leftBtn.dispatchEvent('pointerdown');
+    await page.waitForTimeout(8000);
+
+    await expect(page.getByTestId('ponpon-final-score')).toBeVisible({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## 概要
ミニゲームハブに新しいゲーム「ぽんぽんジャンプ」（縦スクロールジャンプアクション）を追加する。

## 遊び方
- キャラクターが自動で跳ね続ける
- 左右に動かして（ドラッグ or ボタン or 矢印キー）足場を渡り歩き、上を目指す
- 足場を踏み外して画面外（カメラの下端）まで落ちると終了。到達した高さがスコア

## 実装内容
- `app/sansu-100/games/PonPonJumpGame.tsx`: Canvas 2D実装。カメラをプレイヤーの最高到達点に追従させる縦スクロール、足場の動的補充・掃除、落下判定
- `app/sansu-100/minigame/ponpon/page.tsx`: ページラッパー（既存パターン踏襲）
- `minigame-list.ts` / `minigame-rewards.ts` / `badge-catalog.ts`: 一覧登録・バッジ2種追加
- `tests/sansu/ponpon.spec.ts`: E2Eテスト6件（左移動しっぱなしで足場を外して落下→ゲームオーバー画面到達も確認）

## 設計上の注意点（過去のレビュー指摘を反映）
- ゲーム終了は `overRef` で単一ガードし、`onGameOver` の二重呼び出しを防止（既存ゲーム共通パターン踏襲）

## 動作確認
- `npm run build` 成功
- ローカルSWA環境（localhost:4280）で6テストを2回連続実行、全12回pass確認済み

Closes #141