### PR TITLE
feat(sansu-100): ミニゲーム「くるりんボール」を追加

### DIFF
--- a/app/sansu-100/games/KurukurinBallGame.tsx
+++ b/app/sansu-100/games/KurukurinBallGame.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { createMaze, mazeTimeLimit, N, E, S, W, type MazeState } from '../lib/games/maze';
+import { startGameLoop } from '../lib/minigame-core';
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// くるりんボール（迷路傾けアクション）
+// ボードを傾けるイメージでボールを転がし、ゴールを目指す。壁にぶつかると止まる。
+// 既存の迷路生成ロジック（app/sansu-100/lib/games/maze.ts）を流用し、
+// プレイヤーはグリッド移動ではなく連続座標＋速度（加速度・摩擦・壁での停止）で動かす。
+
+const ACCEL = 0.012; // セル単位/tick^2
+const FRICTION = 0.92;
+const MAX_SPEED = 0.35; // セル単位/tick（1tickで1セル以上進まないよう安全マージンを持たせる）
+const BALL_R = 0.28; // セル単位
+
+interface GS {
+  maze: MazeState;
+  bx: number; // ボール位置（セル単位、左上原点）
+  by: number;
+  vx: number;
+  vy: number;
+  level: number;
+  cleared: number;
+  elapsedMs: number;
+  timeLimitMs: number;
+  over: boolean;
+}
+
+function createGS(rand: () => number, level: number): GS {
+  const maze = createMaze(rand, level);
+  return {
+    maze,
+    bx: maze.px + 0.5,
+    by: maze.py + 0.5,
+    vx: 0,
+    vy: 0,
+    level,
+    cleared: level - 1,
+    elapsedMs: 0,
+    timeLimitMs: mazeTimeLimit(level) * 1000,
+    over: false,
+  };
+}
+
+function cellAt(m: MazeState, cx: number, cy: number): number {
+  if (cx < 0 || cy < 0 || cx >= m.cols || cy >= m.rows) return 0;
+  return m.cells[cy * m.cols + cx];
+}
+
+function tick(
+  gs: GS,
+  tiltX: number,
+  tiltY: number,
+  rand: () => number,
+  onEvent: (ev: 'goal' | 'over') => void
+): void {
+  if (gs.over) return;
+  gs.elapsedMs += 16;
+  if (gs.elapsedMs >= gs.timeLimitMs) {
+    gs.over = true;
+    onEvent('over');
+    return;
+  }
+
+  gs.vx = (gs.vx + tiltX * ACCEL) * FRICTION;
+  gs.vy = (gs.vy + tiltY * ACCEL) * FRICTION;
+  gs.vx = Math.max(-MAX_SPEED, Math.min(MAX_SPEED, gs.vx));
+  gs.vy = Math.max(-MAX_SPEED, Math.min(MAX_SPEED, gs.vy));
+
+  const m = gs.maze;
+  const cx = Math.floor(gs.bx);
+  const cy = Math.floor(gs.by);
+  const cell = cellAt(m, cx, cy);
+
+  // X軸移動（壁で停止）
+  if (gs.vx > 0) {
+    const boundary = cx + 1;
+    const nx = gs.bx + gs.vx;
+    if ((cell & E) === 0 && nx + BALL_R >= boundary) {
+      gs.bx = boundary - BALL_R;
+      gs.vx = 0;
+    } else {
+      gs.bx = nx;
+    }
+  } else if (gs.vx < 0) {
+    const boundary = cx;
+    const nx = gs.bx + gs.vx;
+    if ((cell & W) === 0 && nx - BALL_R <= boundary) {
+      gs.bx = boundary + BALL_R;
+      gs.vx = 0;
+    } else {
+      gs.bx = nx;
+    }
+  }
+
+  // Y軸移動（壁で停止）。X軸移動後のセルを再評価する。
+  const cx2 = Math.floor(gs.bx);
+  const cy2 = Math.floor(gs.by);
+  const cell2 = cellAt(m, cx2, cy2);
+  if (gs.vy > 0) {
+    const boundary = cy2 + 1;
+    const ny = gs.by + gs.vy;
+    if ((cell2 & S) === 0 && ny + BALL_R >= boundary) {
+      gs.by = boundary - BALL_R;
+      gs.vy = 0;
+    } else {
+      gs.by = ny;
+    }
+  } else if (gs.vy < 0) {
+    const boundary = cy2;
+    const ny = gs.by + gs.vy;
+    if ((cell2 & N) === 0 && ny - BALL_R <= boundary) {
+      gs.by = boundary + BALL_R;
+      gs.vy = 0;
+    } else {
+      gs.by = ny;
+    }
+  }
+
+  // ゴール判定（ゴールセルの中心に十分近づいたらクリア）
+  const gcx = m.gx + 0.5;
+  const gcy = m.gy + 0.5;
+  const dist = Math.hypot(gs.bx - gcx, gs.by - gcy);
+  if (dist < 0.32) {
+    gs.cleared = gs.level;
+    onEvent('goal');
+    const nextLevel = gs.level + 1;
+    const nextMaze = createMaze(rand, nextLevel);
+    gs.maze = nextMaze;
+    gs.bx = nextMaze.px + 0.5;
+    gs.by = nextMaze.py + 0.5;
+    gs.vx = 0;
+    gs.vy = 0;
+    gs.level = nextLevel;
+    gs.elapsedMs = 0;
+    gs.timeLimitMs = mazeTimeLimit(nextLevel) * 1000;
+  }
+}
+
+function draw(ctx: CanvasRenderingContext2D, gs: GS, cell: number): void {
+  const m = gs.maze;
+  const W0 = m.cols * cell;
+  const H0 = m.rows * cell;
+  ctx.fillStyle = '#e0e7ff';
+  ctx.fillRect(0, 0, W0, H0);
+
+  ctx.fillStyle = '#fde68a';
+  ctx.fillRect(m.gx * cell, m.gy * cell, cell, cell);
+
+  ctx.strokeStyle = '#3730a3';
+  ctx.lineWidth = 3.5;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  for (let y = 0; y < m.rows; y++) {
+    for (let x = 0; x < m.cols; x++) {
+      const c = m.cells[y * m.cols + x];
+      const x0 = x * cell;
+      const y0 = y * cell;
+      if ((c & N) === 0) { ctx.moveTo(x0, y0); ctx.lineTo(x0 + cell, y0); }
+      if ((c & W) === 0) { ctx.moveTo(x0, y0); ctx.lineTo(x0, y0 + cell); }
+      if ((c & E) === 0) { ctx.moveTo(x0 + cell, y0); ctx.lineTo(x0 + cell, y0 + cell); }
+      if ((c & S) === 0) { ctx.moveTo(x0, y0 + cell); ctx.lineTo(x0 + cell, y0 + cell); }
+    }
+  }
+  ctx.stroke();
+
+  ctx.font = `${cell * 0.7}px "Apple Color Emoji","Segoe UI Emoji",serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('🏁', m.gx * cell + cell / 2, m.gy * cell + cell / 2);
+
+  ctx.fillStyle = '#6366f1';
+  ctx.beginPath();
+  ctx.arc(gs.bx * cell, gs.by * cell, BALL_R * cell, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#312e81';
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+function computeCell(cols: number, rows: number): number {
+  if (typeof window === 'undefined') return 30;
+  const byW = (window.innerWidth - 48) / cols;
+  const byH = (window.innerHeight - 320) / rows;
+  return Math.max(16, Math.min(44, byW, byH));
+}
+
+export default function KurukurinBallGame({
+  onGameOver,
+}: {
+  onGameOver: (score: number) => void;
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gsRef = useRef<GS>(createGS(Math.random, 1));
+  const tiltRef = useRef({ x: 0, y: 0 });
+  const cellRef = useRef(30);
+  const overRef = useRef(false);
+  const soundRef = useRef(true);
+  const [level, setLevel] = useState(1);
+  const [timeLeft, setTimeLeft] = useState(mazeTimeLimit(1));
+
+  const configureCanvas = (m: MazeState) => {
+    const cell = computeCell(m.cols, m.rows);
+    cellRef.current = cell;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const cw = m.cols * cell;
+    const ch = m.rows * cell;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(cw * dpr);
+    canvas.height = Math.round(ch * dpr);
+    canvas.style.width = `${cw}px`;
+    canvas.style.height = `${ch}px`;
+    const ctx = canvas.getContext('2d');
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  };
+
+  useEffect(() => {
+    const rand = Math.random.bind(Math);
+    const gs = createGS(rand, 1);
+    gsRef.current = gs;
+    overRef.current = false;
+    soundRef.current = storage.getSettings().soundOn;
+    setLevel(1);
+    setTimeLeft(mazeTimeLimit(1));
+    configureCanvas(gs.maze);
+
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+
+    const handle = startGameLoop({
+      stepMs: () => 16,
+      onTick: () => {
+        if (overRef.current) return;
+        tick(gs, tiltRef.current.x, tiltRef.current.y, rand, (ev) => {
+          if (ev === 'goal') {
+            if (soundRef.current) sound.fanfare();
+            setLevel(gs.level);
+            setTimeLeft(mazeTimeLimit(gs.level));
+            configureCanvas(gs.maze);
+          }
+          if (ev === 'over' && !overRef.current) {
+            overRef.current = true;
+            handle.stop();
+            if (soundRef.current) sound.crash();
+            onGameOver(gs.cleared);
+          }
+        });
+        setTimeLeft(Math.max(0, Math.ceil((gs.timeLimitMs - gs.elapsedMs) / 1000)));
+      },
+      onRender: () => draw(ctx, gsRef.current, cellRef.current),
+    });
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') tiltRef.current.x = -1;
+      else if (e.key === 'ArrowRight') tiltRef.current.x = 1;
+      else if (e.key === 'ArrowUp') tiltRef.current.y = -1;
+      else if (e.key === 'ArrowDown') tiltRef.current.y = 1;
+      else return;
+      e.preventDefault();
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' && tiltRef.current.x < 0) tiltRef.current.x = 0;
+      else if (e.key === 'ArrowRight' && tiltRef.current.x > 0) tiltRef.current.x = 0;
+      else if (e.key === 'ArrowUp' && tiltRef.current.y < 0) tiltRef.current.y = 0;
+      else if (e.key === 'ArrowDown' && tiltRef.current.y > 0) tiltRef.current.y = 0;
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      handle.stop();
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1ゲーム。再戦は親が key で再マウント
+  }, []);
+
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const onPointerDown = (e: React.PointerEvent) => {
+    touchStart.current = { x: e.clientX, y: e.clientY };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const s0 = touchStart.current;
+    if (!s0) return;
+    const dx = e.clientX - s0.x;
+    const dy = e.clientY - s0.y;
+    const mag = Math.hypot(dx, dy);
+    if (mag < 8) {
+      tiltRef.current = { x: 0, y: 0 };
+      return;
+    }
+    tiltRef.current = { x: dx / mag, y: dy / mag };
+  };
+  const onPointerUp = () => {
+    touchStart.current = null;
+    tiltRef.current = { x: 0, y: 0 };
+  };
+
+  const setTilt = (x: number, y: number) => { tiltRef.current = { x, y }; };
+  const clearTilt = () => { tiltRef.current = { x: 0, y: 0 }; };
+  const padBtn = 'flex h-12 w-12 items-center justify-center rounded-xl bg-gray-200 text-xl font-bold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200';
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="flex w-full max-w-xs items-center justify-between px-1 text-sm font-bold text-gray-800 dark:text-gray-100">
+        <span>レベル {level}</span>
+        <span className={timeLeft <= 5 ? 'text-red-600' : ''}>⏱ {timeLeft}秒</span>
+      </div>
+      <canvas
+        ref={canvasRef}
+        data-testid="kururin-canvas"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerLeave={onPointerUp}
+        className="rounded-xl shadow-md"
+        style={{ touchAction: 'none' }}
+      />
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        ゆびで かたむける ほうこうへ ドラッグ、ボタンでもOK
+      </p>
+      <div className="grid grid-cols-3 gap-2" aria-label="かたむけボタン">
+        <span />
+        <button
+          type="button"
+          className={padBtn}
+          data-testid="kururin-up"
+          aria-label="うえ"
+          onPointerDown={() => setTilt(0, -1)}
+          onPointerUp={clearTilt}
+          onPointerLeave={clearTilt}
+        >▲</button>
+        <span />
+        <button
+          type="button"
+          className={padBtn}
+          data-testid="kururin-left"
+          aria-label="ひだり"
+          onPointerDown={() => setTilt(-1, 0)}
+          onPointerUp={clearTilt}
+          onPointerLeave={clearTilt}
+        >◀</button>
+        <span />
+        <button
+          type="button"
+          className={padBtn}
+          data-testid="kururin-right"
+          aria-label="みぎ"
+          onPointerDown={() => setTilt(1, 0)}
+          onPointerUp={clearTilt}
+          onPointerLeave={clearTilt}
+        >▶</button>
+        <span />
+        <button
+          type="button"
+          className={padBtn}
+          data-testid="kururin-down"
+          aria-label="した"
+          onPointerDown={() => setTilt(0, 1)}
+          onPointerUp={clearTilt}
+          onPointerLeave={clearTilt}
+        >▼</button>
+        <span />
+      </div>
+    </div>
+  );
+}

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -108,6 +108,8 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'ponpon_skyhigh', category: 'minigame', name: '天まで とどけ', description: 'ぽんぽんジャンプで たかさ80', icon: '☁️', tier: 'gold', rarity: 'epic' },
   { id: 'airhockey_rookie', category: 'minigame', name: 'ホッケー見習い', description: 'はじいてホッケーで5てん', icon: '🏒', tier: 'silver', rarity: 'rare' },
   { id: 'airhockey_champion', category: 'minigame', name: 'ホッケー王者', description: 'はじいてホッケーで10てん', icon: '🏆', tier: 'gold', rarity: 'epic' },
+  { id: 'kururin_roller', category: 'minigame', name: 'ころころ名人', description: 'くるりんボールで2かいクリア', icon: '🌀', tier: 'silver', rarity: 'rare' },
+  { id: 'kururin_master', category: 'minigame', name: 'めいろの達人', description: 'くるりんボールで5かいクリア', icon: '🎯', tier: 'gold', rarity: 'epic' },
   { id: 'games_explorer', category: 'minigame', name: 'ゲームたんけんか', description: '5しゅるいの ゲームで あそんだ', icon: '🎮', tier: 'silver', rarity: 'rare' },
   { id: 'games_allstar', category: 'minigame', name: 'ゲームマスター', description: 'ぜんぶの ゲームで あそんだ', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -191,6 +191,18 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     ],
     available: true,
   },
+  {
+    id: 'kururin',
+    name: 'くるりんボール',
+    emoji: '🌀',
+    desc: 'かたむけて ゴールを めざそう！',
+    howTo: [
+      'ゆびで かたむける ほうこうへ ドラッグ か ◀▲▼▶ボタンで ボールを ころがす',
+      'かべに ぶつかると とまるよ。🏁ゴールに つくと つぎの めいろへ',
+      'せいげん時間の 中で なんかい クリアできるかな。時間切れで おわり',
+    ],
+    available: true,
+  },
 ];
 
 const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(

--- a/app/sansu-100/lib/minigame-rewards.ts
+++ b/app/sansu-100/lib/minigame-rewards.ts
@@ -16,7 +16,8 @@ export type MinigameId =
   | 'rhythmdon'
   | 'starshooter'
   | 'ponpon'
-  | 'airhockey';
+  | 'airhockey'
+  | 'kururin';
 
 // gameId ごとの { しきい値: バッジID }（昇順）
 const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
@@ -79,6 +80,10 @@ const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
   airhockey: [
     { score: 5, badgeId: 'airhockey_rookie' },
     { score: 10, badgeId: 'airhockey_champion' },
+  ],
+  kururin: [
+    { score: 2, badgeId: 'kururin_roller' },
+    { score: 5, badgeId: 'kururin_master' },
   ],
 };
 

--- a/app/sansu-100/minigame/kururin/page.tsx
+++ b/app/sansu-100/minigame/kururin/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
+import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
+import NewRecordBanner from '../../components/NewRecordBanner';
+import KurukurinBallGame from '../../games/KurukurinBallGame';
+import { useSansuUser } from '../../hooks/useSansuUser';
+import { sansuApi } from '../../lib/api-client';
+import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
+import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
+
+type Phase = 'intro' | 'playing' | 'over';
+
+export default function KururinPage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, saveUser, loaded } = useSansuUser();
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [lastScore, setLastScore] = useState(0);
+  const [round, setRound] = useState(0);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [overlayBadges, setOverlayBadges] = useState<string[]>([]);
+  const [newRecord, setNewRecord] = useState(false);
+
+  const coins = currentUser?.coins ?? 0;
+
+  const start = useCallback(async () => {
+    if (!currentUser) return;
+    setBusy(true);
+    setMessage(null);
+    setNewRecord(false);
+    try {
+      const res = await sansuApi.spend(currentUser.id, 'play');
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        setRound((r) => r + 1);
+        setPhase('playing');
+      } else {
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
+      }
+    } catch {
+      setMessage('いまは つうしんできないよ（あとでね）');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentUser, saveUser]);
+
+  const handleGameOver = useCallback(
+    async (score: number) => {
+      setLastScore(score);
+      setPhase('over');
+      if (!currentUser) return;
+      const newBadges = evaluateMinigameBadges(
+        'kururin',
+        score,
+        currentUser.earnedBadges
+      );
+      try {
+        const res = await sansuApi.awardBadge(currentUser.id, newBadges, score, 'kururin');
+        if (res.user) saveUser(res.user);
+        if (res.newRecord) setNewRecord(true);
+        if (newBadges.length > 0) setOverlayBadges(newBadges);
+      } catch {
+        // 報酬付与失敗は致命的でない
+      }
+    },
+    [currentUser, saveUser]
+  );
+
+  if (loaded && !currentUser) {
+    if (typeof window !== 'undefined') router.replace('/sansu-100');
+    return <main className="p-8" />;
+  }
+  if (!currentUser) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-4 p-4">
+        {phase === 'playing' ? (
+          <Link
+            href="/sansu-100/minigame"
+            className="inline-block text-sm font-semibold text-blue-600 dark:text-blue-300"
+          >
+            ← やめる
+          </Link>
+        ) : (
+          <Header
+            title="🌀 くるりんボール"
+            description="かたむけて ゴールを めざそう！"
+            showBackButton
+            backHref="/sansu-100/minigame"
+            backLabel="ゲームせんたくにもどる"
+          />
+        )}
+
+        {message ? (
+          <div className="rounded-xl bg-yellow-100 px-4 py-3 text-center font-bold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            {message}
+          </div>
+        ) : null}
+
+        {phase === 'intro' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-6xl">🌀</p>
+            <HowToPlay steps={minigameHowTo('kururin')} />
+            <p className="text-gray-700 dark:text-gray-200">
+              コインを {SPEND_COSTS.play}まい つかって あそぶよ
+            </p>
+            <div className="flex justify-center">
+              <CoinBalance coins={coins} />
+            </div>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-indigo-600 py-4 text-lg font-bold text-white hover:bg-indigo-700 disabled:opacity-60"
+              data-testid="kururin-start"
+            >
+              🪙 {SPEND_COSTS.play} であそぶ
+            </button>
+          </section>
+        ) : null}
+
+        {phase === 'playing' ? (
+          <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
+            <KurukurinBallGame key={round} onGameOver={handleGameOver} />
+          </section>
+        ) : null}
+
+        {phase === 'over' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              おわり！
+            </p>
+            <p className="text-lg text-gray-700 dark:text-gray-200">
+              クリアした めいろ: <b data-testid="kururin-final-score">{lastScore}</b>
+            </p>
+            {newRecord ? <NewRecordBanner score={lastScore} /> : null}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-indigo-600 py-4 text-lg font-bold text-white hover:bg-indigo-700 disabled:opacity-60"
+              data-testid="kururin-again"
+            >
+              🪙 {SPEND_COSTS.play} で もういちど
+            </button>
+            <Link
+              href="/sansu-100/minigame"
+              className="block rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ほかの ゲームへ
+            </Link>
+          </section>
+        ) : null}
+      </div>
+
+      {overlayBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={overlayBadges}
+          onDone={() => setOverlayBadges([])}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/tests/sansu/kururin.spec.ts
+++ b/tests/sansu/kururin.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * くるりんボール（迷路傾けアクション）のE2Eテスト。
+ *
+ * - 本番ユーザは触らない。毎回ユニークな E2E 接頭辞ユーザを新規作成する。
+ * - baseURL は http://localhost:4280 (playwright.config.sansu.ts 参照)
+ * - ボールの物理・壁判定はCanvas内のゲームロジックで発生するため、
+ *   ここでは「ページ表示・スタート・タイマー減少・ゲームオーバー画面遷移」まで確認する。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `KRR${suffix}`;
+}
+
+async function registerAndLogin(page: Page, name: string): Promise<void> {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sansu-100:dev-seeded', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of PIN) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'これでとうろく！' }).click();
+  await page.waitForURL('**/sansu-100', { timeout: 10000 });
+}
+
+async function earnCoinsViaDebug(page: Page): Promise<void> {
+  await page.goto('/sansu-100/play');
+  await page.waitForLoadState('networkidle');
+  const lv1 = page.locator('[data-testid="level-pick-1"]');
+  if (await lv1.isVisible()) {
+    await lv1.click();
+  }
+  const dbgBtn = page.locator('[data-testid="debug-finish-perfect"]');
+  if (await dbgBtn.isVisible({ timeout: 5000 })) {
+    await dbgBtn.click();
+  }
+  await page.goto('/sansu-100');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('くるりんボール ミニゲーム', () => {
+  test('ミニゲーム一覧にくるりんボールが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('くるりんボール')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('くるりんボールページにアクセスすると intro 画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame/kururin');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('くるりんボール').first()).toBeVisible({ timeout: 8000 });
+    const startBtn = page.locator('[data-testid="kururin-start"]');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('コイン不足時にスタートするとエラーメッセージが出る', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await page.goto('/sansu-100/minigame/kururin');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="kururin-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+    await expect(
+      page.getByText(/さんすうを|コインが/)
+    ).toBeVisible({ timeout: 6000 });
+  });
+
+  test('コイン取得後にスタートするとキャンバスと操作ボタンが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/kururin');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="kururin-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    await expect(page.locator('[data-testid="kururin-canvas"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="kururin-up"]')).toBeVisible();
+    await expect(page.locator('[data-testid="kururin-down"]')).toBeVisible();
+    await expect(page.locator('[data-testid="kururin-left"]')).toBeVisible();
+    await expect(page.locator('[data-testid="kururin-right"]')).toBeVisible();
+    await expect(page.getByText('← やめる')).toBeVisible();
+  });
+
+  test('時間が経過するとタイマーが減っていく', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/kururin');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="kururin-start"]').click();
+
+    const timerText = page.getByText(/⏱ \d+秒/);
+    await expect(timerText).toBeVisible({ timeout: 8000 });
+    const first = await timerText.textContent();
+    await page.waitForTimeout(2000);
+    const second = await timerText.textContent();
+    expect(first).not.toBe(second);
+  });
+
+  test('傾けボタンを押すとボールが動く', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/kururin');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="kururin-start"]').click();
+    await expect(page.locator('[data-testid="kururin-canvas"]')).toBeVisible({ timeout: 8000 });
+
+    const canvas = page.locator('[data-testid="kururin-canvas"]');
+    const before = await canvas.screenshot();
+
+    const rightBtn = page.locator('[data-testid="kururin-right"]');
+    await rightBtn.dispatchEvent('pointerdown');
+    await page.waitForTimeout(600);
+    await rightBtn.dispatchEvent('pointerup');
+
+    const after = await canvas.screenshot();
+    expect(Buffer.compare(before, after)).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要
ミニゲームハブに新しいゲーム「くるりんボール」（迷路傾けアクション）を追加する。

## 遊び方
- ボードを傾けるイメージでボールを転がし、ゴールを目指す
- ドラッグ/ボタン/矢印キーで傾ける方向を指定すると、その方向にボールが加速して転がる
- 壁にぶつかると止まる。ゴールに着くと次のレベル（大きい迷路）へ
- 制限時間内にクリアした数がスコア。時間切れで終了

## 実装内容
- `app/sansu-100/games/KurukurinBallGame.tsx`: 既存の `lib/games/maze.ts`（迷路生成・壁ビットマスク）を流用。プレイヤーはグリッド移動ではなく連続座標＋速度（加速度・摩擦・壁での軸別停止）で動かす
- `app/sansu-100/minigame/kururin/page.tsx`: ページラッパー（既存パターン踏襲）
- `minigame-list.ts` / `minigame-rewards.ts` / `badge-catalog.ts`: 一覧登録・バッジ2種追加
- `tests/sansu/kururin.spec.ts`: E2Eテスト6件

## 設計上の注意点（過去のレビュー指摘を反映）
- ゲーム終了（時間切れ）は `overRef` で単一ガードし、`onGameOver` の二重呼び出しを防止

## 動作確認
- `npm run build` 成功
- ローカルSWA環境（localhost:4280）で6テストを2回連続実行、全12回pass確認済み
- スクリーンショットで迷路・ボール・ゴール旗の描画を目視確認済み

Closes #146