### PR TITLE
fix(sansu-100): パクパクおじさん誤操作・数並べ表示崩れ・ポンポン無限耐久・ランナー表示不具合を修正

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "swa-dev",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["swa", "start", "http://localhost:3000", "--api-location", "api", "--run", "cross-env PORT=3000 npm run dev"],
+      "port": 4280
+    }
+  ]
+}

--- a/app/sansu-100/games/NumberPopGame.tsx
+++ b/app/sansu-100/games/NumberPopGame.tsx
@@ -23,14 +23,29 @@ function makeBubbles(count: number, round: number): Bubble[] {
     const j = Math.floor(Math.random() * (i + 1));
     [nums[i], nums[j]] = [nums[j], nums[i]];
   }
-  return nums.map((num, idx) => ({
-    id: idx,
-    num,
-    x: 8 + (idx % 3) * 30 + Math.random() * 12,
-    y: 10 + Math.floor(idx / 3) * 30 + Math.random() * 12,
-    tapped: false,
-    wrong: false,
-  }));
+  // count個をなるべく正方形に近い行×列のグリッドへ均等配置する。
+  // 列数に対して行数が足りない最終行は中央寄せにして、左詰めで浮いて見えるのを防ぐ。
+  const cols = Math.ceil(Math.sqrt(count));
+  const rows = Math.ceil(count / cols);
+  const cellW = 100 / cols;
+  const cellH = 100 / rows;
+  const jitter = Math.min(cellW, cellH) * 0.12; // セル内に収まる程度の揺らぎのみ
+  return nums.map((num, idx) => {
+    const row = Math.floor(idx / cols);
+    const itemsInRow = row === rows - 1 ? count - row * cols : cols;
+    const col = idx % cols;
+    const rowOffset = (cols - itemsInRow) / 2; // 最終行を中央寄せ
+    const x = (col + rowOffset + 0.5) * cellW + (Math.random() * 2 - 1) * jitter;
+    const y = (row + 0.5) * cellH + (Math.random() * 2 - 1) * jitter;
+    return {
+      id: idx,
+      num,
+      x: Math.min(95, Math.max(5, x)),
+      y: Math.min(90, Math.max(10, y)),
+      tapped: false,
+      wrong: false,
+    };
+  });
 }
 
 export default function NumberPopGame({
@@ -201,7 +216,11 @@ export default function NumberPopGame({
       ) : null}
 
       {/* Bubble field */}
-      <div className="relative mt-2 flex-1 rounded-2xl bg-sky-50 dark:bg-sky-900/20">
+      {/* 親側(page.tsx)がこのゲームの高さを固定していないため、h-full/flex-1だけでは
+          このdivの高さが0pxに潰れ、top:%指定のバブルが全て同じ行に重なって見える
+          （left:%は幅があるため効くが、topだけ効かず「並んでいない」ように見える）。
+          min-heightで確実に高さを確保する。 */}
+      <div className="relative mt-2 min-h-[280px] flex-1 rounded-2xl bg-sky-50 dark:bg-sky-900/20">
         {bubbles.map((b) => (
           <button
             key={b.id}

--- a/app/sansu-100/games/PakupakuGame.tsx
+++ b/app/sansu-100/games/PakupakuGame.tsx
@@ -223,7 +223,11 @@ export default function PakupakuGame({
 
   // ドラッグ: 指を置いている間、動かした方向へ進み続ける（離すと止まる）。
   const touch = useRef<{ x: number; y: number } | null>(null);
-  const padBtn = 'flex h-12 w-12 items-center justify-center rounded-xl bg-gray-200 text-xl font-bold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200';
+  const padBtn = 'flex h-12 w-12 select-none items-center justify-center rounded-xl bg-gray-200 text-xl font-bold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200';
+  // 連打時にテキスト選択状態になり、ブラウザが選択範囲をリンクとして解釈して
+  // 別画面へ遷移してしまう事故を防ぐ（select-noneだけでは連打耐性が不十分なため
+  // pointerdown側でもpreventDefaultする）。
+  const noSelectStyle: React.CSSProperties = { touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' };
 
   return (
     <div className="flex flex-col items-center gap-2">
@@ -260,7 +264,8 @@ export default function PakupakuGame({
         <button
           type="button"
           className={padBtn}
-          onPointerDown={() => pressDir('up')}
+          style={noSelectStyle}
+          onPointerDown={(e) => { e.preventDefault(); pressDir('up'); }}
           onPointerUp={() => releaseDir('up')}
           onPointerLeave={() => releaseDir('up')}
           aria-label="うえ"
@@ -269,7 +274,8 @@ export default function PakupakuGame({
         <button
           type="button"
           className={padBtn}
-          onPointerDown={() => pressDir('left')}
+          style={noSelectStyle}
+          onPointerDown={(e) => { e.preventDefault(); pressDir('left'); }}
           onPointerUp={() => releaseDir('left')}
           onPointerLeave={() => releaseDir('left')}
           aria-label="ひだり"
@@ -278,7 +284,8 @@ export default function PakupakuGame({
         <button
           type="button"
           className={padBtn}
-          onPointerDown={() => pressDir('right')}
+          style={noSelectStyle}
+          onPointerDown={(e) => { e.preventDefault(); pressDir('right'); }}
           onPointerUp={() => releaseDir('right')}
           onPointerLeave={() => releaseDir('right')}
           aria-label="みぎ"
@@ -287,7 +294,8 @@ export default function PakupakuGame({
         <button
           type="button"
           className={padBtn}
-          onPointerDown={() => pressDir('down')}
+          style={noSelectStyle}
+          onPointerDown={(e) => { e.preventDefault(); pressDir('down'); }}
           onPointerUp={() => releaseDir('down')}
           onPointerLeave={() => releaseDir('down')}
           aria-label="した"

--- a/app/sansu-100/games/PonPonJumpGame.tsx
+++ b/app/sansu-100/games/PonPonJumpGame.tsx
@@ -32,6 +32,16 @@ function draw(ctx: CanvasRenderingContext2D, gs: GS, scale: number): void {
     ctx.fillRect(p.x * scale, sy, PLAT_W * scale, PLAT_H * scale);
   }
 
+  // 迫りあがる床（溶岩）。画面下端より上にあるときだけ描画する。
+  const riseSy = (gs.riseY - gs.cameraY) * scale;
+  if (riseSy < H * scale) {
+    const top = Math.max(0, riseSy);
+    ctx.fillStyle = '#dc2626';
+    ctx.fillRect(0, top, W * scale, H * scale - top);
+    ctx.fillStyle = '#fde047';
+    ctx.fillRect(0, top, W * scale, 4 * scale);
+  }
+
   ctx.fillStyle = '#f97316';
   ctx.beginPath();
   ctx.arc(

--- a/app/sansu-100/games/RunnerGame.tsx
+++ b/app/sansu-100/games/RunnerGame.tsx
@@ -72,10 +72,15 @@ function draw(
       );
     }
   }
-  // プレイヤー
+  // プレイヤー（🦖は絵文字フォント上デフォルトで左向きのため、進行方向（右）を
+  // 向かせるために水平反転させて描く）
   const cx = (RUNNER.playerX + RUNNER.playerW / 2) * scale;
   const cy = yGround - (s.py + RUNNER.playerH / 2) * scale;
-  emoji(ctx, RUNNER_CHAR, cx, cy, RUNNER.playerH * scale * 1.5);
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.scale(-1, 1);
+  emoji(ctx, RUNNER_CHAR, 0, 0, RUNNER.playerH * scale * 1.5);
+  ctx.restore();
 }
 
 // よけよけランナー本体。タップ/スペース/↑ でジャンプ。台に乗って降りられる。
@@ -164,18 +169,26 @@ export default function RunnerGame({
     <div className="flex flex-col items-center gap-3">
       <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
         レベル {level} ・ きょり <span className="tabular-nums">{score}</span>
-        {flash ? (
-          <span className="ml-2 animate-pulse font-extrabold text-orange-500">
-            ⬆️ レベルアップ！
-          </span>
-        ) : null}
       </p>
-      <canvas
-        ref={canvasRef}
-        onPointerDown={jump}
-        className="rounded-xl shadow-md"
-        style={{ touchAction: 'none' }}
-      />
+      {/* レベルアップ表示はcanvasの上に絶対配置のオーバーレイとして重ねる。
+          スコア行に直接テキストを差し込むと行の高さが変わり、下のジャンプ操作の
+          位置がタップ中にずれてしまう（レイアウトシフト）ため、フローの外に置く。 */}
+      <div className="relative">
+        {flash ? (
+          <div
+            className="pointer-events-none absolute inset-x-0 top-2 z-10 animate-pulse text-center text-lg font-extrabold text-orange-500"
+            style={{ textShadow: '0 0 6px rgba(255,255,255,0.9)' }}
+          >
+            ⬆️ レベルアップ！
+          </div>
+        ) : null}
+        <canvas
+          ref={canvasRef}
+          onPointerDown={jump}
+          className="rounded-xl shadow-md"
+          style={{ touchAction: 'none' }}
+        />
+      </div>
       <button
         type="button"
         onClick={jump}

--- a/app/sansu-100/games/logic/ponpon-logic.ts
+++ b/app/sansu-100/games/logic/ponpon-logic.ts
@@ -9,6 +9,13 @@ export const PLAT_H = 8;
 export const PLAT_GAP_MIN = 42;
 export const PLAT_GAP_MAX = 72;
 
+// 迫りあがる床（溶岩）: 一定の猶予の後、プレイヤーの高さに関係なく常に上へ迫ってくる。
+// これがないと、足場に乗ったまま登らずに待機し続ければ理論上ずっと続けられてしまう。
+export const RISE_GRACE = 260; // 開始位置からこの距離だけ下にある間は迫ってこない（初動の猶予）
+export const RISE_SPEED_BASE = 0.2; // 1tickあたりの上昇量（ワールドpx）
+export const RISE_SPEED_MAX = 1.1;
+export const RISE_ACCEL_PER_HEIGHT = 0.0025; // 到達した高さに応じて迫る速度が増していく
+
 export type Platform = { x: number; y: number };
 
 export interface GS {
@@ -18,6 +25,7 @@ export interface GS {
   platforms: Platform[];
   cameraY: number; // 画面上端に対応するワールドY（値が小さいほど高い）
   maxHeight: number; // これまでの最高到達スコア（登った高さ）
+  riseY: number; // 迫りあがる床のワールドY（値が小さいほど高い＝危険）
   over: boolean;
 }
 
@@ -38,6 +46,7 @@ export function createGS(rand: () => number): GS {
     platforms,
     cameraY: 0,
     maxHeight: 0,
+    riseY: H - 30 - PLAYER_R + RISE_GRACE,
     over: false,
   };
 }
@@ -90,8 +99,19 @@ export function tick(
     gs.platforms = gs.platforms.filter((p) => p.y < gs.cameraY + H + 100);
   }
 
-  // 画面（カメラ）の下端より下に落ちたら終了
-  if (gs.playerY - gs.cameraY > H + PLAYER_R * 3) {
+  // 迫りあがる床（溶岩）: 高さに関係なく常に上へ迫るので、登らずに待機し続ける
+  // 「無限耐久」ができないようにする。到達した高さが増えるほど迫る速さも上がる。
+  const riseSpeed = Math.min(
+    RISE_SPEED_MAX,
+    RISE_SPEED_BASE + gs.maxHeight * RISE_ACCEL_PER_HEIGHT
+  );
+  gs.riseY -= riseSpeed;
+
+  // 画面（カメラ）の下端より下に落ちたら終了、または迫りあがる床に飲まれたら終了
+  if (
+    gs.playerY - gs.cameraY > H + PLAYER_R * 3 ||
+    gs.playerY + PLAYER_R > gs.riseY
+  ) {
     gs.over = true;
     onEvent('over');
   }


### PR DESCRIPTION
## Summary
- パクパクおじさん: 方向ボタン連打時にテキスト選択状態になり別画面へ遷移してしまう不具合を修正
- 数並べ: バブル配置をグリッド化。さらに親コンポーネントでゲーム領域の高さが未指定で
  flex-1が0pxに潰れ、縦位置が効かず全バブルが同じ行に重なっていた実際の原因を修正
- ポンポンジャンプ: 登らずに待機し続ければ無限に続けられた問題を修正。高さに関係なく
  常に上へ迫る「迫りあがる床」を追加（登り続ければ逃げ切れる速度で調整済み）
- よけよけランナー: 恐竜が進行方向と逆向きだったのを反転。レベルアップ表示を
  絶対配置オーバーレイに変更し、表示時のジャンプボタン位置ずれを解消

## Test plan
- [x] npm run lint（エラーなし、既存の警告のみ）
- [x] npm run build（全ルートprerender成功）
- [x] npx vitest run（163/163 pass）
- [x] ブラウザでの実プレイ確認（パクパク: 連打20回で選択/遷移なしを確認、数並べ: 2x2グリッド表示とタップ判定を確認、ランナー: 恐竜の向き反転とレベルアップ時のレイアウト非シフトを確認）
- [x] ポンポンジャンプの迫りあがる床はNode上でロジックを直接シミュレーションして検証（放置プレイは約20.7秒で捕まる、積極的に登るプレイは逃げ切れる速度であることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)