### PR TITLE
feat(sansu-100): ショップにカート機能を追加

### DIFF
--- a/app/sansu-100/lib/cart.ts
+++ b/app/sansu-100/lib/cart.ts
@@ -1,0 +1,41 @@
+// カート状態の純粋関数群（PR3）。
+// カート本体は itemId の Set<string> として画面側(useState)で保持し、ここでは
+// 合計金額の計算・コイン内で買える範囲の判定のみを担当する。
+// 実際の一括購入（all-or-nothing）はPR4のバッチ購入APIで行う。
+
+export type CartLine = { id: string; name: string; price: number; owned: boolean };
+
+/** カートに入っているアイテムの合計金額を返す。 */
+export function cartTotal(
+  cart: Set<string>,
+  priceOf: (id: string) => number
+): number {
+  let total = 0;
+  for (const id of cart) {
+    total += priceOf(id);
+  }
+  return total;
+}
+
+/**
+ * 手持ちコインの範囲内でカートの中身を先頭から順に買えるだけ買った場合の
+ * 「買えるアイテムidの一覧」と「その合計金額」を返す。
+ * 現時点のUI（C3-B）では未使用だが、将来的な部分購入UI向けに設計書§4-1の
+ * シグネチャ通り用意しておく。
+ */
+export function affordableWithin(
+  cart: Set<string>,
+  coins: number,
+  priceOf: (id: string) => number
+): { buyable: string[]; total: number } {
+  const buyable: string[] = [];
+  let total = 0;
+  for (const id of cart) {
+    const price = priceOf(id);
+    if (total + price <= coins) {
+      buyable.push(id);
+      total += price;
+    }
+  }
+  return { buyable, total };
+}

--- a/app/sansu-100/shop/page.tsx
+++ b/app/sansu-100/shop/page.tsx
@@ -16,10 +16,12 @@ import {
   AVATAR_CATEGORY_ICON,
   AVATAR_CATEGORY_LABEL,
   AVATAR_SHOP,
+  getAvatarItem,
   type AvatarItemCategory,
   type AvatarItemDef,
   previewConfigWith,
 } from '../lib/avatar-shop';
+import { cartTotal } from '../lib/cart';
 import {
   RARITY_LABEL,
   SHOP_CATALOG,
@@ -64,6 +66,9 @@ export default function ShopPage(): React.JSX.Element {
   const { currentUser, saveUser, loaded } = useSansuUser();
   const [busy, setBusy] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [cart, setCart] = useState<Set<string>>(new Set());
+  const [cartOpen, setCartOpen] = useState(false);
+  const [checkingOut, setCheckingOut] = useState(false);
 
   if (loaded && !currentUser) {
     if (typeof window !== 'undefined') router.replace('/sansu-100');
@@ -96,27 +101,83 @@ export default function ShopPage(): React.JSX.Element {
     }
   };
 
-  const buyAvatar = async (item: AvatarItemDef) => {
-    setBusy(item.id);
+  const toggleCart = (item: AvatarItemDef) => {
+    setCart((prev) => {
+      const next = new Set(prev);
+      if (next.has(item.id)) {
+        next.delete(item.id);
+      } else {
+        next.add(item.id);
+      }
+      return next;
+    });
+  };
+
+  const priceOf = (id: string): number => getAvatarItem(id)?.price ?? 0;
+  const cartLines = Array.from(cart)
+    .map((id) => getAvatarItem(id))
+    .filter((i): i is AvatarItemDef => Boolean(i));
+  const total = cartTotal(cart, priceOf);
+  const shortfall = Math.max(0, total - coins);
+
+  // PR3時点ではバッチ購入API（PR4予定・sansuApi.purchaseBatch）が未実装のため、
+  // 暫定実装として既存の単品購入API(sansuApi.purchase)をカート内アイテム分だけ
+  // 順番に呼ぶ。all-or-nothingではないため、途中でコインが尽きた場合は
+  // そこまで購入したものだけ確定してしまう点に注意。
+  // PR4でバッチ購入API（残高不足なら1件も購入しない・全ロールバック）に置き換え予定。
+  const checkoutCart = async () => {
+    if (cartLines.length === 0 || coins < total) return;
+    setCheckingOut(true);
     setMessage(null);
     try {
-      const res = await sansuApi.purchase(currentUser.id, 'buy', item.id);
-      if (res.ok && res.user) {
-        saveUser(res.user);
-        setMessage(`「${item.name}」を かったよ！🧑‍🎨キャラづくりで つけられるよ`);
-      } else if (res.error === 'conflict') {
-        setMessage('コインが たりないよ');
+      let boughtCount = 0;
+      for (const item of cartLines) {
+        const res = await sansuApi.purchase(currentUser.id, 'buy', item.id);
+        if (res.ok && res.user) {
+          saveUser(res.user);
+          boughtCount += 1;
+          setCart((prev) => {
+            const next = new Set(prev);
+            next.delete(item.id);
+            return next;
+          });
+        } else {
+          // どこかで失敗したら止める（コイン不足・競合など）
+          break;
+        }
       }
-    } catch {
-      setMessage('いまは つうしんできないよ（あとでね）');
+      if (boughtCount === cartLines.length) {
+        setMessage('カートの アイテムを ぜんぶ かったよ！🧑‍🎨キャラづくりで つけられるよ');
+        setCartOpen(false);
+      } else if (boughtCount > 0) {
+        setMessage('とちゅうまで かったよ。のこりは また こんど！');
+      } else {
+        setMessage('いまは つうしんできないよ（あとでね）');
+      }
     } finally {
-      setBusy(null);
+      setCheckingOut(false);
     }
   };
 
   return (
     <main className="flex min-h-screen flex-col items-center bg-gray-50 dark:bg-gray-900">
-      <div className="absolute right-4 top-4">
+      <div className="absolute right-4 top-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setCartOpen((v) => !v)}
+          className="relative flex size-11 items-center justify-center rounded-full bg-white text-xl shadow-md dark:bg-gray-800"
+          aria-label="カートをひらく"
+        >
+          🛒
+          {cart.size > 0 ? (
+            <span
+              data-testid="cart-badge"
+              className="absolute -right-1 -top-1 flex size-5 items-center justify-center rounded-full bg-red-500 text-[11px] font-bold text-white"
+            >
+              {cart.size}
+            </span>
+          ) : null}
+        </button>
         <ThemeToggle />
       </div>
       <div className="container mx-auto max-w-2xl space-y-6 px-4 py-8">
@@ -127,6 +188,78 @@ export default function ShopPage(): React.JSX.Element {
           backHref="/sansu-100"
           backLabel="ホームにもどる"
         />
+
+        {cartOpen ? (
+          <section
+            data-testid="cart-panel"
+            className="space-y-3 rounded-2xl bg-white p-5 shadow-md dark:bg-gray-800"
+          >
+            <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+              🛒 カゴのなか
+            </h2>
+            {cartLines.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                まだ なにも はいっていないよ
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {cartLines.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex items-center gap-3 rounded-xl bg-gray-100 p-2 dark:bg-gray-700"
+                  >
+                    <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-white dark:bg-gray-600">
+                      {COLOR_CATEGORIES.has(item.category) ? (
+                        <div
+                          aria-hidden
+                          className="size-7 rounded-full border-2 border-gray-100 dark:border-gray-500"
+                          style={{ backgroundColor: `#${item.value}` }}
+                        />
+                      ) : (
+                        <DiceBearAvatar
+                          config={previewConfigWith(item.category, item.value)}
+                        />
+                      )}
+                    </div>
+                    <span className="flex-1 text-sm font-bold text-gray-900 dark:text-gray-100">
+                      {item.name}
+                    </span>
+                    <span className="text-xs font-bold text-gray-600 dark:text-gray-300">
+                      🪙 {item.price}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => toggleCart(item)}
+                      className="rounded-lg bg-red-100 px-2 py-1 text-xs font-bold text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-200"
+                    >
+                      はずす
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <p
+              data-testid="cart-total"
+              className="text-center font-bold text-gray-900 dark:text-gray-100"
+            >
+              ぜんぶで 🪙{total}
+            </p>
+            {shortfall > 0 ? (
+              <p className="text-center text-sm font-bold text-red-600 dark:text-red-300">
+                あと 🪙{shortfall} で ぜんぶ かえるよ
+              </p>
+            ) : null}
+            <button
+              type="button"
+              data-testid="cart-checkout"
+              disabled={cartLines.length === 0 || coins < total || checkingOut}
+              onClick={checkoutCart}
+              className="w-full rounded-xl bg-teal-500 py-2.5 font-bold text-white hover:bg-teal-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ぜんぶかう
+            </button>
+          </section>
+        ) : null}
 
         <section className="flex items-center justify-between gap-4 rounded-2xl bg-white p-5 shadow-md dark:bg-gray-800">
           <div className="flex items-center gap-3">
@@ -168,14 +301,16 @@ export default function ShopPage(): React.JSX.Element {
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
               {AVATAR_SHOP.filter((i) => i.category === cat).map((item) => {
                 const isOwned = owned.has(item.id);
-                const canAfford = coins >= item.price;
+                const inCart = cart.has(item.id);
                 return (
                   <div
                     key={item.id}
                     className={`flex flex-col items-center gap-1 rounded-xl border-2 p-3 text-center ${
                       isOwned
                         ? 'border-green-400 bg-green-50 dark:bg-green-900/20'
-                        : 'border-transparent bg-gray-100 dark:bg-gray-700'
+                        : inCart
+                          ? 'border-teal-400 bg-teal-50 dark:bg-teal-900/20'
+                          : 'border-transparent bg-gray-100 dark:bg-gray-700'
                     }`}
                   >
                     <div className="flex size-16 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-gray-600">
@@ -206,12 +341,15 @@ export default function ShopPage(): React.JSX.Element {
                     ) : (
                       <button
                         type="button"
-                        disabled={busy === item.id || !canAfford}
-                        onClick={() => buyAvatar(item)}
-                        className="mt-1 flex w-full items-center justify-center gap-1 rounded-lg bg-yellow-500 px-2 py-1 text-xs font-bold text-white hover:bg-yellow-600 disabled:cursor-not-allowed disabled:opacity-50"
+                        onClick={() => toggleCart(item)}
+                        className={`mt-1 flex w-full items-center justify-center gap-1 rounded-lg px-2 py-1 text-xs font-bold text-white ${
+                          inCart
+                            ? 'bg-teal-500 hover:bg-teal-600'
+                            : 'bg-yellow-500 hover:bg-yellow-600'
+                        }`}
                         data-testid={`buy-${item.id}`}
                       >
-                        🪙 {item.price}
+                        {inCart ? '🛒 カゴにあるよ' : `🛒 かごにいれる 🪙${item.price}`}
                       </button>
                     )}
                   </div>

--- a/tests/sansu/avatar-shop-catalog.spec.ts
+++ b/tests/sansu/avatar-shop-catalog.spec.ts
@@ -70,19 +70,24 @@ test.describe('sansu-100 拡充アバターカタログ（PR1）', () => {
     });
     expect(grantRes.ok()).toBeTruthy();
 
-    // --- ショップで新カテゴリ（かみのいろ・まゆげ）のアイテムを購入 ---
+    // --- ショップで新カテゴリ（かみのいろ・まゆげ）のアイテムをカゴにいれて、まとめて購入 ---
+    // PR3でアバターアイテムは即時購入からカート方式に変わったため、カゴにいれて
+    // カートの「ぜんぶかう」から購入する。
     await page.goto('/sansu-100/shop');
     await page.waitForLoadState('networkidle');
 
     const haircolorBuy = page.getByTestId('buy-av_haircolor_c7a2ff');
     await expect(haircolorBuy).toBeVisible();
     await haircolorBuy.click();
-    await expect(page.getByText('を かったよ！')).toBeVisible();
 
     const eyebrowBuy = page.getByTestId('buy-av_eyebrow_unibrowNatural');
     await expect(eyebrowBuy).toBeVisible();
     await eyebrowBuy.click();
-    await expect(page.getByText('を かったよ！')).toBeVisible();
+
+    await expect(page.getByTestId('cart-badge')).toHaveText('2');
+    await page.getByRole('button', { name: 'カートをひらく' }).click();
+    await page.getByTestId('cart-checkout').click();
+    await expect(page.getByText('を ぜんぶ かったよ！')).toBeVisible();
 
     // --- キャラづくりで購入した値を選択して保存 ---
     await page.goto('/sansu-100/avatar');

--- a/tests/sansu/cart.spec.ts
+++ b/tests/sansu/cart.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * PR3「カート状態＋UI」のE2E回帰テスト。
+ *
+ * - カゴへの投入/取消でバッジ枚数が正しく増減すること
+ * - カート内合計金額が正しく計算されること
+ * - コイン不足時は「ぜんぶかう」ボタンがdisabledになること
+ *
+ * コイン付与はローカル専用のデバッグAPI(/api/sansu/debug-grant)を使う（本番では403）。
+ */
+
+const PIN = '1234';
+
+function uniqueName(): string {
+  const suffix = `${process.hrtime.bigint().toString().slice(-6)}`;
+  return `E2E${suffix}`;
+}
+
+async function enterPin(page: Page, pin: string, confirmLabel: string) {
+  const pad = page.locator('[data-testid=pin-pad]');
+  await pad.waitFor();
+  for (const d of pin) {
+    await pad.getByRole('button', { name: d, exact: true }).click();
+  }
+  await page.getByRole('button', { name: confirmLabel }).click();
+}
+
+async function registerAndGrantCoins(page: Page, amount: number): Promise<string> {
+  const name = uniqueName();
+  await page.addInitScript(() => {
+    try {
+      sessionStorage.setItem('sansu-100:dev-seeded', '1');
+    } catch {
+      /* ignore */
+    }
+  });
+
+  await page.goto('/sansu-100/register');
+  await page.getByTestId('register-name-input').fill(name);
+  await page.getByTestId('register-name-next').click();
+  await enterPin(page, PIN, 'これでとうろく！');
+  await page.waitForURL('**/sansu-100');
+
+  const userId = await page.evaluate(() => {
+    const raw = window.localStorage.getItem('sansu-100:current-user');
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as string;
+    } catch {
+      return null;
+    }
+  });
+  expect(userId).toBeTruthy();
+
+  const grantRes = await page.request.post('/api/sansu/debug-grant', {
+    data: { userId, amount },
+  });
+  expect(grantRes.ok()).toBeTruthy();
+
+  return name;
+}
+
+test.describe('sansu-100 カート機能（PR3）', () => {
+  test('カゴに1個いれるとバッジが1になり、はずすと0に戻る', async ({ page }) => {
+    await registerAndGrantCoins(page, 5000);
+
+    await page.goto('/sansu-100/shop');
+    await page.waitForLoadState('networkidle');
+
+    const buyButton = page.getByTestId('buy-av_haircolor_f59797');
+    await expect(buyButton).toBeVisible();
+    await buyButton.click();
+
+    await expect(page.getByTestId('cart-badge')).toHaveText('1');
+
+    // カートパネルを開いて「はずす」で取り消す
+    await page.getByRole('button', { name: 'カートをひらく' }).click();
+    const panel = page.getByTestId('cart-panel');
+    await expect(panel).toBeVisible();
+    await panel.getByRole('button', { name: 'はずす' }).click();
+
+    await expect(page.getByTestId('cart-badge')).toHaveCount(0);
+  });
+
+  test('カゴに3個いれると合計金額が正しく表示される', async ({ page }) => {
+    await registerAndGrantCoins(page, 5000);
+
+    await page.goto('/sansu-100/shop');
+    await page.waitForLoadState('networkidle');
+
+    // 3つとも normal(🪙50)のアイテム → 合計150
+    await page.getByTestId('buy-av_haircolor_f59797').click();
+    await page.getByTestId('buy-av_haircolor_ecdcbf').click();
+    await page.getByTestId('buy-av_haircolor_d6b370').click();
+
+    await expect(page.getByTestId('cart-badge')).toHaveText('3');
+
+    await page.getByRole('button', { name: 'カートをひらく' }).click();
+    await expect(page.getByTestId('cart-total')).toHaveText('ぜんぶで 🪙150');
+  });
+
+  test('コインが たりないとき「ぜんぶかう」ボタンがdisabledになる', async ({ page }) => {
+    // 合計150に満たない少額のコインだけ付与する
+    await registerAndGrantCoins(page, 100);
+
+    await page.goto('/sansu-100/shop');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('buy-av_haircolor_f59797').click();
+    await page.getByTestId('buy-av_haircolor_ecdcbf').click();
+    await page.getByTestId('buy-av_haircolor_d6b370').click();
+
+    await page.getByRole('button', { name: 'カートをひらく' }).click();
+    await expect(page.getByTestId('cart-total')).toHaveText('ぜんぶで 🪙150');
+    await expect(page.getByTestId('cart-checkout')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- アバターアイテムの購入を即時購入からカート方式に変更。複数選んで合計金額を見てから「ぜんぶかう」でまとめ買いできる
- カートアイコン+バッジ、カート内一覧パネル（サムネ・名前・価格・はずすボタン）、合計金額表示、コイン不足時はcheckoutボタンがdisabled+不足額表示
- 対象はアバターアイテム（hat/glasses/clothing/beard/hairstyle/haircolor/eyebrow/mouthstyle/clothescolor/eyes追加分）のみ。背景/フレーム/動きは引き続き単品購入
- **checkoutは暫定実装**: バッチ購入API（all-or-nothing）はPR4予定のため、本PRでは既存の単品購入APIをカート内アイテム分だけ順番に呼ぶ。途中でコインが尽きた場合は買えたところまでで確定してしまう点はPR4で解消する
- 既存PR1のE2Eテスト(avatar-shop-catalog.spec.ts)をカート購入フローに追随させた

## Test plan
- [x] `npm run build` green / `npm run lint` 新規errorなし
- [x] 新規E2E `tests/sansu/cart.spec.ts`（カゴ投入/取消・合計金額・コイン不足disabled）pass
- [x] 既存 `avatar-shop-catalog.spec.ts`・`avatar-paywall.spec.ts` 回帰 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)