### PR TITLE
feat(sansu-100): ミニゲーム「ひとふでライン」を追加

### DIFF
--- a/app/sansu-100/games/HitofudeLineGame.tsx
+++ b/app/sansu-100/games/HitofudeLineGame.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { sound } from '../lib/sound-presets';
+import { storage } from '../lib/storage';
+
+// ひとふでライン（一筆書きパズル）
+// 中心のハブノードから三角形の「花びら」が複数のびる図形を、同じ線を二度通らずに
+// なぞりきる。花びらはどれも3頂点サイクル（次数2）で、ハブは花びらの数×2の次数を
+// 持つため全頂点が偶数次数＝どの頂点から始めても必ず一筆書きできる。
+// 全部なぞれたら次のレベル（花びらが1つ増える）へ。制限時間切れで終了。
+
+const VIEW = 300;
+const CENTER = VIEW / 2;
+const RADIUS = 105;
+const NODE_R = 14;
+const TIME_LIMIT_SEC = 45;
+
+type Node = { id: number; x: number; y: number };
+type Edge = { id: string; a: number; b: number; traced: boolean };
+
+interface Puzzle {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+function edgeKey(a: number, b: number): string {
+  return a < b ? `${a}-${b}` : `${b}-${a}`;
+}
+
+function buildPuzzle(petals: number): Puzzle {
+  const nodes: Node[] = [{ id: 0, x: CENTER, y: CENTER }];
+  const edges: Edge[] = [];
+  const spread = (Math.PI / petals) * 0.38;
+  for (let i = 0; i < petals; i++) {
+    const angle = (i / petals) * Math.PI * 2 - Math.PI / 2;
+    const aId = 1 + i * 2;
+    const bId = 2 + i * 2;
+    const ax = CENTER + Math.cos(angle - spread) * RADIUS;
+    const ay = CENTER + Math.sin(angle - spread) * RADIUS;
+    const bx = CENTER + Math.cos(angle + spread) * RADIUS;
+    const by = CENTER + Math.sin(angle + spread) * RADIUS;
+    nodes.push({ id: aId, x: ax, y: ay });
+    nodes.push({ id: bId, x: bx, y: by });
+    edges.push({ id: edgeKey(0, aId), a: 0, b: aId, traced: false });
+    edges.push({ id: edgeKey(aId, bId), a: aId, b: bId, traced: false });
+    edges.push({ id: edgeKey(bId, 0), a: bId, b: 0, traced: false });
+  }
+  return { nodes, edges };
+}
+
+function petalsForLevel(level: number): number {
+  return Math.min(6, 1 + level);
+}
+
+export default function HitofudeLineGame({
+  onGameOver,
+}: {
+  onGameOver: (score: number) => void;
+}): React.JSX.Element {
+  const [level, setLevel] = useState(1);
+  const [puzzle, setPuzzle] = useState<Puzzle>(() => buildPuzzle(petalsForLevel(1)));
+  const [currentNode, setCurrentNode] = useState<number | null>(null);
+  const [timeLeft, setTimeLeft] = useState(TIME_LIMIT_SEC);
+
+  const overRef = useRef(false);
+  const soundRef = useRef(true);
+  const timeLeftRef = useRef(TIME_LIMIT_SEC);
+  const clearedRef = useRef(0);
+
+  useEffect(() => {
+    soundRef.current = storage.getSettings().soundOn;
+    clearedRef.current = 0;
+    overRef.current = false;
+
+    const id = setInterval(() => {
+      if (overRef.current) return;
+      const t = timeLeftRef.current - 1;
+      timeLeftRef.current = t;
+      setTimeLeft(Math.max(0, t));
+      if (t <= 0) {
+        clearInterval(id);
+        if (!overRef.current) {
+          overRef.current = true;
+          if (soundRef.current) sound.crash();
+          onGameOver(clearedRef.current);
+        }
+      }
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1回
+  }, []);
+
+  const tapNode = (nodeId: number) => {
+    if (overRef.current) return;
+    if (currentNode === null) {
+      setCurrentNode(nodeId);
+      return;
+    }
+    if (nodeId === currentNode) return;
+    const key = edgeKey(currentNode, nodeId);
+    const edge = puzzle.edges.find((e) => e.id === key);
+    if (!edge || edge.traced) return; // 隣接していない or すでになぞった線
+
+    const nextEdges = puzzle.edges.map((e) => (e.id === key ? { ...e, traced: true } : e));
+    setPuzzle({ nodes: puzzle.nodes, edges: nextEdges });
+    setCurrentNode(nodeId);
+    if (soundRef.current) sound.correct();
+
+    if (nextEdges.every((e) => e.traced)) {
+      // クリア → 次のレベルへ
+      clearedRef.current = level;
+      if (soundRef.current) sound.fanfare();
+      const nextLevel = level + 1;
+      setLevel(nextLevel);
+      setPuzzle(buildPuzzle(petalsForLevel(nextLevel)));
+      setCurrentNode(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="flex w-full max-w-xs items-center justify-between px-1 text-sm font-bold text-gray-800 dark:text-gray-100">
+        <span>レベル {level}</span>
+        <span className={timeLeft <= 5 ? 'text-red-600' : ''}>⏱ {timeLeft}秒</span>
+      </div>
+      <svg
+        viewBox={`0 0 ${VIEW} ${VIEW}`}
+        className="w-full max-w-xs rounded-xl bg-white shadow-md dark:bg-gray-900"
+        data-testid="hitofude-svg"
+      >
+        {puzzle.edges.map((e) => {
+          const na = puzzle.nodes.find((n) => n.id === e.a);
+          const nb = puzzle.nodes.find((n) => n.id === e.b);
+          if (!na || !nb) return null;
+          return (
+            <line
+              key={e.id}
+              x1={na.x}
+              y1={na.y}
+              x2={nb.x}
+              y2={nb.y}
+              stroke={e.traced ? '#22c55e' : '#cbd5e1'}
+              strokeWidth={e.traced ? 6 : 4}
+              strokeLinecap="round"
+              data-testid={`hitofude-edge-${e.id}`}
+              data-traced={e.traced ? 'true' : 'false'}
+            />
+          );
+        })}
+        {puzzle.nodes.map((n) => (
+          <circle
+            key={n.id}
+            cx={n.x}
+            cy={n.y}
+            r={NODE_R}
+            fill={currentNode === n.id ? '#f97316' : '#6366f1'}
+            stroke="white"
+            strokeWidth={2}
+            data-testid={`hitofude-node-${n.id}`}
+            onClick={() => tapNode(n.id)}
+            style={{ cursor: 'pointer' }}
+          />
+        ))}
+      </svg>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        点を じゅんばんに タップして、ぜんぶの せんを 一ふでで なぞろう
+      </p>
+    </div>
+  );
+}

--- a/app/sansu-100/lib/badge-catalog.ts
+++ b/app/sansu-100/lib/badge-catalog.ts
@@ -110,6 +110,8 @@ export const BADGE_CATALOG: readonly BadgeDef[] = [
   { id: 'airhockey_champion', category: 'minigame', name: 'ホッケー王者', description: 'はじいてホッケーで10てん', icon: '🏆', tier: 'gold', rarity: 'epic' },
   { id: 'kururin_roller', category: 'minigame', name: 'ころころ名人', description: 'くるりんボールで2かいクリア', icon: '🌀', tier: 'silver', rarity: 'rare' },
   { id: 'kururin_master', category: 'minigame', name: 'めいろの達人', description: 'くるりんボールで5かいクリア', icon: '🎯', tier: 'gold', rarity: 'epic' },
+  { id: 'hitofude_artist', category: 'minigame', name: 'いっぴつがき名人', description: 'ひとふでラインで3もんクリア', icon: '✏️', tier: 'silver', rarity: 'rare' },
+  { id: 'hitofude_master', category: 'minigame', name: 'せんの達人', description: 'ひとふでラインで6もんクリア', icon: '🖊️', tier: 'gold', rarity: 'epic' },
   { id: 'games_explorer', category: 'minigame', name: 'ゲームたんけんか', description: '5しゅるいの ゲームで あそんだ', icon: '🎮', tier: 'silver', rarity: 'rare' },
   { id: 'games_allstar', category: 'minigame', name: 'ゲームマスター', description: 'ぜんぶの ゲームで あそんだ', icon: '🏅', tier: 'rainbow', rarity: 'legendary' },
 

--- a/app/sansu-100/lib/minigame-list.ts
+++ b/app/sansu-100/lib/minigame-list.ts
@@ -203,6 +203,18 @@ export const MINIGAMES: readonly MinigameMeta[] = [
     ],
     available: true,
   },
+  {
+    id: 'hitofude',
+    name: 'ひとふでライン',
+    emoji: '✏️',
+    desc: '一ふでで ぜんぶの せんを なぞろう！',
+    howTo: [
+      '点と点が せんで つながっているよ',
+      'おなじ せんを 2回 とおらずに、ぜんぶの せんを タップで なぞろう',
+      'ぜんぶ なぞれたら つぎの もんだいへ（はなびらが ふえるよ）。時間切れで おわり',
+    ],
+    available: true,
+  },
 ];
 
 const BY_ID: Record<string, MinigameMeta> = Object.fromEntries(

--- a/app/sansu-100/lib/minigame-rewards.ts
+++ b/app/sansu-100/lib/minigame-rewards.ts
@@ -17,7 +17,8 @@ export type MinigameId =
   | 'starshooter'
   | 'ponpon'
   | 'airhockey'
-  | 'kururin';
+  | 'kururin'
+  | 'hitofude';
 
 // gameId ごとの { しきい値: バッジID }（昇順）
 const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
@@ -84,6 +85,10 @@ const THRESHOLDS: Record<MinigameId, { score: number; badgeId: string }[]> = {
   kururin: [
     { score: 2, badgeId: 'kururin_roller' },
     { score: 5, badgeId: 'kururin_master' },
+  ],
+  hitofude: [
+    { score: 3, badgeId: 'hitofude_artist' },
+    { score: 6, badgeId: 'hitofude_master' },
   ],
 };
 

--- a/app/sansu-100/minigame/hitofude/page.tsx
+++ b/app/sansu-100/minigame/hitofude/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import Header from '../../../components/header';
+import ThemeToggle from '../../../components/theme-toggle';
+import BadgeUnlockOverlay from '../../components/BadgeUnlockOverlay';
+import CoinBalance from '../../components/CoinBalance';
+import HowToPlay from '../../components/HowToPlay';
+import NewRecordBanner from '../../components/NewRecordBanner';
+import HitofudeLineGame from '../../games/HitofudeLineGame';
+import { useSansuUser } from '../../hooks/useSansuUser';
+import { sansuApi } from '../../lib/api-client';
+import { SPEND_COSTS } from '../../lib/minigame-economy';
+import { minigameHowTo } from '../../lib/minigame-list';
+import { evaluateMinigameBadges } from '../../lib/minigame-rewards';
+
+type Phase = 'intro' | 'playing' | 'over';
+
+export default function HitofudePage(): React.JSX.Element {
+  const router = useRouter();
+  const { currentUser, saveUser, loaded } = useSansuUser();
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [lastScore, setLastScore] = useState(0);
+  const [round, setRound] = useState(0);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [overlayBadges, setOverlayBadges] = useState<string[]>([]);
+  const [newRecord, setNewRecord] = useState(false);
+
+  const coins = currentUser?.coins ?? 0;
+
+  const start = useCallback(async () => {
+    if (!currentUser) return;
+    setBusy(true);
+    setMessage(null);
+    setNewRecord(false);
+    try {
+      const res = await sansuApi.spend(currentUser.id, 'play');
+      if (res.ok && res.user) {
+        saveUser(res.user);
+        setRound((r) => r + 1);
+        setPhase('playing');
+      } else {
+        setMessage(
+          res.error === 'no_plays'
+            ? '🧮 さんすうを 1かい といてから あそぼう！'
+            : 'コインが たりないよ'
+        );
+      }
+    } catch {
+      setMessage('いまは つうしんできないよ（あとでね）');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentUser, saveUser]);
+
+  const handleGameOver = useCallback(
+    async (score: number) => {
+      setLastScore(score);
+      setPhase('over');
+      if (!currentUser) return;
+      const newBadges = evaluateMinigameBadges(
+        'hitofude',
+        score,
+        currentUser.earnedBadges
+      );
+      try {
+        const res = await sansuApi.awardBadge(currentUser.id, newBadges, score, 'hitofude');
+        if (res.user) saveUser(res.user);
+        if (res.newRecord) setNewRecord(true);
+        if (newBadges.length > 0) setOverlayBadges(newBadges);
+      } catch {
+        // 報酬付与失敗は致命的でない
+      }
+    },
+    [currentUser, saveUser]
+  );
+
+  if (loaded && !currentUser) {
+    if (typeof window !== 'undefined') router.replace('/sansu-100');
+    return <main className="p-8" />;
+  }
+  if (!currentUser) return <main className="p-8" />;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+      <div className="container mx-auto max-w-md space-y-4 p-4">
+        {phase === 'playing' ? (
+          <Link
+            href="/sansu-100/minigame"
+            className="inline-block text-sm font-semibold text-blue-600 dark:text-blue-300"
+          >
+            ← やめる
+          </Link>
+        ) : (
+          <Header
+            title="✏️ ひとふでライン"
+            description="一ふでで ぜんぶの せんを なぞろう！"
+            showBackButton
+            backHref="/sansu-100/minigame"
+            backLabel="ゲームせんたくにもどる"
+          />
+        )}
+
+        {message ? (
+          <div className="rounded-xl bg-yellow-100 px-4 py-3 text-center font-bold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+            {message}
+          </div>
+        ) : null}
+
+        {phase === 'intro' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-6xl">✏️</p>
+            <HowToPlay steps={minigameHowTo('hitofude')} />
+            <p className="text-gray-700 dark:text-gray-200">
+              コインを {SPEND_COSTS.play}まい つかって あそぶよ
+            </p>
+            <div className="flex justify-center">
+              <CoinBalance coins={coins} />
+            </div>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-teal-600 py-4 text-lg font-bold text-white hover:bg-teal-700 disabled:opacity-60"
+              data-testid="hitofude-start"
+            >
+              🪙 {SPEND_COSTS.play} であそぶ
+            </button>
+          </section>
+        ) : null}
+
+        {phase === 'playing' ? (
+          <section className="rounded-2xl bg-white p-4 shadow-md dark:bg-gray-800">
+            <HitofudeLineGame key={round} onGameOver={handleGameOver} />
+          </section>
+        ) : null}
+
+        {phase === 'over' ? (
+          <section className="space-y-4 rounded-2xl bg-white p-6 text-center shadow-md dark:bg-gray-800">
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              おわり！
+            </p>
+            <p className="text-lg text-gray-700 dark:text-gray-200">
+              クリアした もんだい: <b data-testid="hitofude-final-score">{lastScore}</b>
+            </p>
+            {newRecord ? <NewRecordBanner score={lastScore} /> : null}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={start}
+              className="w-full rounded-xl bg-teal-600 py-4 text-lg font-bold text-white hover:bg-teal-700 disabled:opacity-60"
+              data-testid="hitofude-again"
+            >
+              🪙 {SPEND_COSTS.play} で もういちど
+            </button>
+            <Link
+              href="/sansu-100/minigame"
+              className="block rounded-xl bg-gray-200 py-3 font-bold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              ほかの ゲームへ
+            </Link>
+          </section>
+        ) : null}
+      </div>
+
+      {overlayBadges.length > 0 ? (
+        <BadgeUnlockOverlay
+          badgeIds={overlayBadges}
+          onDone={() => setOverlayBadges([])}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/tests/sansu/hitofude.spec.ts
+++ b/tests/sansu/hitofude.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * ひとふでライン（一筆書きパズル）のE2Eテスト。
+ *
+ * - 本番ユーザは触らない。毎回ユニークな E2E 接頭辞ユーザを新規作成する。
+ * - baseURL は http://localhost:4280 (playwright.config.sansu.ts 参照)
+ * - レベル1は花びら2枚（ハブ+4頂点、6本の辺）の決定的な図形なので、
+ *   実際になぞりきってレベルアップすることまで確認できる。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `HTF${suffix}`;
+}
+
+async function registerAndLogin(page: Page, name: string): Promise<void> {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sansu-100:dev-seeded', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of PIN) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'これでとうろく！' }).click();
+  await page.waitForURL('**/sansu-100', { timeout: 10000 });
+}
+
+async function earnCoinsViaDebug(page: Page): Promise<void> {
+  await page.goto('/sansu-100/play');
+  await page.waitForLoadState('networkidle');
+  const lv1 = page.locator('[data-testid="level-pick-1"]');
+  if (await lv1.isVisible()) {
+    await lv1.click();
+  }
+  const dbgBtn = page.locator('[data-testid="debug-finish-perfect"]');
+  if (await dbgBtn.isVisible({ timeout: 5000 })) {
+    await dbgBtn.click();
+  }
+  await page.goto('/sansu-100');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('ひとふでライン ミニゲーム', () => {
+  test('ミニゲーム一覧にひとふでラインが表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('ひとふでライン')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('ひとふでラインページにアクセスすると intro 画面が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+
+    await page.goto('/sansu-100/minigame/hitofude');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('ひとふでライン').first()).toBeVisible({ timeout: 8000 });
+    const startBtn = page.locator('[data-testid="hitofude-start"]');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('コイン不足時にスタートするとエラーメッセージが出る', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await page.goto('/sansu-100/minigame/hitofude');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="hitofude-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+    await expect(
+      page.getByText(/さんすうを|コインが/)
+    ).toBeVisible({ timeout: 6000 });
+  });
+
+  test('コイン取得後にスタートするとノードと辺が表示される', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/hitofude');
+    await page.waitForLoadState('networkidle');
+    const startBtn = page.locator('[data-testid="hitofude-start"]');
+    await startBtn.waitFor({ timeout: 8000 });
+    await startBtn.click();
+
+    await expect(page.locator('[data-testid="hitofude-svg"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="hitofude-node-0"]')).toBeVisible();
+    await expect(page.getByText('← やめる')).toBeVisible();
+  });
+
+  test('レベル1（花びら2枚）を実際になぞりきるとレベル2へ進む', async ({ page }) => {
+    const name = uniqueName();
+    await registerAndLogin(page, name);
+    await earnCoinsViaDebug(page);
+
+    await page.goto('/sansu-100/minigame/hitofude');
+    await page.waitForLoadState('networkidle');
+    await page.locator('[data-testid="hitofude-start"]').click();
+    await expect(page.locator('[data-testid="hitofude-svg"]')).toBeVisible({ timeout: 8000 });
+
+    // レベル1は petalsForLevel(1)=2 枚の花びら。ノードIDは 0(ハブ), 1,2(花びら0), 3,4(花びら1)。
+    // 一筆書き経路: 0→1→2→0→3→4→0 で全6辺をなぞりきれる。
+    const order = [0, 1, 2, 0, 3, 4, 0];
+    for (const nodeId of order) {
+      await page.locator(`[data-testid="hitofude-node-${nodeId}"]`).click();
+      await page.waitForTimeout(150);
+    }
+
+    await expect(page.getByText('レベル 2')).toBeVisible({ timeout: 3000 });
+  });
+});


### PR DESCRIPTION
## 概要
ミニゲームハブに新しいゲーム「ひとふでライン」（一筆書きパズル）を追加する。

## 遊び方
- 中心のハブから三角形の「花びら」が複数のびる図形が表示される
- 同じ線を二度通らず、全ての線をタップでなぞりきる（一筆書き）
- 全部なぞれたら次のレベル（花びらが1枚増える）へ。制限時間内にクリアした数がスコア

## 実装内容
- `app/sansu-100/games/HitofudeLineGame.tsx`: SVGで実装（Canvas不要）。花びら＝3頂点サイクル（次数2）× ハブノードという構造にすることで、常に全頂点が偶数次数＝どの頂点から始めても一筆書き可能な図形を手軽に生成できる
- `app/sansu-100/minigame/hitofude/page.tsx`: ページラッパー（既存パターン踏襲）
- `minigame-list.ts` / `minigame-rewards.ts` / `badge-catalog.ts`: 一覧登録・バッジ2種追加
- `tests/sansu/hitofude.spec.ts`: E2Eテスト5件（レベル1の決定的な図形を実際になぞりきってレベルアップすることまで確認）

## 動作確認
- `npm run build` 成功
- ローカルSWA環境（localhost:4280）で5テストを2回連続実行、全10回pass確認済み
- スクリーンショットでノード・エッジ・なぞり済み線の色分けを目視確認済み

Closes #148