### PR TITLE
fix(sansu-100): 表情アイテム名を子供向けに改名

### DIFF
--- a/app/sansu-100/lib/avatar-shop.ts
+++ b/app/sansu-100/lib/avatar-shop.ts
@@ -146,7 +146,7 @@ const SEEDS: Seed[] = [
   ['mouthstyle', 'concerned', 'こまりがお', 'normal'],
   ['mouthstyle', 'grimace', 'にやり', 'rare'],
   ['mouthstyle', 'sad', 'しょんぼり', 'normal'],
-  ['mouthstyle', 'vomit', 'げろげろ', 'rare'],
+  ['mouthstyle', 'vomit', 'びっくりくち', 'rare'],
   // ---- ふくのいろ（新カテゴリ。clothesColor に入る） ----
   ['clothescolor', 'ff488e', 'ホットピンク', 'normal'],
   ['clothescolor', 'a7ffc4', 'ミント', 'normal'],


### PR DESCRIPTION
## Summary
agyのUIレビューで、新規追加した表情アイテム「げろげろ」(av_mouthstyle_vomit)が教育向け子供アプリとして不適切な表現と指摘されたため「びっくりくち」に改名。

## Test plan
- [x] `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)