### PR TITLE
feat(sansu-100): アバターカタログを拡充（新規43アイテム）

### DIFF
--- a/api/src/shared/avatarOptions.ts
+++ b/api/src/shared/avatarOptions.ts
@@ -1,7 +1,7 @@
 // パーツ組み立て式アバター（avataaars）の許可値（クライアント lib/avatar-options.ts と同期）。
 // サーバーを権威として、未知の値・未所持の有料パーツはデフォルトに丸める。
 
-import { ownsValue, type AvatarItemCategory } from './avatarShop';
+import { ownsValue, PAID_VALUES, type AvatarItemCategory } from './avatarShop';
 
 export type AvatarConfig = {
   skinColor: string;
@@ -16,7 +16,11 @@ export type AvatarConfig = {
   clothing: string;
 };
 
-const SKIN = ['ffdbb4', 'edb98a', 'fd9841', 'd08b5b', 'ae5d29', '614335'];
+// 身体的アイデンティティなので無料のまま（既存6色は変更せず4色追加。app/lib/avatar-options.ts と同期）。
+const SKIN = [
+  'ffdbb4', 'f7d7c4', 'edb98a', 'e8b17d', 'fd9841', 'd08b5b', 'c68863',
+  'ae5d29', '8d5524', '614335',
+];
 const HAIR_COLOR = [
   '2c1b18', '4a312c', '724133', 'a55728', 'b58143', 'e8e1e1', 'c93305',
   '65c9ff', 'ff488e', '7ed957',
@@ -42,6 +46,19 @@ const MOUTH = [
   'screamOpen',
 ];
 const FREE_CLOTHING = 'shirtCrewNeck';
+
+// PR1（カタログ拡充のみ・有料化検証はPR2）時点では、新カテゴリの値も
+// まだ無条件で保存を許可する（=事実上無料相当）。PR2の pickPaid 拡張で
+// 所持チェックに切り替える。値の実在確認は avatarShop.ts の SEEDS を正とする。
+const valsOf = (cat: AvatarItemCategory): string[] =>
+  Array.from(PAID_VALUES[cat]);
+// hat(帽子)は既存どおり所持チェック対象のまま。hairstyle だけ PR1時点で無条件許可に混ぜる。
+const ALL_TOP = [...HAIRSTYLES, ...valsOf('hairstyle')];
+const ALL_HAIR_COLOR = [...HAIR_COLOR, ...valsOf('haircolor')];
+const ALL_EYES = [...EYES, ...valsOf('eyes')];
+const ALL_EYEBROWS = [...EYEBROWS, ...valsOf('eyebrow')];
+const ALL_MOUTH = [...MOUTH, ...valsOf('mouthstyle')];
+const ALL_CLOTHES_COLOR = [...CLOTHES_COLOR, ...valsOf('clothescolor')];
 
 export const DEFAULT_AVATAR_CONFIG: AvatarConfig = {
   skinColor: 'edb98a',
@@ -82,15 +99,16 @@ export function sanitizeAvatarConfig(
   const owned = new Set(ownedIds);
   return {
     skinColor: pick(c.skinColor, SKIN, DEFAULT_AVATAR_CONFIG.skinColor),
-    hairColor: pick(c.hairColor, HAIR_COLOR, DEFAULT_AVATAR_CONFIG.hairColor),
-    // top は無料の髪型 or 所持している有料の帽子
-    top: pickPaid(c.top, 'hat', HAIRSTYLES, owned, DEFAULT_AVATAR_CONFIG.top),
-    eyes: pick(c.eyes, EYES, DEFAULT_AVATAR_CONFIG.eyes),
-    eyebrows: pick(c.eyebrows, EYEBROWS, DEFAULT_AVATAR_CONFIG.eyebrows),
-    mouth: pick(c.mouth, MOUTH, DEFAULT_AVATAR_CONFIG.mouth),
+    // PR1時点では新カテゴリ(haircolor等)もカタログ実在値なら無条件許可（有料検証はPR2）。
+    hairColor: pick(c.hairColor, ALL_HAIR_COLOR, DEFAULT_AVATAR_CONFIG.hairColor),
+    // top は無料の髪型 or 所持している有料の帽子（+ PR1時点ではhairstyleも無条件許可）
+    top: pickPaid(c.top, 'hat', ALL_TOP, owned, DEFAULT_AVATAR_CONFIG.top),
+    eyes: pick(c.eyes, ALL_EYES, DEFAULT_AVATAR_CONFIG.eyes),
+    eyebrows: pick(c.eyebrows, ALL_EYEBROWS, DEFAULT_AVATAR_CONFIG.eyebrows),
+    mouth: pick(c.mouth, ALL_MOUTH, DEFAULT_AVATAR_CONFIG.mouth),
     clothesColor: pick(
       c.clothesColor,
-      CLOTHES_COLOR,
+      ALL_CLOTHES_COLOR,
       DEFAULT_AVATAR_CONFIG.clothesColor
     ),
     accessory: pickPaid(c.accessory, 'glasses', ['none'], owned, 'none'),

--- a/api/src/shared/avatarShop.ts
+++ b/api/src/shared/avatarShop.ts
@@ -1,7 +1,17 @@
 // 有料アバター・アクセサリーのサーバー版（購入価格＋所持検証の正）。
 // クライアント app/sansu-100/lib/avatar-shop.ts と id・価格・カテゴリ・値を一致させること。
 
-export type AvatarItemCategory = 'hat' | 'glasses' | 'clothing' | 'beard';
+export type AvatarItemCategory =
+  | 'hat'
+  | 'glasses'
+  | 'clothing'
+  | 'beard'
+  | 'hairstyle'
+  | 'haircolor'
+  | 'eyes'
+  | 'eyebrow'
+  | 'mouthstyle'
+  | 'clothescolor';
 
 // カテゴリ → avatarConfig のどのフィールドに入るか
 export const AVATAR_ITEM_FIELD: Record<AvatarItemCategory, string> = {
@@ -9,6 +19,12 @@ export const AVATAR_ITEM_FIELD: Record<AvatarItemCategory, string> = {
   glasses: 'accessory',
   clothing: 'clothing',
   beard: 'facialHair',
+  hairstyle: 'top',
+  haircolor: 'hairColor',
+  eyes: 'eyes',
+  eyebrow: 'eyebrows',
+  mouthstyle: 'mouth',
+  clothescolor: 'clothesColor',
 };
 
 const PRICE = { normal: 50, rare: 200, epic: 1000 } as const;
@@ -43,6 +59,55 @@ const SEEDS: Seed[] = [
   ['beard', 'moustacheFancy', 'rare'],
   ['beard', 'moustacheMagnum', 'epic'],
   ['beard', 'beardMajestic', 'epic'],
+  // ---- かみがた（新カテゴリ。top に入る） ----
+  ['hairstyle', 'curvy', 'rare'],
+  ['hairstyle', 'miaWallace', 'rare'],
+  ['hairstyle', 'frida', 'rare'],
+  ['hairstyle', 'froBand', 'rare'],
+  ['hairstyle', 'straight02', 'normal'],
+  ['hairstyle', 'straightAndStrand', 'normal'],
+  ['hairstyle', 'dreads02', 'rare'],
+  ['hairstyle', 'frizzle', 'normal'],
+  ['hairstyle', 'shaggy', 'normal'],
+  ['hairstyle', 'shaggyMullet', 'rare'],
+  ['hairstyle', 'shavedSides', 'rare'],
+  ['hairstyle', 'theCaesarAndSidePart', 'normal'],
+  // ---- かみのいろ（新カテゴリ。hairColor に入る） ----
+  ['haircolor', 'f59797', 'normal'],
+  ['haircolor', 'ecdcbf', 'normal'],
+  ['haircolor', 'd6b370', 'normal'],
+  ['haircolor', 'c7a2ff', 'rare'],
+  ['haircolor', 'a7ffc4', 'rare'],
+  ['haircolor', 'b1e2ff', 'rare'],
+  ['haircolor', 'ffd6f5', 'rare'],
+  ['haircolor', 'c0c0c0', 'epic'],
+  // ---- め（既存カテゴリに追加。eyes に入る） ----
+  ['eyes', 'cry', 'normal'],
+  ['eyes', 'eyeRoll', 'normal'],
+  ['eyes', 'winkWacky', 'rare'],
+  ['eyes', 'xDizzy', 'rare'],
+  // ---- まゆげ（新カテゴリ。eyebrows に入る） ----
+  ['eyebrow', 'angryNatural', 'normal'],
+  ['eyebrow', 'frownNatural', 'normal'],
+  ['eyebrow', 'raisedExcitedNatural', 'normal'],
+  ['eyebrow', 'sadConcernedNatural', 'normal'],
+  ['eyebrow', 'unibrowNatural', 'rare'],
+  ['eyebrow', 'upDownNatural', 'rare'],
+  ['eyebrow', 'upDown', 'normal'],
+  // ---- くち（新カテゴリ。mouth に入る） ----
+  ['mouthstyle', 'concerned', 'normal'],
+  ['mouthstyle', 'grimace', 'rare'],
+  ['mouthstyle', 'sad', 'normal'],
+  ['mouthstyle', 'vomit', 'rare'],
+  // ---- ふくのいろ（新カテゴリ。clothesColor に入る） ----
+  ['clothescolor', 'ff488e', 'normal'],
+  ['clothescolor', 'a7ffc4', 'normal'],
+  ['clothescolor', 'b1e2ff', 'normal'],
+  ['clothescolor', 'ffffb1', 'normal'],
+  ['clothescolor', 'ffafb9', 'normal'],
+  ['clothescolor', '25557c', 'rare'],
+  ['clothescolor', 'ffffff', 'rare'],
+  ['clothescolor', '262e33', 'rare'],
 ];
 
 const idOf = (category: AvatarItemCategory, value: string): string =>
@@ -59,6 +124,12 @@ export const PAID_VALUES: Record<AvatarItemCategory, Set<string>> = {
   glasses: new Set(),
   clothing: new Set(),
   beard: new Set(),
+  hairstyle: new Set(),
+  haircolor: new Set(),
+  eyes: new Set(),
+  eyebrow: new Set(),
+  mouthstyle: new Set(),
+  clothescolor: new Set(),
 };
 for (const [c, v] of SEEDS) PAID_VALUES[c].add(v);
 

--- a/app/sansu-100/avatar/page.tsx
+++ b/app/sansu-100/avatar/page.tsx
@@ -38,20 +38,50 @@ type Cat = {
   label: string;
   kind: 'parts' | 'color';
   free: readonly string[];
-  paid?: AvatarItemCategory; // 所持していれば足す有料カテゴリ
+  paid?: AvatarItemCategory | AvatarItemCategory[]; // 所持していれば足す有料カテゴリ（複数可）
 };
 
 const CATEGORIES: Cat[] = [
-  { key: 'top', label: 'かみ・ぼうし', kind: 'parts', free: AVATAR_HAIR, paid: 'hat' },
-  { key: 'hairColor', label: 'かみのいろ', kind: 'color', free: AVATAR_HAIR_COLOR },
-  { key: 'eyes', label: 'め', kind: 'parts', free: AVATAR_EYES },
-  { key: 'eyebrows', label: 'まゆげ', kind: 'parts', free: AVATAR_EYEBROWS },
-  { key: 'mouth', label: 'くち', kind: 'parts', free: AVATAR_MOUTH },
+  {
+    key: 'top',
+    label: 'かみ・ぼうし',
+    kind: 'parts',
+    free: AVATAR_HAIR,
+    paid: ['hat', 'hairstyle'],
+  },
+  {
+    key: 'hairColor',
+    label: 'かみのいろ',
+    kind: 'color',
+    free: AVATAR_HAIR_COLOR,
+    paid: 'haircolor',
+  },
+  { key: 'eyes', label: 'め', kind: 'parts', free: AVATAR_EYES, paid: 'eyes' },
+  {
+    key: 'eyebrows',
+    label: 'まゆげ',
+    kind: 'parts',
+    free: AVATAR_EYEBROWS,
+    paid: 'eyebrow',
+  },
+  {
+    key: 'mouth',
+    label: 'くち',
+    kind: 'parts',
+    free: AVATAR_MOUTH,
+    paid: 'mouthstyle',
+  },
   { key: 'accessory', label: 'メガネ', kind: 'parts', free: ['none'], paid: 'glasses' },
   { key: 'facialHair', label: 'ひげ', kind: 'parts', free: ['none'], paid: 'beard' },
   { key: 'clothing', label: 'ふく', kind: 'parts', free: ['shirtCrewNeck'], paid: 'clothing' },
   { key: 'skinColor', label: 'はだのいろ', kind: 'color', free: AVATAR_SKIN },
-  { key: 'clothesColor', label: 'ふくのいろ', kind: 'color', free: AVATAR_CLOTHES_COLOR },
+  {
+    key: 'clothesColor',
+    label: 'ふくのいろ',
+    kind: 'color',
+    free: AVATAR_CLOTHES_COLOR,
+    paid: 'clothescolor',
+  },
 ];
 
 function randomFrom(opts: string[]): string {
@@ -175,9 +205,9 @@ export default function AvatarBuilderPage(): React.JSX.Element {
     return () => window.removeEventListener('beforeunload', onBeforeUnload);
   }, [dirty]);
 
-  // カテゴリごとの選べる値（無料＋所持している有料）
+  // カテゴリごとの選べる値（無料＋所持している有料。色カテゴリも有料値があれば追加）
   const optionsFor = (cat: Cat): string[] => {
-    if (cat.kind === 'color' || !cat.paid) return [...cat.free];
+    if (!cat.paid) return [...cat.free];
     return [...cat.free, ...ownedValuesOf(cat.paid, owned)];
   };
 

--- a/app/sansu-100/lib/avatar-options.ts
+++ b/app/sansu-100/lib/avatar-options.ts
@@ -53,13 +53,18 @@ export const AVATAR_MOUTH: string[] = [
   'screamOpen',
 ];
 
-// 肌の色（明→暗）。
+// 肌の色（明→暗。身体的アイデンティティなので無料のまま、ショップには載せない）。
+// 既存6色は変更せず、中間色・アンダートーン違いを4色追加（Monk Skin Tone Scale の趣旨）。
 export const AVATAR_SKIN: string[] = [
   'ffdbb4',
+  'f7d7c4',
   'edb98a',
+  'e8b17d',
   'fd9841',
   'd08b5b',
+  'c68863',
   'ae5d29',
+  '8d5524',
   '614335',
 ];
 

--- a/app/sansu-100/lib/avatar-shop.ts
+++ b/app/sansu-100/lib/avatar-shop.ts
@@ -5,7 +5,17 @@ import type { AvatarConfig } from './types';
 // 買うと ownedItems に id が入り、ビルダーで装備（avatarConfig に反映）できる。
 // サーバー avatarShop.ts と id・価格・カテゴリを一致させること。
 
-export type AvatarItemCategory = 'hat' | 'glasses' | 'clothing' | 'beard';
+export type AvatarItemCategory =
+  | 'hat'
+  | 'glasses'
+  | 'clothing'
+  | 'beard'
+  | 'hairstyle'
+  | 'haircolor'
+  | 'eyes'
+  | 'eyebrow'
+  | 'mouthstyle'
+  | 'clothescolor';
 
 // カテゴリ → avatarConfig のどのフィールドに入るか
 export const AVATAR_ITEM_FIELD: Record<AvatarItemCategory, keyof AvatarConfig> = {
@@ -13,6 +23,12 @@ export const AVATAR_ITEM_FIELD: Record<AvatarItemCategory, keyof AvatarConfig> =
   glasses: 'accessory',
   clothing: 'clothing',
   beard: 'facialHair',
+  hairstyle: 'top',
+  haircolor: 'hairColor',
+  eyes: 'eyes',
+  eyebrow: 'eyebrows',
+  mouthstyle: 'mouth',
+  clothescolor: 'clothesColor',
 };
 
 export const AVATAR_CATEGORY_LABEL: Record<AvatarItemCategory, string> = {
@@ -20,6 +36,12 @@ export const AVATAR_CATEGORY_LABEL: Record<AvatarItemCategory, string> = {
   glasses: 'メガネ',
   clothing: 'ふく',
   beard: 'ひげ',
+  hairstyle: 'かみがた',
+  haircolor: 'かみのいろ',
+  eyes: 'め',
+  eyebrow: 'まゆげ',
+  mouthstyle: 'くち',
+  clothescolor: 'ふくのいろ',
 };
 
 export const AVATAR_CATEGORY_ICON: Record<AvatarItemCategory, string> = {
@@ -27,6 +49,12 @@ export const AVATAR_CATEGORY_ICON: Record<AvatarItemCategory, string> = {
   glasses: '👓',
   clothing: '👕',
   beard: '🧔',
+  hairstyle: '💇',
+  haircolor: '🎨',
+  eyes: '👀',
+  eyebrow: '🤨',
+  mouthstyle: '👄',
+  clothescolor: '🌈',
 };
 
 export type ItemRarity = 'normal' | 'rare' | 'epic';
@@ -79,6 +107,55 @@ const SEEDS: Seed[] = [
   ['beard', 'moustacheFancy', 'おしゃれひげ', 'rare'],
   ['beard', 'moustacheMagnum', 'カイゼルひげ', 'epic'],
   ['beard', 'beardMajestic', 'りっぱなひげ', 'epic'],
+  // ---- かみがた（新カテゴリ。top に入る） ----
+  ['hairstyle', 'curvy', 'ながいウェーブ', 'rare'],
+  ['hairstyle', 'miaWallace', 'ぱっつんボブ', 'rare'],
+  ['hairstyle', 'frida', 'みつあみ', 'rare'],
+  ['hairstyle', 'froBand', 'もりもりヘアバンド', 'rare'],
+  ['hairstyle', 'straight02', 'ストレートロング', 'normal'],
+  ['hairstyle', 'straightAndStrand', 'さらさらまえがみ', 'normal'],
+  ['hairstyle', 'dreads02', 'ドレッズロング', 'rare'],
+  ['hairstyle', 'frizzle', 'ふわふわヘア', 'normal'],
+  ['hairstyle', 'shaggy', 'ふんわりレイヤー', 'normal'],
+  ['hairstyle', 'shaggyMullet', 'ウルフカット', 'rare'],
+  ['hairstyle', 'shavedSides', 'サイドがり', 'rare'],
+  ['hairstyle', 'theCaesarAndSidePart', '７３わけ', 'normal'],
+  // ---- かみのいろ（新カテゴリ。hairColor に入る） ----
+  ['haircolor', 'f59797', 'さくらピンク', 'normal'],
+  ['haircolor', 'ecdcbf', 'ミルクベージュ', 'normal'],
+  ['haircolor', 'd6b370', 'はちみつ', 'normal'],
+  ['haircolor', 'c7a2ff', 'ラベンダー', 'rare'],
+  ['haircolor', 'a7ffc4', 'ミントグリーン', 'rare'],
+  ['haircolor', 'b1e2ff', 'そらいろ', 'rare'],
+  ['haircolor', 'ffd6f5', 'ゆめかわピンク', 'rare'],
+  ['haircolor', 'c0c0c0', 'シルバー', 'epic'],
+  // ---- め（既存カテゴリに追加。eyes に入る） ----
+  ['eyes', 'cry', 'なきむし', 'normal'],
+  ['eyes', 'eyeRoll', 'くるりんめ', 'normal'],
+  ['eyes', 'winkWacky', 'おちゃめウィンク', 'rare'],
+  ['eyes', 'xDizzy', 'ぐるぐるめ', 'rare'],
+  // ---- まゆげ（新カテゴリ。eyebrows に入る） ----
+  ['eyebrow', 'angryNatural', 'りりしいまゆ', 'normal'],
+  ['eyebrow', 'frownNatural', 'むっとまゆ', 'normal'],
+  ['eyebrow', 'raisedExcitedNatural', 'わくわくまゆ', 'normal'],
+  ['eyebrow', 'sadConcernedNatural', 'しょんぼりまゆ', 'normal'],
+  ['eyebrow', 'unibrowNatural', 'つながりまゆ', 'rare'],
+  ['eyebrow', 'upDownNatural', 'ちぐはぐまゆ', 'rare'],
+  ['eyebrow', 'upDown', 'びっくりまゆ', 'normal'],
+  // ---- くち（新カテゴリ。mouth に入る） ----
+  ['mouthstyle', 'concerned', 'こまりがお', 'normal'],
+  ['mouthstyle', 'grimace', 'にやり', 'rare'],
+  ['mouthstyle', 'sad', 'しょんぼり', 'normal'],
+  ['mouthstyle', 'vomit', 'げろげろ', 'rare'],
+  // ---- ふくのいろ（新カテゴリ。clothesColor に入る） ----
+  ['clothescolor', 'ff488e', 'ホットピンク', 'normal'],
+  ['clothescolor', 'a7ffc4', 'ミント', 'normal'],
+  ['clothescolor', 'b1e2ff', 'パステルブルー', 'normal'],
+  ['clothescolor', 'ffffb1', 'レモンイエロー', 'normal'],
+  ['clothescolor', 'ffafb9', 'コーラルピンク', 'normal'],
+  ['clothescolor', '25557c', 'ネイビー', 'rare'],
+  ['clothescolor', 'ffffff', 'しろ', 'rare'],
+  ['clothescolor', '262e33', 'くろ', 'rare'],
 ];
 
 export const AVATAR_SHOP: AvatarItemDef[] = SEEDS.map(
@@ -100,14 +177,18 @@ export function getAvatarItem(id: string): AvatarItemDef | undefined {
   return AVATAR_SHOP_BY_ID[id];
 }
 
-// あるカテゴリで「所持している値」一覧（ビルダーで選べるもの）。
+// あるカテゴリ（複数可。例: top タブは hat と hairstyle 両方）で
+// 「所持している値」一覧（ビルダーで選べるもの）。
 export function ownedValuesOf(
-  category: AvatarItemCategory,
+  category: AvatarItemCategory | AvatarItemCategory[],
   ownedIds: string[]
 ): string[] {
   const owned = new Set(ownedIds);
+  const categories = new Set(
+    Array.isArray(category) ? category : [category]
+  );
   return AVATAR_SHOP.filter(
-    (it) => it.category === category && owned.has(it.id)
+    (it) => categories.has(it.category) && owned.has(it.id)
   ).map((it) => it.value);
 }
 

--- a/app/sansu-100/lib/avatar-svg.ts
+++ b/app/sansu-100/lib/avatar-svg.ts
@@ -23,12 +23,12 @@ const valsOf = (cat: string): string[] =>
 // 各フィールドの「描画してよい値」（無料＋全有料パーツ。描画は所持に関係なくOK）。
 const ALLOWED: Record<keyof AvatarConfig, string[]> = {
   skinColor: AVATAR_SKIN,
-  hairColor: AVATAR_HAIR_COLOR,
-  clothesColor: AVATAR_CLOTHES_COLOR,
-  eyes: AVATAR_EYES,
-  eyebrows: AVATAR_EYEBROWS,
-  mouth: AVATAR_MOUTH,
-  top: [...AVATAR_HAIR, ...valsOf('hat')],
+  hairColor: [...AVATAR_HAIR_COLOR, ...valsOf('haircolor')],
+  clothesColor: [...AVATAR_CLOTHES_COLOR, ...valsOf('clothescolor')],
+  eyes: [...AVATAR_EYES, ...valsOf('eyes')],
+  eyebrows: [...AVATAR_EYEBROWS, ...valsOf('eyebrow')],
+  mouth: [...AVATAR_MOUTH, ...valsOf('mouthstyle')],
+  top: [...AVATAR_HAIR, ...valsOf('hat'), ...valsOf('hairstyle')],
   accessory: ['none', ...valsOf('glasses')],
   facialHair: ['none', ...valsOf('beard')],
   clothing: ['shirtCrewNeck', ...valsOf('clothing')],

--- a/app/sansu-100/shop/page.tsx
+++ b/app/sansu-100/shop/page.tsx
@@ -39,7 +39,19 @@ const AVATAR_CATEGORIES: AvatarItemCategory[] = [
   'glasses',
   'clothing',
   'beard',
+  'hairstyle',
+  'haircolor',
+  'eyes',
+  'eyebrow',
+  'mouthstyle',
+  'clothescolor',
 ];
+
+// 色そのものを見せたいカテゴリ（サムネはDiceBearプレビューでなく色丸にする）
+const COLOR_CATEGORIES: ReadonlySet<AvatarItemCategory> = new Set([
+  'haircolor',
+  'clothescolor',
+]);
 
 const RARITY_BADGE: Record<ItemRarity, string> = {
   normal: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
@@ -166,10 +178,18 @@ export default function ShopPage(): React.JSX.Element {
                         : 'border-transparent bg-gray-100 dark:bg-gray-700'
                     }`}
                   >
-                    <div className="size-16 overflow-hidden rounded-xl bg-white dark:bg-gray-600">
-                      <DiceBearAvatar
-                        config={previewConfigWith(item.category, item.value)}
-                      />
+                    <div className="flex size-16 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-gray-600">
+                      {COLOR_CATEGORIES.has(item.category) ? (
+                        <div
+                          aria-hidden
+                          className="size-12 rounded-full border-4 border-gray-100 shadow dark:border-gray-500"
+                          style={{ backgroundColor: `#${item.value}` }}
+                        />
+                      ) : (
+                        <DiceBearAvatar
+                          config={previewConfigWith(item.category, item.value)}
+                        />
+                      )}
                     </div>
                     <span className="text-sm font-bold text-gray-900 dark:text-gray-100">
                       {item.name}

--- a/tests/sansu/avatar-shop-catalog.spec.ts
+++ b/tests/sansu/avatar-shop-catalog.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * PR1「カタログ拡充」の回帰テスト。
+ * 新カテゴリ(hairstyle/haircolor/eyebrow/mouthstyle/clothescolor)のアイテムを
+ * ショップで購入 → キャラづくりで選択 → 保存後もAvatarDisplayに<svg>が描画される、
+ * という一連のE2Eを検証する。
+ *
+ * コイン付与はローカル専用のデバッグAPI(/api/sansu/debug-grant)を使う（本番では403）。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `E2E${suffix}`;
+}
+
+async function enterPin(page: Page, pin: string, confirmLabel: string) {
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of pin) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: confirmLabel }).click();
+}
+
+async function expectBuiltAvatar(page: Page, name: string) {
+  const avatar = page.locator(`[aria-label="${name}のアバター"]`).first();
+  await expect(avatar).toBeVisible();
+  await expect(avatar.locator('svg')).toBeVisible();
+}
+
+test.describe('sansu-100 拡充アバターカタログ（PR1）', () => {
+  test('新カテゴリのアイテムを購入してキャラづくりで選択すると、保存後もSVGが描画される', async ({
+    page,
+  }) => {
+    const name = uniqueName();
+    await page.addInitScript(() => {
+      try {
+        sessionStorage.setItem('sansu-100:dev-seeded', '1');
+      } catch {
+        /* ignore */
+      }
+    });
+
+    // --- 登録 ---
+    await page.goto('/sansu-100/register');
+    await page.getByTestId('register-name-input').fill(name);
+    await page.getByTestId('register-name-next').click();
+    await enterPin(page, PIN, 'これでとうろく！');
+    await page.waitForURL('**/sansu-100');
+    await expectBuiltAvatar(page, name);
+
+    // --- テスト用にコインを付与（ローカル限定のデバッグAPI） ---
+    // storage.setCurrentUserId は id を JSON.stringify しただけの文字列を保存する。
+    const userId = await page.evaluate(() => {
+      const raw = window.localStorage.getItem('sansu-100:current-user');
+      if (!raw) return null;
+      try {
+        return JSON.parse(raw) as string;
+      } catch {
+        return null;
+      }
+    });
+    expect(userId).toBeTruthy();
+    const grantRes = await page.request.post('/api/sansu/debug-grant', {
+      data: { userId, amount: 5000 },
+    });
+    expect(grantRes.ok()).toBeTruthy();
+
+    // --- ショップで新カテゴリ（かみのいろ・まゆげ）のアイテムを購入 ---
+    await page.goto('/sansu-100/shop');
+    await page.waitForLoadState('networkidle');
+
+    const haircolorBuy = page.getByTestId('buy-av_haircolor_c7a2ff');
+    await expect(haircolorBuy).toBeVisible();
+    await haircolorBuy.click();
+    await expect(page.getByText('を かったよ！')).toBeVisible();
+
+    const eyebrowBuy = page.getByTestId('buy-av_eyebrow_unibrowNatural');
+    await expect(eyebrowBuy).toBeVisible();
+    await eyebrowBuy.click();
+    await expect(page.getByText('を かったよ！')).toBeVisible();
+
+    // --- キャラづくりで購入した値を選択して保存 ---
+    await page.goto('/sansu-100/avatar');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('tab-hairColor').click();
+    await page.getByTestId('opt-hairColor-c7a2ff').click();
+
+    await page.getByTestId('tab-eyebrows').click();
+    await page.getByTestId('opt-eyebrows-unibrowNatural').click();
+
+    await page.getByTestId('avatar-save').click();
+    await expect(page.getByTestId('avatar-save')).toContainText('ほぞんしたよ');
+
+    // --- ホームに戻り、保存済みの見た目がSVGとして描画されることを確認 ---
+    await page.goto('/sansu-100');
+    await page.waitForLoadState('networkidle');
+    await expectBuiltAvatar(page, name);
+  });
+});


### PR DESCRIPTION
## Summary
- 子供から「服がダサい/可愛くない」というフィードバックを受け、DiceBear avataaars が実サポートする範囲でアバターショップを拡充（かみがた12・かみいろ8・め4・まゆげ7・くち4・ふくいろ8 = 計43アイテム）
- 肌の色（skinColor）は身体的アイデンティティとして引き続き**無料維持**・ショップには載せない（6→10色に無料拡充のみ）。inclusive avatar design の知見（Toca Boca等の実例・学術文献）に基づく判断。詳細は `.aimix/1030propus/character-shop-design.md`
- 本PRは「見た目の拡充」のみ。新カテゴリの所持チェック強化・非破壊マイグレーションは次PR（C2）で対応

## Test plan
- [x] `npm run build`（フロント）/ `cd api && npm run build` green
- [x] `npm run lint` — 新規errorなし（既存warningのみ）
- [x] 新規E2E `tests/sansu/avatar-shop-catalog.spec.ts` pass
- [x] 既存 `tests/sansu/avatar.spec.ts` 回帰 pass
- [x] `tests/sansu/` フルスイート実行、失敗7件は全て変更前でも再現する既存の不安定テスト（coins-level-based.spec.ts のセレクタ問題、starshooter のタイミングflake）であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)