### PR TITLE
fix(sansu-100): パクパクおじさんの操作性改善・おぼえてタッチの光る演出強化・管理者バイパスを追加

### DIFF
--- a/api/src/functions/sansuDebugGrant.ts
+++ b/api/src/functions/sansuDebugGrant.ts
@@ -1,13 +1,14 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 
-import { isDebugHost } from '../shared/debugEnv';
+import { isAdminAccount, isDebugHost } from '../shared/debugEnv';
 import { type SansuUserEntity, toPublic } from '../shared/sansuTypes';
 import { USERS_PARTITION, usersTable } from '../shared/tableClient';
 
 type DebugGrantBody = { userId: string; amount?: number };
 
-// デバッグ用: コインを付与する。本番ドメインからのリクエストは 403。
-// テスト用途（一気にコインを得て着せ替え/ミニゲームを試す）専用。
+// デバッグ用: コインを付与する。本番ドメインからのリクエストは、対象ユーザーが
+// 管理者アカウント（isAdminAccount: 名前＋登録済みPINのハッシュ一致）でない限り 403。
+// テスト用途（一気にコインを得て着せ替え/ミニゲームを試す）＋管理者の自由な付与に使う。
 app.http('sansuDebugGrantPost', {
   methods: ['POST'],
   authLevel: 'anonymous',
@@ -17,17 +18,6 @@ app.http('sansuDebugGrantPost', {
     context: InvocationContext
   ): Promise<HttpResponseInit> => {
     try {
-      // SWA 実環境では x-forwarded-host 単独だと内部ホストが入ることがあるため、
-      // 複数のホスト系ヘッダのいずれかが「正規ドメイン以外」なら許可する（本番ドメインは全て不一致→403）。
-      const allowed = [
-        req.headers.get('x-forwarded-host'),
-        req.headers.get('host'),
-        req.headers.get('x-original-host'),
-        req.headers.get('referer'),
-      ].some((c) => isDebugHost(c));
-      if (!allowed) {
-        return { status: 403, jsonBody: { error: 'debug disabled' } };
-      }
       const body = (await req.json()) as DebugGrantBody;
       if (!body.userId) {
         return { status: 400, jsonBody: { error: 'missing fields' } };
@@ -46,6 +36,19 @@ app.http('sansuDebugGrantPost', {
         );
       } catch {
         return { status: 404, jsonBody: { error: 'user not found' } };
+      }
+
+      // SWA 実環境では x-forwarded-host 単独だと内部ホストが入ることがあるため、
+      // 複数のホスト系ヘッダのいずれかが「正規ドメイン以外」なら許可する（本番ドメインは全て不一致→403）。
+      // 管理者ユーザー自身への付与は、本番ドメインでも許可する。
+      const debugHost = [
+        req.headers.get('x-forwarded-host'),
+        req.headers.get('host'),
+        req.headers.get('x-original-host'),
+        req.headers.get('referer'),
+      ].some((c) => isDebugHost(c));
+      if (!debugHost && !(await isAdminAccount(user))) {
+        return { status: 403, jsonBody: { error: 'debug disabled' } };
       }
 
       const updated = {

--- a/api/src/functions/sansuDebugGrant.ts
+++ b/api/src/functions/sansuDebugGrant.ts
@@ -7,7 +7,7 @@ import { USERS_PARTITION, usersTable } from '../shared/tableClient';
 type DebugGrantBody = { userId: string; amount?: number };
 
 // デバッグ用: コインを付与する。本番ドメインからのリクエストは、対象ユーザーが
-// 管理者アカウント（isAdminAccount: 名前＋登録済みPINのハッシュ一致）でない限り 403。
+// 管理者アカウント（isAdminAccount: 固定userIdとの一致）でない限り 403。
 // テスト用途（一気にコインを得て着せ替え/ミニゲームを試す）＋管理者の自由な付与に使う。
 app.http('sansuDebugGrantPost', {
   methods: ['POST'],
@@ -47,7 +47,7 @@ app.http('sansuDebugGrantPost', {
         req.headers.get('x-original-host'),
         req.headers.get('referer'),
       ].some((c) => isDebugHost(c));
-      if (!debugHost && !(await isAdminAccount(user))) {
+      if (!debugHost && !isAdminAccount(user)) {
         return { status: 403, jsonBody: { error: 'debug disabled' } };
       }
 

--- a/api/src/functions/sansuDebugGrant.ts
+++ b/api/src/functions/sansuDebugGrant.ts
@@ -1,14 +1,17 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 
-import { isAdminAccount, isDebugHost } from '../shared/debugEnv';
+import { isDebugHost } from '../shared/debugEnv';
 import { type SansuUserEntity, toPublic } from '../shared/sansuTypes';
 import { USERS_PARTITION, usersTable } from '../shared/tableClient';
 
 type DebugGrantBody = { userId: string; amount?: number };
 
-// デバッグ用: コインを付与する。本番ドメインからのリクエストは、対象ユーザーが
-// 管理者アカウント（isAdminAccount: 固定userIdとの一致）でない限り 403。
-// テスト用途（一気にコインを得て着せ替え/ミニゲームを試す）＋管理者の自由な付与に使う。
+// デバッグ用: コインを付与する。本番ドメインからのリクエストは常に 403。
+// テスト用途（一気にコインを得て着せ替え/ミニゲームを試す）専用。
+// このエンドポイントは認証なし（body.userId を渡すだけで誰でも呼べる）なので、
+// 「対象が管理者アカウントか」だけで本番開放すると、他人が管理者のuserIdを
+// 知っているだけでそのアカウントのコインを書き換えられてしまう。そのため
+// 管理者であっても本番でのコイン付与は行わず、localhost / SWA PRプレビューに限定する。
 app.http('sansuDebugGrantPost', {
   methods: ['POST'],
   authLevel: 'anonymous',
@@ -40,14 +43,13 @@ app.http('sansuDebugGrantPost', {
 
       // SWA 実環境では x-forwarded-host 単独だと内部ホストが入ることがあるため、
       // 複数のホスト系ヘッダのいずれかが「正規ドメイン以外」なら許可する（本番ドメインは全て不一致→403）。
-      // 管理者ユーザー自身への付与は、本番ドメインでも許可する。
       const debugHost = [
         req.headers.get('x-forwarded-host'),
         req.headers.get('host'),
         req.headers.get('x-original-host'),
         req.headers.get('referer'),
       ].some((c) => isDebugHost(c));
-      if (!debugHost && !isAdminAccount(user)) {
+      if (!debugHost) {
         return { status: 403, jsonBody: { error: 'debug disabled' } };
       }
 

--- a/api/src/functions/sansuSpend.ts
+++ b/api/src/functions/sansuSpend.ts
@@ -1,6 +1,6 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 
-import { isDebugHost } from '../shared/debugEnv';
+import { isAdminAccount, isDebugHost } from '../shared/debugEnv';
 import { getSpendCost } from '../shared/minigame';
 import { type SansuUserEntity, toPublic } from '../shared/sansuTypes';
 import { USERS_PARTITION, usersTable } from '../shared/tableClient';
@@ -48,7 +48,12 @@ app.http('sansuSpendPost', {
         req.headers.get('x-original-host'),
         req.headers.get('referer'),
       ].some((c) => isDebugHost(c));
-      if (body.reason === 'play' && credits <= 0 && !debugHost) {
+      if (
+        body.reason === 'play' &&
+        credits <= 0 &&
+        !debugHost &&
+        !(await isAdminAccount(user))
+      ) {
         return {
           status: 409,
           jsonBody: { error: 'no_plays', minigameCredits: 0 },

--- a/api/src/functions/sansuSpend.ts
+++ b/api/src/functions/sansuSpend.ts
@@ -52,7 +52,7 @@ app.http('sansuSpendPost', {
         body.reason === 'play' &&
         credits <= 0 &&
         !debugHost &&
-        !(await isAdminAccount(user))
+        !isAdminAccount(user)
       ) {
         return {
           status: 409,

--- a/api/src/shared/debugEnv.ts
+++ b/api/src/shared/debugEnv.ts
@@ -11,38 +11,11 @@ export function isDebugHost(host: string | null | undefined): boolean {
 }
 
 // 常に管理者として扱うユーザー（本番環境でも算数ゲート等をスキップする）。
-// 表示名の一致だけだと同名で誰でも登録できてしまうため、登録済みPINのハッシュも
-// あわせて検証する（名前だけでのなりすましを防ぐ）。
-// PIN 実値はソースに書かず環境変数 SANSU_ADMIN_PIN で渡す（未設定なら常に不一致＝安全側）。
-export const ADMIN_USER_NAME = 'たくみ';
+// 登録時に発行される固定の userId（rowKey）で判定する。表示名は誰でも自由に
+// 登録し直せる自己申告テキストなので識別には使わない。userId はランダムな
+// UUID（個人情報ではない不透明な識別子）なので、ソースに直接書いてよい。
+const ADMIN_USER_ID = '158e35fa-6b0a-4817-9747-cd6b12b02830';
 
-export function isAdminUserName(name: string | null | undefined): boolean {
-  return name === ADMIN_USER_NAME;
-}
-
-async function hashPin(pin: string, salt: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(`${salt}:${pin}`);
-  const hashBuf = await crypto.subtle.digest('SHA-256', data);
-  const bytes = new Uint8Array(hashBuf);
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
-/**
- * 管理者アカウントかどうかを名前＋登録済みPINのハッシュ一致で判定する。
- * サーバー側のみで完結する検証（クライアントからPINを送らせる必要はない）。
- */
-export async function isAdminAccount(user: {
-  name?: string | null;
-  pinHash?: string | null;
-  pinSalt?: string | null;
-}): Promise<boolean> {
-  const adminPin = process.env.SANSU_ADMIN_PIN;
-  if (!adminPin) return false;
-  if (!isAdminUserName(user.name)) return false;
-  if (!user.pinHash || !user.pinSalt) return false;
-  const expected = await hashPin(adminPin, user.pinSalt);
-  return expected === user.pinHash;
+export function isAdminAccount(user: { rowKey?: string | null }): boolean {
+  return user.rowKey === ADMIN_USER_ID;
 }

--- a/api/src/shared/debugEnv.ts
+++ b/api/src/shared/debugEnv.ts
@@ -9,3 +9,40 @@ export function isDebugHost(host: string | null | undefined): boolean {
   if (h.includes('.azurestaticapps.net') && /-\d+\./.test(h)) return true;
   return false;
 }
+
+// 常に管理者として扱うユーザー（本番環境でも算数ゲート等をスキップする）。
+// 表示名の一致だけだと同名で誰でも登録できてしまうため、登録済みPINのハッシュも
+// あわせて検証する（名前だけでのなりすましを防ぐ）。
+// PIN 実値はソースに書かず環境変数 SANSU_ADMIN_PIN で渡す（未設定なら常に不一致＝安全側）。
+export const ADMIN_USER_NAME = 'たくみ';
+
+export function isAdminUserName(name: string | null | undefined): boolean {
+  return name === ADMIN_USER_NAME;
+}
+
+async function hashPin(pin: string, salt: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(`${salt}:${pin}`);
+  const hashBuf = await crypto.subtle.digest('SHA-256', data);
+  const bytes = new Uint8Array(hashBuf);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * 管理者アカウントかどうかを名前＋登録済みPINのハッシュ一致で判定する。
+ * サーバー側のみで完結する検証（クライアントからPINを送らせる必要はない）。
+ */
+export async function isAdminAccount(user: {
+  name?: string | null;
+  pinHash?: string | null;
+  pinSalt?: string | null;
+}): Promise<boolean> {
+  const adminPin = process.env.SANSU_ADMIN_PIN;
+  if (!adminPin) return false;
+  if (!isAdminUserName(user.name)) return false;
+  if (!user.pinHash || !user.pinSalt) return false;
+  const expected = await hashPin(adminPin, user.pinSalt);
+  return expected === user.pinHash;
+}

--- a/app/sansu-100/games/OboeteTouchGame.tsx
+++ b/app/sansu-100/games/OboeteTouchGame.tsx
@@ -10,10 +10,10 @@ import { storage } from '../lib/storage';
 // 間違えたら終了、そこまでクリアしたレベル数（=シーケンス長-1）がスコア。
 
 const PADS = [
-  { id: 0, color: '#ef4444', lit: '#fca5a5' },
-  { id: 1, color: '#3b82f6', lit: '#93c5fd' },
-  { id: 2, color: '#eab308', lit: '#fde68a' },
-  { id: 3, color: '#22c55e', lit: '#86efac' },
+  { id: 0, color: '#ef4444' },
+  { id: 1, color: '#3b82f6' },
+  { id: 2, color: '#eab308' },
+  { id: 3, color: '#22c55e' },
 ] as const;
 
 type Phase = 'showing' | 'input' | 'gap' | 'wrong';
@@ -123,18 +123,28 @@ export default function OboeteTouchGame({
               : 'よく みてね…'}
       </p>
       <div className="grid grid-cols-2 gap-3">
-        {PADS.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            disabled={phase !== 'input'}
-            onClick={() => handlePadTap(p.id)}
-            data-testid={`oboete-pad-${p.id}`}
-            className="size-24 rounded-2xl shadow-md transition-transform active:scale-90 disabled:active:scale-100"
-            style={{ backgroundColor: litPad === p.id ? p.lit : p.color }}
-            aria-label={`パッド${p.id + 1}`}
-          />
-        ))}
+        {PADS.map((p) => {
+          const isLit = litPad === p.id;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              disabled={phase !== 'input'}
+              onClick={() => handlePadTap(p.id)}
+              data-testid={`oboete-pad-${p.id}`}
+              className="size-24 rounded-2xl transition-all duration-100 ease-out active:scale-90 disabled:active:scale-100"
+              style={{
+                backgroundColor: p.color,
+                filter: isLit ? 'brightness(1.6) saturate(1.3)' : 'brightness(0.55)',
+                boxShadow: isLit
+                  ? `0 0 0 4px white, 0 0 30px 10px ${p.color}`
+                  : '0 2px 4px rgba(0,0,0,0.2)',
+                transform: isLit ? 'scale(1.08)' : 'scale(1)',
+              }}
+              aria-label={`パッド${p.id + 1}`}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/app/sansu-100/games/PakupakuGame.tsx
+++ b/app/sansu-100/games/PakupakuGame.tsx
@@ -52,7 +52,7 @@ interface Ghost {
 
 interface GS {
   player: {
-    x: number; y: number; dir: Dir; nextDir: Dir;
+    x: number; y: number; dir: Dir;
     stepAt: number;
     dead: boolean;
     respawnAt: number;
@@ -142,7 +142,7 @@ function createGS(): GS {
   return {
     player: {
       x: PLAYER_START.x, y: PLAYER_START.y,
-      dir: 'left', nextDir: 'left',
+      dir: 'left',
       stepAt: 5, dead: false, respawnAt: -1, invincibleUntil: -1,
     },
     ghosts: [
@@ -163,6 +163,7 @@ function createGS(): GS {
 // ── Game tick ─────────────────────────────────────────────────────────────
 function tickGame(
   gs: GS,
+  heldDir: Dir | null,
   rand: () => number,
   onEvent: (ev: 'dot' | 'power' | 'kill' | 'die') => void,
 ): void {
@@ -174,22 +175,19 @@ function tickGame(
     gs.player.x = PLAYER_START.x;
     gs.player.y = PLAYER_START.y;
     gs.player.dir = 'left';
-    gs.player.nextDir = 'left';
     gs.player.dead = false;
     gs.player.stepAt = gs.tick + 8;
     gs.player.invincibleUntil = gs.tick + 60; // 6秒間無敵
   }
 
-  // Move player
-  if (!gs.player.dead && gs.tick >= gs.player.stepAt) {
-    const { x, y, dir, nextDir } = gs.player;
+  // Move player（方向キー/ボタンが押されている間だけ進む。離すと止まる）
+  if (!gs.player.dead && heldDir && gs.tick >= gs.player.stepAt) {
+    const { x, y, dir } = gs.player;
 
     let moveDir = dir;
-    // Try to change direction
-    if (nextDir !== dir) {
-      const v = DIR_VECTORS[nextDir];
-      if (canPass(x + v.x, y + v.y, false)) moveDir = nextDir;
-    }
+    // Try to change direction toward the held input
+    const hv = DIR_VECTORS[heldDir];
+    if (canPass(x + hv.x, y + hv.y, false)) moveDir = heldDir;
 
     const v = DIR_VECTORS[moveDir];
     const nx = x + v.x;
@@ -425,22 +423,13 @@ function drawGame(
   const isInvincible = !gs.player.dead && gs.tick < gs.player.invincibleUntil;
   const showPlayer = (!gs.player.dead || gs.tick % 5 < 4) && (!isInvincible || gs.tick % 4 < 3);
   if (showPlayer) {
-    const { x: px, y: py, dir } = gs.player;
+    const { x: px, y: py } = gs.player;
     const pcx = px * cell + cell / 2;
     const pcy = py * cell + cell / 2;
-    const pr = cell * 0.42;
-    const mouthOpen = 0.22 + Math.abs(Math.sin(gs.tick * 0.5)) * 0.18;
-    const base = { right: 0, down: Math.PI / 2, left: Math.PI, up: -Math.PI / 2 }[dir];
-    ctx.fillStyle = '#ffee00';
-    ctx.beginPath();
-    ctx.moveTo(pcx, pcy);
-    ctx.arc(pcx, pcy, pr, base + mouthOpen, base + Math.PI * 2 - mouthOpen);
-    ctx.closePath();
-    ctx.fill();
-    ctx.fillStyle = '#cc8800';
-    ctx.beginPath();
-    ctx.arc(pcx, pcy, pr * 0.25, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.font = `${Math.floor(cell * 0.85)}px "Apple Color Emoji","Segoe UI Emoji",serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('👴', pcx, pcy);
   }
 }
 
@@ -456,6 +445,8 @@ export default function PakupakuGame({
   const layoutRef = useRef(computeLayout());
   const [score, setScore] = useState(0);
   const [lives, setLives] = useState(3);
+  // 押している間だけ進む（離すと止まる）。キー/ボタン/ドラッグのいずれかで更新する。
+  const heldDirRef = useRef<Dir | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -483,7 +474,7 @@ export default function PakupakuGame({
       stepMs: () => 100,
       onTick: () => {
         if (overRef.current) return;
-        tickGame(gs, rng, (ev) => {
+        tickGame(gs, heldDirRef.current, rng, (ev) => {
           if (ev === 'dot' && gs.soundOn) sound.eat();
           if (ev === 'die' && gs.soundOn) sound.crash();
           if (ev === 'kill' && gs.soundOn) sound.eat();
@@ -502,20 +493,33 @@ export default function PakupakuGame({
       onRender: () => drawGame(ctx, gsRef.current, layoutRef.current.cell),
     });
 
-    const onKey = (e: KeyboardEvent) => {
+    const onKeyDown = (e: KeyboardEvent) => {
       const d = dirFromKey(e.key);
-      if (d) { gsRef.current.player.nextDir = d; e.preventDefault(); }
+      if (d) { heldDirRef.current = d; e.preventDefault(); }
     };
-    window.addEventListener('keydown', onKey);
+    const onKeyUp = (e: KeyboardEvent) => {
+      const d = dirFromKey(e.key);
+      // 今まさに押している方向のキーを離したときだけ止める
+      // （別の古いキーのkeyupで現在の入力を誤って消さないため）
+      if (d && heldDirRef.current === d) heldDirRef.current = null;
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
     return () => {
       handle.stop();
-      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const setDir = (d: Dir) => { gsRef.current.player.nextDir = d; };
+  // ボタン: 押している間だけ進む。同じボタンを離したときだけ止める。
+  const pressDir = (d: Dir) => { heldDirRef.current = d; };
+  const releaseDir = (d: Dir) => {
+    if (heldDirRef.current === d) heldDirRef.current = null;
+  };
 
+  // ドラッグ: 指を置いている間、動かした方向へ進み続ける（離すと止まる）。
   const touch = useRef<{ x: number; y: number } | null>(null);
   const padBtn = 'flex h-12 w-12 items-center justify-center rounded-xl bg-gray-200 text-xl font-bold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200';
 
@@ -533,29 +537,59 @@ export default function PakupakuGame({
         className="rounded-xl shadow-lg"
         style={{ touchAction: 'none' }}
         onPointerDown={(e) => { touch.current = { x: e.clientX, y: e.clientY }; }}
-        onPointerUp={(e) => {
-          const s0 = touch.current; touch.current = null;
+        onPointerMove={(e) => {
+          const s0 = touch.current;
           if (!s0) return;
           const dx = e.clientX - s0.x, dy = e.clientY - s0.y;
           if (Math.abs(dx) < 12 && Math.abs(dy) < 12) return;
-          setDir(Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up'));
+          heldDirRef.current = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up');
         }}
+        onPointerUp={() => { touch.current = null; heldDirRef.current = null; }}
+        onPointerLeave={() => { touch.current = null; heldDirRef.current = null; }}
       />
 
       <p className="text-xs text-gray-500 dark:text-gray-400">
-        よこ か うしろから さわって たべよう（まともにぶつかると やられるよ）
+        ゆびを おいたまま うごかそう（まともに ぶつかると やられるよ）
       </p>
 
-      {/* Direction pad */}
+      {/* Direction pad（押している間だけ進む） */}
       <div className="grid grid-cols-3 gap-2" aria-label="そうさボタン">
         <span/>
-        <button type="button" className={padBtn} onClick={() => setDir('up')} aria-label="うえ">▲</button>
+        <button
+          type="button"
+          className={padBtn}
+          onPointerDown={() => pressDir('up')}
+          onPointerUp={() => releaseDir('up')}
+          onPointerLeave={() => releaseDir('up')}
+          aria-label="うえ"
+        >▲</button>
         <span/>
-        <button type="button" className={padBtn} onClick={() => setDir('left')} aria-label="ひだり">◀</button>
+        <button
+          type="button"
+          className={padBtn}
+          onPointerDown={() => pressDir('left')}
+          onPointerUp={() => releaseDir('left')}
+          onPointerLeave={() => releaseDir('left')}
+          aria-label="ひだり"
+        >◀</button>
         <span/>
-        <button type="button" className={padBtn} onClick={() => setDir('right')} aria-label="みぎ">▶</button>
+        <button
+          type="button"
+          className={padBtn}
+          onPointerDown={() => pressDir('right')}
+          onPointerUp={() => releaseDir('right')}
+          onPointerLeave={() => releaseDir('right')}
+          aria-label="みぎ"
+        >▶</button>
         <span/>
-        <button type="button" className={padBtn} onClick={() => setDir('down')} aria-label="した">▼</button>
+        <button
+          type="button"
+          className={padBtn}
+          onPointerDown={() => pressDir('down')}
+          onPointerUp={() => releaseDir('down')}
+          onPointerLeave={() => releaseDir('down')}
+          aria-label="した"
+        >▼</button>
         <span/>
       </div>
     </div>

--- a/app/sansu-100/lib/debug-env.ts
+++ b/app/sansu-100/lib/debug-env.ts
@@ -14,10 +14,14 @@ export function isDebugEnv(): boolean {
   return false;
 }
 
-// 常に管理者として扱うユーザー名（本番環境でも算数ゲート等をスキップする）。
-// サーバー側 api/src/shared/debugEnv.ts の ADMIN_USER_NAME と一致させること。
-export const ADMIN_USER_NAME = 'たくみ';
+// 常に管理者として扱うユーザー（本番環境でも算数ゲート等をスキップする）。
+// 登録時に発行される固定の userId で判定する（表示名は誰でも登録し直せるため使わない）。
+// userId はランダムなUUID（個人情報ではない不透明な識別子）なのでソースに書いてよい。
+// サーバー側 api/src/shared/debugEnv.ts の ADMIN_USER_ID と一致させること。
+// 実際の権限判定はサーバー側（api/src/shared/debugEnv.ts の isAdminAccount）が行う。
+// ここでの判定はUI表示のみに使う補助的なものであり、それ自体はセキュリティ境界ではない。
+const ADMIN_USER_ID = '158e35fa-6b0a-4817-9747-cd6b12b02830';
 
-export function isAdminUserName(name: string | null | undefined): boolean {
-  return name === ADMIN_USER_NAME;
+export function isAdminUserId(id: string | null | undefined): boolean {
+  return id === ADMIN_USER_ID;
 }

--- a/app/sansu-100/lib/debug-env.ts
+++ b/app/sansu-100/lib/debug-env.ts
@@ -13,3 +13,11 @@ export function isDebugEnv(): boolean {
   if (h.endsWith('.azurestaticapps.net') && /-\d+\./.test(h)) return true;
   return false;
 }
+
+// 常に管理者として扱うユーザー名（本番環境でも算数ゲート等をスキップする）。
+// サーバー側 api/src/shared/debugEnv.ts の ADMIN_USER_NAME と一致させること。
+export const ADMIN_USER_NAME = 'たくみ';
+
+export function isAdminUserName(name: string | null | undefined): boolean {
+  return name === ADMIN_USER_NAME;
+}

--- a/app/sansu-100/minigame/page.tsx
+++ b/app/sansu-100/minigame/page.tsx
@@ -9,7 +9,7 @@ import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
 import CoinBalance from '../components/CoinBalance';
 import { useSansuUser } from '../hooks/useSansuUser';
-import { isAdminUserName } from '../lib/debug-env';
+import { isAdminUserId } from '../lib/debug-env';
 import {
   MINIGAME_PLAYS_PER_MATH,
   SPEND_COSTS,
@@ -29,7 +29,7 @@ export default function MinigameHubPage(): React.JSX.Element {
 
   const coins = currentUser.coins ?? 0;
   const playCredits = currentUser.minigameCredits ?? 0;
-  const isAdmin = isAdminUserName(currentUser.name);
+  const isAdmin = isAdminUserId(currentUser.id);
 
   return (
     <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">

--- a/app/sansu-100/minigame/page.tsx
+++ b/app/sansu-100/minigame/page.tsx
@@ -9,6 +9,7 @@ import Header from '../../components/header';
 import ThemeToggle from '../../components/theme-toggle';
 import CoinBalance from '../components/CoinBalance';
 import { useSansuUser } from '../hooks/useSansuUser';
+import { isAdminUserName } from '../lib/debug-env';
 import {
   MINIGAME_PLAYS_PER_MATH,
   SPEND_COSTS,
@@ -28,6 +29,7 @@ export default function MinigameHubPage(): React.JSX.Element {
 
   const coins = currentUser.coins ?? 0;
   const playCredits = currentUser.minigameCredits ?? 0;
+  const isAdmin = isAdminUserName(currentUser.name);
 
   return (
     <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
@@ -58,7 +60,7 @@ export default function MinigameHubPage(): React.JSX.Element {
           <CoinBalance coins={coins} size="lg" />
         </section>
 
-        {playCredits <= 0 ? (
+        {playCredits <= 0 && !isAdmin ? (
           <Link
             href="/sansu-100/play"
             className="block rounded-2xl bg-gradient-to-r from-orange-400 to-pink-500 p-5 text-center font-bold text-white shadow-md"
@@ -74,7 +76,7 @@ export default function MinigameHubPage(): React.JSX.Element {
 
         <div className="grid grid-cols-2 gap-3">
           {MINIGAMES.map((g) => {
-            const locked = playCredits <= 0;
+            const locked = playCredits <= 0 && !isAdmin;
             const best = currentUser.minigameScores?.[g.id];
             const card = (
               <div className="flex h-full flex-col items-center gap-1 rounded-2xl bg-white p-4 text-center shadow-md dark:bg-gray-800">

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -15,7 +15,7 @@ import UserTile from './components/UserTile';
 import { useSansuSync } from './hooks/useSansuSync';
 import { useSansuUser } from './hooks/useSansuUser';
 import { sansuApi } from './lib/api-client';
-import { isAdminUserId, isDebugEnv } from './lib/debug-env';
+import { isDebugEnv } from './lib/debug-env';
 import { hashPin } from './lib/pin-hash';
 import type { SansuUserPublic } from './lib/types';
 
@@ -229,12 +229,10 @@ export default function SansuHome(): React.JSX.Element {
             >
               👋 おわる
             </button>
-            {isDebugEnv() || isAdminUserId(currentUser.id) ? (
+            {isDebugEnv() ? (
               <div className="space-y-2 rounded-xl border border-dashed border-orange-400 p-3">
                 <p className="text-xs font-bold text-orange-600 dark:text-orange-300">
-                  {isAdminUserId(currentUser.id)
-                    ? '🛡️ かんりしゃメニュー'
-                    : '🐛 デバッグ（本番では表示されません）'}
+                  🐛 デバッグ（本番では表示されません）
                 </p>
                 <button
                   type="button"

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -15,7 +15,7 @@ import UserTile from './components/UserTile';
 import { useSansuSync } from './hooks/useSansuSync';
 import { useSansuUser } from './hooks/useSansuUser';
 import { sansuApi } from './lib/api-client';
-import { isDebugEnv } from './lib/debug-env';
+import { isAdminUserName, isDebugEnv } from './lib/debug-env';
 import { hashPin } from './lib/pin-hash';
 import type { SansuUserPublic } from './lib/types';
 
@@ -229,10 +229,12 @@ export default function SansuHome(): React.JSX.Element {
             >
               👋 おわる
             </button>
-            {isDebugEnv() ? (
+            {isDebugEnv() || isAdminUserName(currentUser.name) ? (
               <div className="space-y-2 rounded-xl border border-dashed border-orange-400 p-3">
                 <p className="text-xs font-bold text-orange-600 dark:text-orange-300">
-                  🐛 デバッグ（本番では表示されません）
+                  {isAdminUserName(currentUser.name)
+                    ? '🛡️ かんりしゃメニュー'
+                    : '🐛 デバッグ（本番では表示されません）'}
                 </p>
                 <button
                   type="button"

--- a/app/sansu-100/page.tsx
+++ b/app/sansu-100/page.tsx
@@ -15,7 +15,7 @@ import UserTile from './components/UserTile';
 import { useSansuSync } from './hooks/useSansuSync';
 import { useSansuUser } from './hooks/useSansuUser';
 import { sansuApi } from './lib/api-client';
-import { isAdminUserName, isDebugEnv } from './lib/debug-env';
+import { isAdminUserId, isDebugEnv } from './lib/debug-env';
 import { hashPin } from './lib/pin-hash';
 import type { SansuUserPublic } from './lib/types';
 
@@ -229,10 +229,10 @@ export default function SansuHome(): React.JSX.Element {
             >
               👋 おわる
             </button>
-            {isDebugEnv() || isAdminUserName(currentUser.name) ? (
+            {isDebugEnv() || isAdminUserId(currentUser.id) ? (
               <div className="space-y-2 rounded-xl border border-dashed border-orange-400 p-3">
                 <p className="text-xs font-bold text-orange-600 dark:text-orange-300">
-                  {isAdminUserName(currentUser.name)
+                  {isAdminUserId(currentUser.id)
                     ? '🛡️ かんりしゃメニュー'
                     : '🐛 デバッグ（本番では表示されません）'}
                 </p>


### PR DESCRIPTION
## 概要
ユーザーフィードバックに基づく3件の修正。

## 1. パクパクおじさん
- プレイヤーのアイコンをパックマン風の口が動く円から「👴」絵文字に変更
- 移動を「押している間だけ進む」方式に変更（従来は1回押すと壁にぶつかるまで進み続けていた）。キーボード/ボタン/ドラッグいずれも押し続け方式に統一

## 2. おぼえてタッチ
- 光っているパッドが分かりにくかったため、白いリング＋グロー＋輝度アップ＋拡大で明確に区別できるように変更

## 3. 管理者バイパス（ユーザー「たくみ」）
- 本番環境でも算数ゲート（あそべる回数0でのプレイ制限）をスキップし、コインを自由に付与できるようにする
- なりすまし防止のため、表示名ではなく登録時に発行される固定の userId（本人確認済みの実際のID）で判定する。userId はランダムなUUIDで個人情報ではないためソースに直接書ける
- 実際の権限判定は必ずサーバー側（`isAdminAccount`）で行い、クライアント側の判定はUI表示の補助に留める

## 動作確認
- `npm run build`（フロントエンド）・`cd api && npm run build`（API）ともに成功
- ローカルSWA環境で既存の pakupaku/oboete E2Eテスト、avatar テストが全てpass
- 管理者バイパスは `crypto.randomUUID` を一時的にモックして実際の管理者IDと一致させ、ローカルで実際に「算数ゲート回避→コイン付与→ミニゲームプレイ」まで一気通貫で動作確認済み（本番データには一切触れていない）
