### PR TITLE
feat(sansu-100): ミニゲーム「はじいてホッケー」を追加

### DIFF
--- a/app/sansu-100/games/AirHockeyGame.tsx
+++ b/app/sansu-100/games/AirHockeyGame.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { startGameLoop } from '../lib/minigame-core';
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// はじいてホッケー（エアホッケー風の反射ゲーム）
+// 下のマレット（自分）を左右に動かしてパックを打ち返し、上の相手ゴールに入れる。
+// 相手（CPU）は自動でパックを追いかける。制限時間30秒、または5点差をつけられると終了。
+
+const W = 260;
+const H = 380;
+const PADDLE_W = 56;
+const PADDLE_H = 10;
+const PLAYER_Y = H - 24;
+const CPU_Y = 24;
+const PUCK_R = 8;
+const CPU_SPEED = 2.4;
+const GAME_DURATION_MS = 30000;
+const LOSE_MARGIN = 5;
+const PUCK_SPEED_INIT = 2.6;
+const PUCK_SPEED_MAX = 6;
+
+interface GS {
+  playerX: number;
+  cpuX: number;
+  puckX: number;
+  puckY: number;
+  puckVX: number;
+  puckVY: number;
+  playerScore: number;
+  cpuScore: number;
+  elapsedMs: number;
+  over: boolean;
+}
+
+function servePuck(gs: GS, rand: () => number): void {
+  gs.puckX = W / 2;
+  gs.puckY = H / 2;
+  const angle = (rand() * 0.8 - 0.4) * Math.PI; // ほぼ縦方向、ややランダムに左右
+  const dir = rand() < 0.5 ? 1 : -1;
+  gs.puckVX = Math.sin(angle) * PUCK_SPEED_INIT;
+  gs.puckVY = Math.cos(angle) * PUCK_SPEED_INIT * dir;
+}
+
+function createGS(rand: () => number): GS {
+  const gs: GS = {
+    playerX: W / 2 - PADDLE_W / 2,
+    cpuX: W / 2 - PADDLE_W / 2,
+    puckX: W / 2,
+    puckY: H / 2,
+    puckVX: 0,
+    puckVY: 0,
+    playerScore: 0,
+    cpuScore: 0,
+    elapsedMs: 0,
+    over: false,
+  };
+  servePuck(gs, rand);
+  return gs;
+}
+
+function reflectOffPaddle(gs: GS, paddleX: number, goingDown: boolean): void {
+  const hitOffset = (gs.puckX - (paddleX + PADDLE_W / 2)) / (PADDLE_W / 2); // -1..1
+  gs.puckVY = goingDown ? -Math.abs(gs.puckVY) : Math.abs(gs.puckVY);
+  gs.puckVX += hitOffset * 1.5;
+  const speed = Math.hypot(gs.puckVX, gs.puckVY);
+  if (speed > PUCK_SPEED_MAX) {
+    const s = PUCK_SPEED_MAX / speed;
+    gs.puckVX *= s;
+    gs.puckVY *= s;
+  }
+}
+
+function tick(
+  gs: GS,
+  deltaMs: number,
+  moveDir: number,
+  rand: () => number,
+  onEvent: (ev: 'hit' | 'score' | 'over') => void
+): void {
+  if (gs.over) return;
+  gs.elapsedMs += deltaMs;
+
+  if (gs.elapsedMs >= GAME_DURATION_MS) {
+    gs.over = true;
+    onEvent('over');
+    return;
+  }
+
+  // プレイヤーマレット移動
+  gs.playerX = Math.max(0, Math.min(W - PADDLE_W, gs.playerX + moveDir * 4));
+
+  // CPUマレットはパックを追いかける
+  const cpuCenter = gs.cpuX + PADDLE_W / 2;
+  if (Math.abs(gs.puckX - cpuCenter) > 2) {
+    gs.cpuX += Math.sign(gs.puckX - cpuCenter) * CPU_SPEED;
+  }
+  gs.cpuX = Math.max(0, Math.min(W - PADDLE_W, gs.cpuX));
+
+  // パック移動
+  gs.puckX += gs.puckVX;
+  gs.puckY += gs.puckVY;
+
+  // 左右の壁で反射
+  if (gs.puckX - PUCK_R < 0) {
+    gs.puckX = PUCK_R;
+    gs.puckVX = Math.abs(gs.puckVX);
+  } else if (gs.puckX + PUCK_R > W) {
+    gs.puckX = W - PUCK_R;
+    gs.puckVX = -Math.abs(gs.puckVX);
+  }
+
+  // プレイヤーマレットとの衝突（下向き移動中のみ）
+  if (
+    gs.puckVY > 0 &&
+    gs.puckY + PUCK_R >= PLAYER_Y &&
+    gs.puckY + PUCK_R <= PLAYER_Y + PADDLE_H + 8 &&
+    gs.puckX >= gs.playerX - PUCK_R &&
+    gs.puckX <= gs.playerX + PADDLE_W + PUCK_R
+  ) {
+    gs.puckY = PLAYER_Y - PUCK_R;
+    reflectOffPaddle(gs, gs.playerX, true);
+    onEvent('hit');
+  }
+
+  // CPUマレットとの衝突（上向き移動中のみ）
+  if (
+    gs.puckVY < 0 &&
+    gs.puckY - PUCK_R <= CPU_Y + PADDLE_H &&
+    gs.puckY - PUCK_R >= CPU_Y - 8 &&
+    gs.puckX >= gs.cpuX - PUCK_R &&
+    gs.puckX <= gs.cpuX + PADDLE_W + PUCK_R
+  ) {
+    gs.puckY = CPU_Y + PADDLE_H + PUCK_R;
+    reflectOffPaddle(gs, gs.cpuX, false);
+    onEvent('hit');
+  }
+
+  // ゴール判定
+  if (gs.puckY - PUCK_R < -6) {
+    gs.playerScore += 1;
+    onEvent('score');
+    servePuck(gs, rand);
+  } else if (gs.puckY + PUCK_R > H + 6) {
+    gs.cpuScore += 1;
+    onEvent('score');
+    servePuck(gs, rand);
+    if (gs.cpuScore - gs.playerScore >= LOSE_MARGIN) {
+      gs.over = true;
+      onEvent('over');
+    }
+  }
+}
+
+function draw(ctx: CanvasRenderingContext2D, gs: GS, scale: number): void {
+  ctx.fillStyle = '#0f172a';
+  ctx.fillRect(0, 0, W * scale, H * scale);
+
+  // センターライン
+  ctx.strokeStyle = 'rgba(148,163,184,0.3)';
+  ctx.setLineDash([5, 5]);
+  ctx.beginPath();
+  ctx.moveTo(0, (H / 2) * scale);
+  ctx.lineTo(W * scale, (H / 2) * scale);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // CPUマレット
+  ctx.fillStyle = '#f87171';
+  ctx.fillRect(gs.cpuX * scale, CPU_Y * scale, PADDLE_W * scale, PADDLE_H * scale);
+
+  // プレイヤーマレット
+  ctx.fillStyle = '#60a5fa';
+  ctx.fillRect(gs.playerX * scale, PLAYER_Y * scale, PADDLE_W * scale, PADDLE_H * scale);
+
+  // パック
+  ctx.fillStyle = '#fde047';
+  ctx.beginPath();
+  ctx.arc(gs.puckX * scale, gs.puckY * scale, PUCK_R * scale, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function computeWidth(): number {
+  if (typeof window === 'undefined') return W;
+  return Math.max(220, Math.min(320, window.innerWidth - 48));
+}
+
+export default function AirHockeyGame({
+  onGameOver,
+}: {
+  onGameOver: (score: number) => void;
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gsRef = useRef<GS>(createGS(Math.random));
+  const moveRef = useRef(0);
+  const scaleRef = useRef(1);
+  const overRef = useRef(false);
+  const soundRef = useRef(true);
+  const [playerScore, setPlayerScore] = useState(0);
+  const [cpuScore, setCpuScore] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(Math.ceil(GAME_DURATION_MS / 1000));
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const cw = computeWidth();
+    const scale = cw / W;
+    scaleRef.current = scale;
+    const ch = H * scale;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(cw * dpr);
+    canvas.height = Math.round(ch * dpr);
+    canvas.style.width = `${cw}px`;
+    canvas.style.height = `${ch}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const rand = Math.random.bind(Math);
+    gsRef.current = createGS(rand);
+    overRef.current = false;
+    moveRef.current = 0;
+    soundRef.current = storage.getSettings().soundOn;
+    setPlayerScore(0);
+    setCpuScore(0);
+    setTimeLeft(Math.ceil(GAME_DURATION_MS / 1000));
+
+    const handle = startGameLoop({
+      stepMs: () => 16,
+      onTick: () => {
+        if (overRef.current) return;
+        const gs = gsRef.current;
+        tick(gs, 16, moveRef.current, rand, (ev) => {
+          if (ev === 'hit' && soundRef.current) sound.correct();
+          if (ev === 'score') {
+            setPlayerScore(gs.playerScore);
+            setCpuScore(gs.cpuScore);
+            if (soundRef.current) sound.eat();
+          }
+          if (ev === 'over' && !overRef.current) {
+            overRef.current = true;
+            handle.stop();
+            if (soundRef.current) sound.fanfare();
+            onGameOver(gs.playerScore);
+          }
+        });
+        setTimeLeft(
+          Math.max(0, Math.ceil((GAME_DURATION_MS - gs.elapsedMs) / 1000))
+        );
+      },
+      onRender: () => draw(ctx, gsRef.current, scaleRef.current),
+    });
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') moveRef.current = -1;
+      else if (e.key === 'ArrowRight') moveRef.current = 1;
+    };
+    const onKeyUp = () => {
+      moveRef.current = 0;
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      handle.stop();
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1ゲーム。再戦は親が key で再マウント
+  }, []);
+
+  const onMove = (e: React.PointerEvent) => {
+    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
+    const logicalX = (e.clientX - rect.left) / scaleRef.current;
+    gsRef.current.playerX = Math.max(
+      0,
+      Math.min(W - PADDLE_W, logicalX - PADDLE_W / 2)
+    );
+  };
+
+  const btn =
+    'flex h-14 flex-1 items-center justify-center rounded-xl bg-gray-200 text-2xl font-bold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 select-none';
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="flex w-full max-w-xs items-center justify-between px-1 text-sm font-bold text-gray-800 dark:text-gray-100">
+        <span data-testid="airhockey-score">
+          きみ <span className="tabular-nums">{playerScore}</span> - <span className="tabular-nums">{cpuScore}</span> あいて
+        </span>
+        <span className={timeLeft <= 5 ? 'text-red-600' : ''}>⏱ {timeLeft}秒</span>
+      </div>
+      <canvas
+        ref={canvasRef}
+        data-testid="airhockey-canvas"
+        onPointerDown={onMove}
+        onPointerMove={onMove}
+        className="touch-none rounded-xl shadow-md"
+        style={{ touchAction: 'none' }}
+      />
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        ゆびで うごかす、ボタンでもOK
+      </p>
+      <div className="flex w-full max-w-xs gap-3">
+        <button
+          type="button"
+          className={btn}
+          data-testid="airhockey-left"
+          aria-label="ひだり"
+          onPointerDown={() => (moveRef.current = -1)}
+          onPointerUp={() => (moveRef.current = 0)}
+          onPointerLeave={() => (moveRef.current = 0)}
+        >
+          ◀
+        </button>
+        <button
+          type="button"
+          className={btn}
+          data-testid="airhockey-right"
+          aria-label="みぎ"
+          onPointerDown={() => (moveRef.current = 1)}
+          onPointerUp={() => (moveRef.current = 0)}
+          onPointerLeave={() => (moveRef.current = 0)}
+        >
+          ▶
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/games/AirHockeyGame.tsx
+++ b/app/sansu-100/games/AirHockeyGame.tsx
@@ -62,6 +62,8 @@ function createGS(rand: () => number): GS {
   return gs;
 }
 
+const PUCK_VY_MIN = 1.5; // これ未満だとパックがほぼ水平に張り付いて停滞するので下限を設ける
+
 function reflectOffPaddle(gs: GS, paddleX: number, goingDown: boolean): void {
   const hitOffset = (gs.puckX - (paddleX + PADDLE_W / 2)) / (PADDLE_W / 2); // -1..1
   gs.puckVY = goingDown ? -Math.abs(gs.puckVY) : Math.abs(gs.puckVY);
@@ -71,6 +73,9 @@ function reflectOffPaddle(gs: GS, paddleX: number, goingDown: boolean): void {
     const s = PUCK_SPEED_MAX / speed;
     gs.puckVX *= s;
     gs.puckVY *= s;
+  }
+  if (Math.abs(gs.puckVY) < PUCK_VY_MIN) {
+    gs.puckVY = Math.sign(gs.puckVY) * PUCK_VY_MIN;
   }
 }
 

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -106,6 +106,8 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'starshooter_hero', category: 'minigame', name: '宇宙のヒーロー', description: 'ピューピュー星空で35てん', icon: '🌟', tier: 'gold', rarity: 'epic' },
   { id: 'ponpon_climber', category: 'minigame', name: 'のぼり名人', description: 'ぽんぽんジャンプで たかさ30', icon: '🐰', tier: 'silver', rarity: 'rare' },
   { id: 'ponpon_skyhigh', category: 'minigame', name: '天まで とどけ', description: 'ぽんぽんジャンプで たかさ80', icon: '☁️', tier: 'gold', rarity: 'epic' },
+  { id: 'airhockey_rookie', category: 'minigame', name: 'ホッケー見習い', description: 'はじいてホッケーで5てん', icon: '🏒', tier: 'silver', rarity: 'rare' },
+  { id: 'airhockey_champion', category: 'minigame', name: 'ホッケー王者', description: 'はじいてホッケーで10てん', icon: '🏆', tier: 'gold', rarity: 'epic' },
   { id: 'games_explorer', category: 'minigame', name: 'ゲームたんけんか', description: '5しゅるいの ゲームで あそんだ', icon: '🎮', tier: 'silver', rarity: 'rare' },
   { id: 'games_allstar', category: 'minigame', name: 'ゲームマスター', description: 'ぜんぶの ゲームで あそんだ', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -179,6 +179,18 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     ],
     available: true,
   },
+  {
+    id: 'airhockey',
+    name: 'はじいてホッケー',
+    emoji: '🏒',
+    desc: 'マレットで パックを うちかえせ！',
+    howTo: [
+      'ゆびで うごかす か ◀▶ボタンで じぶんの マレットを うごかす',
+      'パックを うちかえして あいての ゴールに いれよう',
+      'せいげん時間の あいだ つづくよ。あいてに 5てん さきに ひきはなされると おわり',
+    ],
+    available: true,
+  },
 ];
 
 const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(

--- a/app/sansu-100/lib/minigame-rewards.ts
+++ b/app/sansu-100/lib/minigame-rewards.ts
@@ -15,7 +15,8 @@ export type MinigameId =
   | 'swipesort'
   | 'rhythmdon'
   | 'starshooter'
-  | 'ponpon';
+  | 'ponpon'
+  | 'airhockey';
 
 // gameId ごとの { しきい値: バッジID }（昇順）
 const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
@@ -74,6 +75,10 @@ const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
   ponpon: [
     { score: 30, badgeId: 'ponpon_climber' },
     { score: 80, badgeId: 'ponpon_skyhigh' },
+  ],
+  airhockey: [
+    { score: 5, badgeId: 'airhockey_rookie' },
+    { score: 10, badgeId: 'airhockey_champion' },
   ],
 };
 

--- a/app/sansu-100/minigame/airhockey/page.tsx
+++ b/app/sansu-100/minigame/airhockey/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
+import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
+import NewRecordBanner from '../../components/NewRecordBanner';
+import AirHockeyGame from '../../games/AirHockeyGame';
+import { useSansuUser } from '../../hooks/useSansuUser';
+import { sansuApi } from '../../lib/api-client';
+import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
+import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
+
+type Phase = 'intro' | 'playing' | 'over';
+
+export default function AirHockeyPage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, saveUser, loaded } = useSansuUser();
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [lastScore, setLastScore] = useState(0);
+  const [round, setRound] = useState(0);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [overlayBadges, setOverlayBadges] = useState<string[]>([]);
+  const [newRecord, setNewRecord] = useState(false);
+
+  const coins = currentUser?.coins ?? 0;
+
+  const start = useCallback(async () => {
+    if (!currentUser) return;
+    setBusy(true);
+    setMessage(null);
+    setNewRecord(false);
+    try {
+      const res = await sansuApi.spend(currentUser.id, 'play');
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        setRound((r) => r + 1);
+        setPhase('playing');
+      } else {
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
+      }
+    } catch {
+      setMessage('いまは つうしんできないよ（あとでね）');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentUser, saveUser]);
+
+  const handleGameOver = useCallback(
+    async (score: number) => {
+      setLastScore(score);
+      setPhase('over');
+      if (!currentUser) return;
+      const newBadges = evaluateMinigameBadges(
+        'airhockey',
+        score,
+        currentUser.earnedBadges
+      );
+      try {
+        const res = await sansuApi.awardBadge(currentUser.id, newBadges, score, 'airhockey');
+        if (res.user) saveUser(res.user);
+        if (res.newRecord) setNewRecord(true);
+        if (newBadges.length > 0) setOverlayBadges(newBadges);
+      } catch {
+        // 報酬付与失敗は致命的でない
+      }
+    },
+    [currentUser, saveUser]
+  );
+
+  if (loaded && !currentUser) {
+    if (typeof window !== 'undefined') router.replace('/sansu-100');
+    return <main className="p-8" />;
+  }
+  if (!currentUser) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-4 p-4">
+        {phase === 'playing' ? (
+          <Link
+            href="/sansu-100/minigame"
+            className="inline-block text-sm font-semibold text-blue-600 dark:text-blue-300"
+          >
+            ← やめる
+          </Link>
+        ) : (
+          <Header
+            title="🏒 はじいてホッケー"
+            description="マレットで パックを うちかえせ！"
+            showBackButton
+            backHref="/sansu-100/minigame"
+            backLabel="ゲームせんたくにもどる"
+          />
+        )}
+
+        {message ? (
+          <div className="rounded-xl bg-yellow-100 px-4 py-3 text-center font-bold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            {message}
+          </div>
+        ) : null}
+
+        {phase === 'intro' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-6xl">🏒</p>
+            <HowToPlay steps={minigameHowTo('airhockey')} />
+            <p className="text-gray-700 dark:text-gray-200">
+              コインを {SPEND_COSTS.play}まい つかって あそぶよ
+            </p>
+            <div className="flex justify-center">
+              <CoinBalance coins={coins} />
+            </div>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-cyan-600 py-4 text-lg font-bold text-white hover:bg-cyan-700 disabled:opacity-60"
+              data-testid="airhockey-start"
+            >
+              🪙 {SPEND_COSTS.play} であそぶ
+            </button>
+          </section>
+        ) : null}
+
+        {phase === 'playing' ? (
+          <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
+            <AirHockeyGame key={round} onGameOver={handleGameOver} />
+          </section>
+        ) : null}
+
+        {phase === 'over' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              おわり！
+            </p>
+            <p className="text-lg text-gray-700 dark:text-gray-200">
+              きみの とくてん: <b data-testid="airhockey-final-score">{lastScore}</b>
+            </p>
+            {newRecord ? <NewRecordBanner score={lastScore} /> : null}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-cyan-600 py-4 text-lg font-bold text-white hover:bg-cyan-700 disabled:opacity-60"
+              data-testid="airhockey-again"
+            >
+              🪙 {SPEND_COSTS.play} で もういちど
+            </button>
+            <Link
+              href="/sansu-100/minigame"
+              className="block rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ほかの ゲームへ
+            </Link>
+          </section>
+        ) : null}
+      </div>
+
+      {overlayBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={overlayBadges}
+          onDone={() => setOverlayBadges([])}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/tests/sansu/airhockey.spec.ts
+++ b/tests/sansu/airhockey.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * はじいてホッケー（エアホッケー風の反射ゲーム）のE2Eテスト。
+ *
+ * - 本番ユーザは触らない。毎回ユニークな E2E 接頭辞ユーザを新規作成する。
+ * - baseURL は http://localhost:4280 (playwright.config.sansu.ts 参照)
+ * - パックの反射・得点判定はCanvas内のゲームロジックで発生するため、
+ *   ここでは「ページ表示・スタート・スコア表示・時間経過」まで確認する。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `AHK${suffix}`;
+}
+
+async function registerAndLogin(page: Page, name: string): Promise<void> {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sansu-100:dev-seeded', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of PIN) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'これでとうろく！' }).click();
+  await page.waitForURL('**/sansu-100', { timeout: 10000 });
+}
+
+async function earnCoinsViaDebug(page: Page): Promise<void> {
+  await page.goto('/sansu-100/play');
+  await page.waitForLoadState('networkidle');
+  const lv1 = page.locator('[data-testid="level-pick-1"]');
+  if (await lv1.isVisible()) {
+    await lv1.click();
+  }
+  const dbgBtn = page.locator('[data-testid="debug-finish-perfect"]');
+  if (await dbgBtn.isVisible({ timeout: 5000 })) {
+    await dbgBtn.click();
+  }
+  await page.goto('/sansu-100');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('はじいてホッケー ミニゲーム', () => {
+  test('ミニゲーム一覧にはじいてホッケーが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('はじいてホッケー')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('はじいてホッケーページにアクセスすると intro 画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame/airhockey');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('はじいてホッケー').first()).toBeVisible({ timeout: 8000 });
+    const startBtn = page.locator('[data-testid="airhockey-start"]');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('コイン不足時にスタートするとエラーメッセージが出る', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await page.goto('/sansu-100/minigame/airhockey');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="airhockey-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+    await expect(
+      page.getByText(/さんすうを|コインが/)
+    ).toBeVisible({ timeout: 6000 });
+  });
+
+  test('コイン取得後にスタートするとキャンバスと操作ボタンが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/airhockey');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="airhockey-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    await expect(page.locator('[data-testid="airhockey-canvas"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="airhockey-left"]')).toBeVisible();
+    await expect(page.locator('[data-testid="airhockey-right"]')).toBeVisible();
+    await expect(page.getByText('← やめる')).toBeVisible();
+  });
+
+  test('時間が経過するとタイマーが減っていく', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/airhockey');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="airhockey-start"]').click();
+
+    const timerText = page.getByText(/⏱ \d+秒/);
+    await expect(timerText).toBeVisible({ timeout: 8000 });
+    const first = await timerText.textContent();
+    await page.waitForTimeout(2000);
+    const second = await timerText.textContent();
+    expect(first).not.toBe(second);
+  });
+
+  test('スコア表示が「きみ N - N あいて」の形式で表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/airhockey');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="airhockey-start"]').click();
+
+    await expect(page.getByTestId('airhockey-score')).toBeVisible({ timeout: 8000 });
+    const text = await page.getByTestId('airhockey-score').textContent();
+    expect(text).toMatch(/きみ\s*\d+\s*-\s*\d+\s*あいて/);
+  });
+});


### PR DESCRIPTION
## 概要
ミニゲームハブに新しいゲーム「はじいてホッケー」（エアホッケー風の反射ゲーム）を追加する。

## 遊び方
- 下側のマレットを左右に動かして（ドラッグ or ボタン or 矢印キー）パックを打ち返す
- 上側のCPUマレットが自動でパックを追いかけて打ち返す
- 相手ゴール（上）にパックを入れると得点。制限時間30秒、または5点差をつけられると終了
- 自分の得点がスコア

## 実装内容
- `app/sansu-100/games/AirHockeyGame.tsx`: Canvas 2D実装。ブロックくずしのボール反射ロジックを応用し、パドルを2つ（プレイヤー/CPU）にして得点制にした
- `app/sansu-100/minigame/airhockey/page.tsx`: ページラッパー（既存パターン踏襲）
- `minigame-list.ts` / `minigame-rewards.ts` / `badge-catalog.ts`: 一覧登録・バッジ2種追加
- `tests/sansu/airhockey.spec.ts`: E2Eテスト6件

## 設計上の注意点（過去のレビュー指摘を反映）
- ゲーム終了（時間切れ／5点差）は `overRef` で単一ガードし、`onGameOver` の二重呼び出しを防止

## 動作確認
- `npm run build` 成功
- ローカルSWA環境（localhost:4280）で6テストを2回連続実行、全12回pass確認済み

Closes #143